### PR TITLE
feat: improve init command with project name, dir args, and agent sel…

### DIFF
--- a/bin/specflow-init
+++ b/bin/specflow-init
@@ -3,48 +3,225 @@ set -euo pipefail
 
 CONFIG_DIR="$HOME/.config/specflow"
 
-# --- フラグ解析 ---
+# -------------------------------------------------------
+# Agent definitions (extensible arrays)
+# -------------------------------------------------------
+MAIN_AGENTS=("claude")
+MAIN_AGENT_DEFAULT=0
+
+REVIEW_AGENTS=("codex")
+REVIEW_AGENT_DEFAULT=0
+
+# -------------------------------------------------------
+# Helper functions
+# -------------------------------------------------------
+
+select_agent() {
+  local agents_str=$1
+  local default_idx=$2
+  local role_name=$3
+
+  # Split comma-separated string into array (Bash 3.2 compatible)
+  local IFS=','
+  local agents=()
+  read -ra agents <<< "$agents_str"
+  local count=${#agents[@]}
+
+  echo "Select $role_name agent:" >&2
+  local i=0
+  for agent in "${agents[@]}"; do
+    local suffix=""
+    if [[ "$i" -eq "$default_idx" ]]; then
+      suffix=" [default]"
+    fi
+    echo "  $((i + 1))) ${agent}$suffix" >&2
+    i=$((i + 1))
+  done
+
+  while true; do
+    read -rp "> " choice
+    if [[ -z "$choice" ]]; then
+      echo "${agents[$default_idx]}"
+      return
+    fi
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [[ "$choice" -ge 1 ]] && [[ "$choice" -le "$count" ]]; then
+      echo "${agents[$((choice - 1))]}"
+      return
+    fi
+    echo "  Invalid choice. Enter 1-$count or press Enter for default." >&2
+  done
+}
+
+prompt_project_name() {
+  local default_name=$1
+  read -rp "Project name [$default_name]: " input_name
+  if [[ -z "$input_name" ]]; then
+    echo "$default_name"
+  else
+    echo "$input_name"
+  fi
+}
+
+ensure_gitignore_entry() {
+  local entry=$1
+  local gitignore=".gitignore"
+
+  if [[ ! -f "$gitignore" ]]; then
+    echo "$entry" > "$gitignore"
+    echo "Created $gitignore with $entry"
+    return
+  fi
+
+  if grep -qxF "$entry" "$gitignore" 2>/dev/null; then
+    echo "$gitignore already contains $entry, skipped"
+    return
+  fi
+
+  echo "$entry" >> "$gitignore"
+  echo "Added $entry to $gitignore"
+}
+
+check_not_subdirectory() {
+  local target_path=$1
+  local check_dir="$target_path"
+
+  # If target doesn't exist, check the nearest existing ancestor
+  if [[ ! -d "$check_dir" ]]; then
+    check_dir="$(dirname "$check_dir")"
+    # Walk up until we find an existing directory
+    while [[ ! -d "$check_dir" ]] && [[ "$check_dir" != "/" ]]; do
+      check_dir="$(dirname "$check_dir")"
+    done
+    if [[ ! -d "$check_dir" ]]; then
+      return 0
+    fi
+  fi
+
+  local git_root
+  git_root="$(cd "$check_dir" && git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -z "$git_root" ]]; then
+    return 0
+  fi
+
+  # Resolve target to absolute path for comparison
+  local abs_target
+  if [[ -d "$target_path" ]]; then
+    abs_target="$(cd "$target_path" && pwd)"
+  else
+    # For non-existing paths, resolve what the absolute path would be
+    case "$target_path" in
+      /*) abs_target="$target_path" ;;
+      *)  abs_target="$(pwd)/$target_path" ;;
+    esac
+  fi
+
+  if [[ "$abs_target" != "$git_root" ]]; then
+    echo "Error: $target_path is inside an existing git repository ($git_root)."
+    echo "Initialize at the repository root instead."
+    exit 1
+  fi
+}
+
+inject_config_name() {
+  local name=$1
+  local config_file="openspec/config.yaml"
+
+  # Validate project name: alphanumeric, hyphens, underscores, dots only
+  if [[ ! "$name" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    echo "Error: project name contains invalid characters: $name"
+    echo "Allowed: letters, numbers, hyphens, underscores, dots"
+    exit 1
+  fi
+
+  if [[ ! -f "$config_file" ]]; then
+    echo "Warning: $config_file not found, skipping name injection"
+    return
+  fi
+
+  # Use a temp file approach instead of sed to avoid escaping issues
+  local tmpfile
+  tmpfile="$(mktemp)"
+  if grep -q "^name:" "$config_file" 2>/dev/null; then
+    awk -v newname="$name" '/^name:/{print "name: " newname; next}{print}' "$config_file" > "$tmpfile"
+  else
+    echo "name: $name" > "$tmpfile"
+    cat "$config_file" >> "$tmpfile"
+  fi
+  mv "$tmpfile" "$config_file"
+  echo "Set project name: $name"
+}
+
+# -------------------------------------------------------
+# 1.1: Argument parsing
+# -------------------------------------------------------
+
 UPDATE_MODE=false
-for arg in "$@"; do
-  case "$arg" in
-    --update) UPDATE_MODE=true ;;
+PROJECT_NAME=""
+TARGET_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --update)
+      UPDATE_MODE=true
+      shift
+      ;;
     -h|--help)
-      echo "Usage: specflow-init [--update]"
+      echo "Usage: specflow-init [<project-name>] [--dir <path>] [--update]"
       echo
-      echo "  (default)   Initialize openspec/, .mcp.json, CLAUDE.md and install slash commands"
-      echo "  --update    Force-update ~/.claude/commands/ slash commands only"
+      echo "Initialize a new specflow + OpenSpec project."
+      echo
+      echo "Patterns:"
+      echo "  specflow-init <name>              Create ./<name>/ and initialize inside it"
+      echo "  specflow-init --dir <path>        Initialize in <path> (created if needed)"
+      echo "  specflow-init --dir <path> <name> Initialize in <path> with project name"
+      echo "  specflow-init                     Initialize in current git root"
+      echo
+      echo "Options:"
+      echo "  --update    Update slash commands only (skip initialization)"
+      echo "  -h, --help  Show this help message"
       exit 0
       ;;
-    *)
-      echo "Unknown option: $arg"
-      echo "Usage: specflow-init [--update]"
+    --dir)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --dir requires a path argument"
+        exit 1
+      fi
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Unknown option: $1"
+      echo "Usage: specflow-init [<project-name>] [--dir <path>] [--update]"
       exit 1
+      ;;
+    *)
+      if [[ -n "$PROJECT_NAME" ]]; then
+        echo "Error: unexpected argument: $1"
+        echo "Usage: specflow-init [<project-name>] [--dir <path>] [--update]"
+        exit 1
+      fi
+      PROJECT_NAME="$1"
+      shift
       ;;
   esac
 done
 
-# --- インストール済みチェック ---
-if [[ ! -d "$CONFIG_DIR/template" ]]; then
-  echo "Error: specflow is not installed."
-  echo "Run 'specflow-install' first (from the specflow repository)."
-  exit 1
-fi
+# -------------------------------------------------------
+# --update mode: update commands only, early exit
+# -------------------------------------------------------
 
-# --- プロジェクトルート ---
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-cd "$ROOT"
-
-# --- --update モード: コマンドだけ更新して終了 ---
 if [[ "$UPDATE_MODE" == true ]]; then
+  # Resolve to git root for --update (preserve original behavior)
+  UPDATE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  cd "$UPDATE_ROOT"
+
   GLOBAL_DIR="$CONFIG_DIR/global"
   if [[ ! -d "$GLOBAL_DIR" ]]; then
     echo "Error: global/ not found at $GLOBAL_DIR"
     echo "Run 'specflow-install' to update."
     exit 1
   fi
-  if [[ ! -d "$GLOBAL_DIR/commands" ]]; then
-    echo "Warning: $GLOBAL_DIR/commands/ not found, skipping slash commands"
-  else
+  if [[ -d "$GLOBAL_DIR/commands" ]]; then
     mkdir -p "$HOME/.claude/commands"
     for cmd_file in "$GLOBAL_DIR/commands"/*.md; do
       [[ -f "$cmd_file" ]] || continue
@@ -52,8 +229,9 @@ if [[ "$UPDATE_MODE" == true ]]; then
       cp "$cmd_file" "$HOME/.claude/commands/$base"
       echo "Updated ~/.claude/commands/$base"
     done
+  else
+    echo "Warning: $GLOBAL_DIR/commands/ not found, skipping slash commands"
   fi
-  # openspec/ に不足しているサブディレクトリを補完
   if [[ -d "openspec" ]]; then
     mkdir -p openspec/specs openspec/changes
   fi
@@ -61,80 +239,203 @@ if [[ "$UPDATE_MODE" == true ]]; then
   exit 0
 fi
 
-# --- 初回セットアップ ---
-if [[ -f "openspec/config.yaml" ]]; then
-  echo "openspec/ already initialized in $ROOT"
+# -------------------------------------------------------
+# 1.2: Preflight validation (before any file writes)
+# -------------------------------------------------------
+
+if ! command -v openspec &>/dev/null; then
+  echo "Error: openspec CLI is not installed."
+  echo "Run 'npm install -g openspec' first."
+  exit 1
+fi
+
+if [[ ! -d "$CONFIG_DIR/template" ]]; then
+  echo "Error: specflow is not installed."
+  echo "Run 'specflow-install' first (from the specflow repository)."
+  exit 1
+fi
+
+# -------------------------------------------------------
+# 1.3: Target path resolution (no mkdir yet)
+# -------------------------------------------------------
+
+TARGET_PATH=""
+FLOW=""
+
+if [[ -n "$TARGET_DIR" ]]; then
+  # Pattern 2 or 3: --dir <path> [<project-name>]
+  TARGET_PATH="$TARGET_DIR"
+  FLOW="dir"
+elif [[ -n "$PROJECT_NAME" ]]; then
+  # Pattern 1: <project-name>
+  TARGET_PATH="./$PROJECT_NAME"
+  FLOW="name"
+else
+  # Pattern 4: no args
+  TARGET_PATH="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -z "$TARGET_PATH" ]]; then
+    echo "Error: not inside a git repository."
+    echo "Use 'specflow-init <project-name>' to create a new project."
+    exit 1
+  fi
+  FLOW="noargs"
+fi
+
+# -------------------------------------------------------
+# 1.4: Target path validation (before file writes)
+# -------------------------------------------------------
+
+# Subdirectory check (--dir flow only)
+if [[ "$FLOW" == "dir" ]]; then
+  check_not_subdirectory "$TARGET_PATH"
+fi
+
+# Already initialized check (if target exists)
+if [[ -d "$TARGET_PATH" ]] && [[ -f "$TARGET_PATH/openspec/config.yaml" ]]; then
+  echo "openspec/ already initialized in $TARGET_PATH"
   echo "Use --update to refresh slash commands only."
   exit 1
 fi
 
-# --- テンプレート取得 ---
+# -------------------------------------------------------
+# 1.5: Directory creation & cd (after validation)
+# -------------------------------------------------------
+
+case "$FLOW" in
+  name)
+    mkdir -p "$TARGET_PATH"
+    cd "$TARGET_PATH"
+    ;;
+  dir)
+    mkdir -p "$TARGET_PATH"
+    cd "$TARGET_PATH"
+    ;;
+  noargs)
+    cd "$TARGET_PATH"
+    ;;
+esac
+
+ROOT="$(pwd)"
+
+# -------------------------------------------------------
+# 2.1: git init (if no repo)
+# -------------------------------------------------------
+
+if ! git rev-parse --show-toplevel &>/dev/null; then
+  git init
+  echo "Initialized git repository"
+fi
+
+# -------------------------------------------------------
+# 2.2: Project name resolution (serial)
+# -------------------------------------------------------
+
+if [[ -z "$PROJECT_NAME" ]]; then
+  default_name="$(basename "$ROOT")"
+  PROJECT_NAME="$(prompt_project_name "$default_name")"
+fi
+
+# -------------------------------------------------------
+# 2.3: Agent selection (serial, 2 prompts)
+# -------------------------------------------------------
+
+echo
+MAIN_AGENTS_STR="$(IFS=','; echo "${MAIN_AGENTS[*]}")"
+MAIN_AGENT="$(select_agent "$MAIN_AGENTS_STR" "$MAIN_AGENT_DEFAULT" "main")"
+echo "  → main agent: $MAIN_AGENT"
+echo
+
+REVIEW_AGENTS_STR="$(IFS=','; echo "${REVIEW_AGENTS[*]}")"
+REVIEW_AGENT="$(select_agent "$REVIEW_AGENTS_STR" "$REVIEW_AGENT_DEFAULT" "review")"
+echo "  → review agent: $REVIEW_AGENT"
+echo
+
+TOOLS_ARG="${MAIN_AGENT},${REVIEW_AGENT}"
+
+# -------------------------------------------------------
+# 3.1: openspec init
+# -------------------------------------------------------
+
+echo "Running: openspec init . --tools $TOOLS_ARG"
+if ! openspec init . --tools "$TOOLS_ARG"; then
+  echo "Error: openspec init failed."
+  exit 1
+fi
+echo
+
+# -------------------------------------------------------
+# 3.2: Inject project name into config.yaml
+# -------------------------------------------------------
+
+inject_config_name "$PROJECT_NAME"
+
+# -------------------------------------------------------
+# 4.1: .specflow/config.env generation
+# -------------------------------------------------------
+
+mkdir -p .specflow
+cat > .specflow/config.env <<ENVEOF
+# specflow agent configuration
+# Edit these values to change your agents
+SPECFLOW_MAIN_AGENT=$MAIN_AGENT
+SPECFLOW_REVIEW_AGENT=$REVIEW_AGENT
+ENVEOF
+echo "Created .specflow/config.env"
+
+# -------------------------------------------------------
+# 4.2: .gitignore idempotent update
+# -------------------------------------------------------
+
+ensure_gitignore_entry ".specflow/config.env"
+
+# -------------------------------------------------------
+# 4.3: Template copy (.mcp.json, CLAUDE.md)
+# -------------------------------------------------------
+
 TEMPLATE_DIR=""
 
 if [[ -n "${SPECFLOW_TEMPLATE_REPO:-}" ]]; then
-  # 外部テンプレートリポジトリからクローン
   TMPDIR="$(mktemp -d)"
   trap 'rm -rf "$TMPDIR"' EXIT
 
   echo "Fetching template from $SPECFLOW_TEMPLATE_REPO..."
   if ! gh repo clone "$SPECFLOW_TEMPLATE_REPO" "$TMPDIR/template" -- --depth 1 2>/dev/null; then
-    echo "Failed to clone template repo: $SPECFLOW_TEMPLATE_REPO"
-    echo
-    echo "Ensure:"
-    echo "  1. gh auth login is done"
-    echo "  2. SPECFLOW_TEMPLATE_REPO is set correctly"
-    echo
-    echo "Current value: $SPECFLOW_TEMPLATE_REPO"
-    exit 1
+    echo "Warning: Failed to clone template repo: $SPECFLOW_TEMPLATE_REPO"
+    echo "Skipping .mcp.json and CLAUDE.md template copy."
+    TEMPLATE_DIR=""
+  else
+    TEMPLATE_DIR="$TMPDIR/template"
   fi
-  TEMPLATE_DIR="$TMPDIR/template"
 else
-  # インストール済みテンプレートを使用
   TEMPLATE_DIR="$CONFIG_DIR/template"
 fi
 
-# テンプレート検証
-if [[ ! -f "$TEMPLATE_DIR/openspec/config.yaml" ]] && [[ ! -d "$TEMPLATE_DIR/openspec" ]]; then
-  echo "Error: openspec/ not found in template ($TEMPLATE_DIR)"
-  exit 1
-fi
-
-# --- ファイルコピー ---
-
-# .mcp.json
-if [[ ! -f ".mcp.json" ]]; then
-  if [[ -f "$TEMPLATE_DIR/.mcp.json" ]]; then
-    cp "$TEMPLATE_DIR/.mcp.json" .mcp.json
-    echo "Created .mcp.json"
+if [[ -n "$TEMPLATE_DIR" ]]; then
+  # .mcp.json
+  if [[ ! -f ".mcp.json" ]]; then
+    if [[ -f "$TEMPLATE_DIR/.mcp.json" ]]; then
+      cp "$TEMPLATE_DIR/.mcp.json" .mcp.json
+      echo "Created .mcp.json"
+    fi
+  else
+    echo ".mcp.json already exists, skipped"
   fi
-else
-  echo ".mcp.json already exists, skipped"
-fi
 
-# CLAUDE.md
-if [[ ! -f "CLAUDE.md" ]]; then
-  if [[ -f "$TEMPLATE_DIR/CLAUDE.md" ]]; then
-    cp "$TEMPLATE_DIR/CLAUDE.md" CLAUDE.md
-    echo "Created CLAUDE.md — edit to match your project"
+  # CLAUDE.md
+  if [[ ! -f "CLAUDE.md" ]]; then
+    if [[ -f "$TEMPLATE_DIR/CLAUDE.md" ]]; then
+      cp "$TEMPLATE_DIR/CLAUDE.md" CLAUDE.md
+      echo "Created CLAUDE.md — edit to match your project"
+    fi
+  else
+    echo "CLAUDE.md already exists, skipped"
   fi
-else
-  echo "CLAUDE.md already exists, skipped"
 fi
 
-# openspec/ directory structure
-if [[ ! -d "openspec" ]]; then
-  mkdir -p openspec/specs openspec/changes
-  if [[ -f "$TEMPLATE_DIR/openspec/README.md" ]]; then
-    cp "$TEMPLATE_DIR/openspec/README.md" openspec/README.md
-  fi
-  echo "Created openspec/ (specs/, changes/, README.md)"
-else
-  # Ensure subdirectories exist even if openspec/ already exists
-  mkdir -p openspec/specs openspec/changes
-  echo "openspec/ already exists, ensured subdirectories"
-fi
+# -------------------------------------------------------
+# 4.4: Slash commands install
+# -------------------------------------------------------
 
-# --- スラッシュコマンドのインストール ---
 GLOBAL_DIR="$CONFIG_DIR/global"
 if [[ -d "$GLOBAL_DIR/commands" ]]; then
   mkdir -p "$HOME/.claude/commands"
@@ -150,11 +451,17 @@ else
   echo "Warning: $GLOBAL_DIR/commands/ not found, skipping slash commands"
 fi
 
-echo
-echo "Initialized openspec/ in $ROOT"
-echo
+# -------------------------------------------------------
+# 5.2: Completion message
+# -------------------------------------------------------
 
+echo
+echo "Initialized specflow + OpenSpec project: $PROJECT_NAME"
+echo "  Location: $ROOT"
+echo "  Main agent: $MAIN_AGENT"
+echo "  Review agent: $REVIEW_AGENT"
+echo
 echo "Next steps:"
 echo "  1. Edit CLAUDE.md — fill in Tech Stack, Commands, Code Style"
 echo "  2. Edit openspec/config.yaml if needed"
-echo "  3. Ensure Codex CLI is installed (npm install -g @openai/codex)"
+echo "  3. Run '/specflow <issue-url>' to start your first feature"

--- a/openspec/changes/improve-init-command/approval-summary.md
+++ b/openspec/changes/improve-init-command/approval-summary.md
@@ -1,0 +1,78 @@
+# Approval Summary: improve-init-command
+
+**Generated**: 2026-04-07
+**Branch**: improve-init-command
+**Status**: ⚠️ 1 unresolved high (spec phase — user chose to proceed)
+
+## What Changed
+
+Primary change: `bin/specflow-init` rewritten to support:
+- Project name argument (`specflow-init <name>`)
+- Directory argument (`specflow-init --dir <path>`)
+- Interactive agent selection (main/review)
+- OpenSpec CLI integration (`openspec init --tools`)
+- `.specflow/config.env` generation
+- `.gitignore` idempotent update
+
+## Files Touched (this feature)
+
+- `bin/specflow-init` — main implementation (rewritten)
+- `openspec/changes/improve-init-command/` — spec artifacts
+
+## Review Loop Summary
+
+### Spec Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 2     |
+| Resolved high      | 2     |
+| Unresolved high    | 1     |
+| New high (later)   | 1     |
+| Total rounds       | 3     |
+
+### Plan Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 3     |
+| Unresolved high    | 0     |
+| New high (later)   | 2     |
+| Total rounds       | 3     |
+
+### Impl Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 2     |
+| Resolved high      | 2     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 2     |
+
+## Spec Coverage
+
+| # | Criterion | Covered? | Mapped Files |
+|---|-----------|----------|--------------|
+| 1 | `specflow-init my-project` creates ./my-project/ and runs openspec init | Yes | bin/specflow-init |
+| 2 | `specflow-init` no args shows project name prompt with default | Yes | bin/specflow-init |
+| 3 | `specflow-init --dir <path>` initializes in path | Yes | bin/specflow-init |
+| 4 | `--dir` subdirectory of existing repo → error | Yes | bin/specflow-init |
+| 5 | Numbered agent selection (main/review) | Yes | bin/specflow-init |
+| 6 | `.specflow/config.env` persistence | Yes | bin/specflow-init |
+| 7 | `.gitignore` idempotent update | Yes | bin/specflow-init |
+| 8 | openspec CLI missing → error | Yes | bin/specflow-init |
+| 9 | `--update` mode preserved | Yes | bin/specflow-init |
+
+**Coverage Rate**: 9/9 (100%)
+
+## Remaining Risks
+
+- ⚠️ Spec R3-F05: "Chosen project name is never mapped to OpenSpec or persisted" (severity: high) — addressed in implementation via `inject_config_name()` but spec was not updated to reflect this decision
+- ⚠️ No shell test coverage for new init flows (acknowledged — shell script project)
+
+## Human Checkpoints
+
+- [ ] Run `specflow-init test-project` in a clean directory and verify directory creation + openspec init + config.env
+- [ ] Run `specflow-init` with no args inside an existing git repo and verify project name prompt works
+- [ ] Run `specflow-init --dir /tmp/subdir` inside an existing repo and verify subdirectory rejection
+- [ ] Verify `.specflow/config.env` is correctly gitignored after initialization
+- [ ] Verify `specflow-init --update` still works from a subdirectory of an existing project

--- a/openspec/changes/improve-init-command/current-phase.md
+++ b/openspec/changes/improve-init-command/current-phase.md
@@ -1,0 +1,10 @@
+# Current Phase: improve-init-command
+
+- Phase: impl-review
+- Round: 2
+- Status: all_resolved
+- Open High Findings: 0 件
+- Accepted Risks: none
+- Latest Changes:
+  - (no commits yet)
+- Next Recommended Action: /specflow.approve

--- a/openspec/changes/improve-init-command/plan.md
+++ b/openspec/changes/improve-init-command/plan.md
@@ -1,0 +1,96 @@
+# Plan: improve-init-command
+
+## Overview
+
+`bin/specflow-init` を書き換えて、openspec CLI 呼び出し・プロジェクト名指定・ディレクトリ引数・エージェント選択を追加する。
+
+## Architecture
+
+### 実行フロー（新）
+
+```
+specflow-init [<project-name>] [--dir <path>] [--update]
+  │
+  ├─ --update → コマンド更新のみ（既存動作）→ 早期 exit
+  │
+  ├─ 引数解析
+  │   ├─ <project-name> → PROJECT_NAME に設定
+  │   ├─ --dir <path> → TARGET_DIR に設定
+  │   └─ 引数なし → TARGET_DIR="", PROJECT_NAME=""
+  │
+  ├─ Preflight バリデーション（ファイル書き込み前に全チェック）
+  │   ├─ openspec CLI 存在チェック（command -v openspec）
+  │   └─ specflow-install 済みチェック（$CONFIG_DIR/template 存在）
+  │
+  ├─ ターゲットパス解決（ディレクトリ作成はまだしない）
+  │   ├─ パターン 1: TARGET_PATH="./<project-name>"
+  │   ├─ パターン 2/3: TARGET_PATH="<path>"
+  │   └─ パターン 4: TARGET_PATH=$(git rev-parse --show-toplevel 2>/dev/null)
+  │       → 空の場合: "Error: not inside a git repository." → exit 1
+  │
+  ├─ ターゲットパスバリデーション（ファイル書き込み前）
+  │   ├─ --dir フローのみ: サブディレクトリチェック
+  │   │   TARGET_PATH が既存 git リポジトリ内のサブディレクトリ → エラー
+  │   └─ TARGET_PATH が既に存在する場合: openspec/config.yaml チェック → エラー
+  │
+  ├─ ターゲットディレクトリ作成 & 移動（バリデーション通過後）
+  │   ├─ パターン 1: mkdir <project-name> && cd <project-name>
+  │   ├─ パターン 2/3: mkdir -p <path> if needed && cd <path>
+  │   └─ パターン 4: cd $TARGET_PATH
+  │
+  ├─ git init（git リポジトリがない場合のみ。パターン 1/2/3 で発生しうる）
+  │
+  ├─ プロジェクト名解決
+  │   ├─ PROJECT_NAME が設定済み → そのまま使用
+  │   └─ 未設定（パターン 2/4）→ ディレクトリ名をデフォルトで対話プロンプト
+  │
+  ├─ エージェント選択（番号選択式、2 回実行）
+  │   ├─ main: select_agent(MAIN_AGENTS, MAIN_AGENT_DEFAULT) → MAIN_AGENT
+  │   │   "Select main agent: 1) claude [default]"
+  │   └─ review: select_agent(REVIEW_AGENTS, REVIEW_AGENT_DEFAULT) → REVIEW_AGENT
+  │       "Select review agent: 1) codex [default]"
+  │   → TOOLS_ARG="${MAIN_AGENT},${REVIEW_AGENT}"
+  │
+  ├─ openspec init . --tools $TOOLS_ARG
+  │
+  ├─ config.yaml に name フィールドを追加（inject_config_name $PROJECT_NAME）
+  │
+  ├─ specflow 固有セットアップ（openspec init 完了後に実行）
+  │   ├─ .specflow/config.env 生成（SPECFLOW_MAIN_AGENT=$MAIN_AGENT, SPECFLOW_REVIEW_AGENT=$REVIEW_AGENT）
+  │   ├─ .mcp.json コピー（テンプレートから、既存ならスキップ）
+  │   ├─ CLAUDE.md コピー（テンプレートから、既存ならスキップ）
+  │   └─ スラッシュコマンドインストール
+  │
+  └─ .gitignore 更新（冪等、.specflow/config.env のみ）
+```
+
+### エージェント定義（拡張可能な配列）
+
+```bash
+# Main agents
+MAIN_AGENTS=("claude")
+MAIN_AGENT_DEFAULT=0
+
+# Review agents
+REVIEW_AGENTS=("codex")
+REVIEW_AGENT_DEFAULT=0
+```
+
+### ヘルパー関数
+
+1. `select_agent(agents_array, default_index)` — 番号選択式 UI。配列とデフォルトインデックスを受け取り、選択されたエージェント名を返す。main/review それぞれで呼び出す。
+2. `prompt_project_name(default)` — デフォルト値付きのプロジェクト名入力。Enter で確定。
+3. `ensure_gitignore_entry(entry)` — .gitignore に指定エントリのみを冪等に追加。他のエントリは追加しない。
+4. `check_not_subdirectory()` — `--dir` フロー専用。ターゲットディレクトリが既存 git リポジトリ内のサブディレクトリの場合にエラー
+5. `inject_config_name(name)` — openspec/config.yaml に name フィールドを追加
+
+## Risks
+
+1. **openspec CLI のバージョン差異**: `openspec init` の出力形式が変わる可能性
+   - 対策: `openspec init` の終了コードのみに依存し、出力パースは最小限にする
+2. **config.yaml の書き換え**: openspec init が生成する config.yaml のフォーマットが不明
+   - 対策: sed で `schema:` 行の後に `name:` を挿入する or 末尾に追加
+3. **既存の specflow-init ユーザーへの影響**: 引数なしの動作が変わる（プロジェクト名プロンプト追加）
+   - 対策: デフォルト値ありで Enter だけで確定可能にし、UX の変更を最小限に
+4. **git リポジトリ外での引数なし実行**: git rev-parse --show-toplevel が失敗する
+   - 対策: エラーメッセージで `specflow-init <project-name>` の使用を案内

--- a/openspec/changes/improve-init-command/proposal.md
+++ b/openspec/changes/improve-init-command/proposal.md
@@ -1,0 +1,161 @@
+# Proposal: initコマンドの改善
+
+**Change ID**: improve-init-command
+**Status**: Draft
+**Created**: 2026-04-07
+**Issue**: https://github.com/skr19930617/specflow/issues/36
+
+## Purpose
+
+`specflow-init` コマンドを OpenSpec 準拠で改善し、プロジェクト名の指定・ディレクトリ引数によるカレントディレクトリ初期化・エージェント選択のインタラクティブ化を実現する。
+
+## Background
+
+現行の `specflow-init` は:
+- プロジェクト名を受け取らない（git ルートを自動検出するのみ）
+- ディレクトリを引数で指定できない
+- エージェント（main / review）の選択がハードコードされている
+- `.gitignore` の自動設定が行われない
+- テンプレートから openspec/ をコピーしているが、`openspec init` CLI を呼んでいない
+
+## Decisions (Clarify Results)
+
+1. **プロジェクト名**: 引数なしの場合、ディレクトリ名から自動推定し確認プロンプトを表示。Enter で確定、または別名を入力。
+2. **`.gitignore`**: `.specflow/config.env` のみを追加。openspec/ の成果物はすべてコミット対象。
+3. **エージェント選択 UI**: 番号選択式（例: `1) claude  2) codex`）。デフォルト値あり、Enter だけで確定可能。
+4. **OpenSpec init**: テンプレートコピーではなく、外部 `openspec init` CLI を呼び出して初期化する。
+5. **`--dir` で git リポジトリなし**: `git init` を自動実行してから初期化を進行。
+6. **サブディレクトリ init 禁止**: 初期化対象は必ず git リポジトリルートでなければならない。既存リポジトリ内のサブディレクトリを `--dir` で指定した場合はエラー。
+
+## CLI Behavior Matrix
+
+以下の 4 パターンで動作を定義する。
+
+### パターン 1: `specflow-init <project-name>`
+- カレントディレクトリに `<project-name>/` ディレクトリを**新規作成**
+- 作成したディレクトリ内で `git init` を実行
+- 作成したディレクトリ内で `openspec init` を実行（エージェント選択結果を `--tools` で渡す）
+- specflow 固有の設定（`.specflow/config.env`, `.mcp.json`, `CLAUDE.md`, スラッシュコマンド）をセットアップ
+
+### パターン 2: `specflow-init --dir <path>`
+- `<path>` で指定されたディレクトリに移動して初期化（ディレクトリが存在しなければ作成）
+- git リポジトリがなければ `git init` を自動実行
+- **制約**: `<path>` が既存 git リポジトリ内のサブディレクトリの場合はエラー終了（`"Error: <path> is inside an existing git repository. Initialize at the repository root instead."`）
+- プロジェクト名はディレクトリ名から推定し、確認プロンプトで確定
+
+### パターン 3: `specflow-init --dir <path> <project-name>`
+- パターン 2 と同じディレクトリ処理（サブディレクトリ制約を含む）
+- `<project-name>` をプロジェクト名として使用（プロンプトなし）
+
+### パターン 4: `specflow-init` (引数なし)
+- カレントディレクトリ（git ルート）で初期化（現行動作を維持）
+- プロジェクト名はディレクトリ名をデフォルト値として対話プロンプトで確認
+
+### 共通動作
+- 既に `openspec/config.yaml` が存在する場合は「already initialized」でエラー終了（現行動作を維持）
+- `--update` モードは引き続き独立して動作（プロジェクト名・エージェント選択には影響しない）
+- `.gitignore` の更新先は常に初期化対象ディレクトリ（= git ルート）の `.gitignore`
+
+## OpenSpec Init Integration
+
+### 実行フロー
+specflow-init は `openspec init` CLI を外部コマンドとして呼び出して openspec/ ディレクトリを初期化する。
+
+1. エージェント選択で選ばれた main/review エージェントを `openspec init` の `--tools` オプションにマッピング
+2. `openspec init [path] --tools <main>,<review>` を実行
+3. `openspec init` が `openspec/config.yaml`, `openspec/specs/`, `openspec/changes/` を作成
+4. specflow 固有のセットアップ（`.specflow/config.env`, `.mcp.json`, `CLAUDE.md`, スラッシュコマンド）は specflow-init が直接行う
+
+### エージェント → openspec --tools マッピング
+| specflow エージェント | openspec --tools 値 |
+|----------------------|---------------------|
+| claude (main)        | `claude`            |
+| codex (review)       | `codex`             |
+
+実行例:
+```bash
+openspec init . --tools claude,codex
+```
+
+### openspec init 失敗時
+- `openspec` コマンドが見つからない場合: `"Error: openspec CLI is not installed. Run 'npm install -g openspec' first."` でエラー終了
+- `openspec init` が非ゼロ終了した場合: エラーメッセージを表示してエラー終了
+
+## Agent Configuration
+
+### 有効値（このリリース）
+| ロール | 有効値 | デフォルト |
+|--------|--------|-----------|
+| main   | `claude` | `claude` |
+| review | `codex`  | `codex`  |
+
+### 永続化先
+- **`.specflow/config.env`** で specflow 固有のエージェント設定を管理
+- `openspec init --tools` で openspec 側にもエージェント情報を渡す（openspec 側の永続化は openspec CLI が行う）
+- specflow のワークフローコマンド（plan, impl, review 等）は `.specflow/config.env` を `source` して `SPECFLOW_MAIN_AGENT` / `SPECFLOW_REVIEW_AGENT` 環境変数を読み取る
+
+### config.env の出力形式
+```bash
+# specflow agent configuration
+# Edit these values to change your agents
+SPECFLOW_MAIN_AGENT=claude
+SPECFLOW_REVIEW_AGENT=codex
+```
+
+### エージェント選択フロー
+1. 番号選択式で main エージェントを選択（デフォルト: 1=claude）
+2. 番号選択式で review エージェントを選択（デフォルト: 1=codex）
+3. 選択結果を `.specflow/config.env` に書き出し
+4. 選択結果を `openspec init --tools` に渡す
+
+### 将来の拡張
+- エージェント定義は bash の配列で管理（例: `MAIN_AGENTS=("claude" "aider")`）
+- 新しいエージェントの追加は配列にエントリを追加するだけで対応可能
+- openspec の `--tools` オプションが対応する値のリストは `openspec init --help` から取得可能
+
+## .gitignore 更新ルール
+
+1. `.gitignore` の更新先は常に初期化対象ディレクトリ（= git ルート）の `.gitignore`
+2. `.gitignore` が存在しない場合: 新規作成し `.specflow/config.env` エントリを追加
+3. `.gitignore` が存在する場合:
+   - `.specflow/config.env` がすでに含まれていれば何もしない（冪等性）
+   - 含まれていなければ末尾に追加
+4. `.specflow/config.env` 以外のエントリは追加しない
+
+## Scope
+
+### 変更対象
+- `bin/specflow-init` — 引数パース・インタラクティブ設定・openspec init CLI 呼び出し
+- `.specflow/config.env` — エージェント設定の永続化先
+- `.gitignore` — `.specflow/config.env` エントリの冪等な追加
+
+### 変更内容
+1. **プロジェクト名の指定**: `specflow-init <project-name>` で新規ディレクトリを作成して初期化。引数なしならディレクトリ名をデフォルト値として対話プロンプト表示。
+2. **ディレクトリ引数**: `specflow-init --dir <path>` で指定ディレクトリに初期化。ディレクトリが存在しなければ作成。git リポジトリがなければ `git init` を自動実行。サブディレクトリ init は禁止。
+3. **エージェント選択**: 番号選択式の対話 UI で main エージェント（デフォルト: claude）と review エージェント（デフォルト: codex）を選択。
+4. **OpenSpec init 呼び出し**: テンプレートコピーではなく `openspec init --tools <agents>` を呼び出し。
+5. **設定の永続化**: `.specflow/config.env` に `SPECFLOW_MAIN_AGENT` / `SPECFLOW_REVIEW_AGENT` を書き出し。
+6. **`.gitignore` 設定**: `.specflow/config.env` のみを冪等に `.gitignore` に追加。
+7. **将来の拡張性**: エージェント定義を bash 配列で管理し、新しいエージェントの追加を容易にする。
+
+## Out of Scope
+
+- 新しいエージェント（claude / codex 以外）の追加実装
+- OpenSpec 自体のスキーマ定義の変更
+- specflow のワークフローコマンド（plan, impl 等）の変更
+- CI/CD 関連の変更
+
+## Completion Criteria
+
+- `specflow-init my-project` で `./my-project/` ディレクトリが作成され、内部で `openspec init --tools claude,codex` が実行される
+- `specflow-init` 引数なしでディレクトリ名をデフォルト値として対話プロンプトが表示される
+- `specflow-init --dir <path>` で指定ディレクトリに初期化が動作する（ディレクトリなしなら作成、git なしなら自動 git init）
+- `specflow-init --dir <path>` でサブディレクトリ（既存リポジトリ内）を指定した場合はエラー終了
+- `specflow-init --dir <path> my-project` で指定ディレクトリにプロジェクト名付きで初期化される
+- 番号選択式プロンプトで main / review エージェントを選択できる
+- 選択結果が `.specflow/config.env` に `SPECFLOW_MAIN_AGENT` / `SPECFLOW_REVIEW_AGENT` として永続化される
+- 選択結果が `openspec init --tools` に渡される
+- `.specflow/config.env` を手動編集してエージェントを後から変更できる
+- `.gitignore` に `.specflow/config.env` が冪等に追加される（既に存在すれば追加しない）
+- `openspec` CLI がインストールされていない場合は適切なエラーメッセージが表示される
+- `--update` モードが引き続き正常に動作する

--- a/openspec/changes/improve-init-command/research.md
+++ b/openspec/changes/improve-init-command/research.md
@@ -1,0 +1,41 @@
+# Research: improve-init-command
+
+## openspec CLI
+
+- `openspec init [path] --tools <tools>` で初期化
+- `--tools`: カンマ区切りで AI ツールを指定（claude, codex, cursor 等）
+- `[path]` は初期化先ディレクトリ（省略時はカレント）
+- プロジェクト名を渡すオプションは**ない** → init 後に config.yaml の name フィールドを上書きする必要あり
+- `--force`: レガシーファイルの自動クリーンアップ
+- `--profile`: config プロファイルの指定
+
+## 現行 specflow-init の構造
+
+1. `--update` フラグ解析（コマンド更新のみモード）
+2. `$CONFIG_DIR/template` の存在チェック（specflow-install 済みか）
+3. git ルート検出 → `cd $ROOT`
+4. `openspec/config.yaml` 存在チェック（already initialized）
+5. テンプレート取得（`$SPECFLOW_TEMPLATE_REPO` or ローカル `$CONFIG_DIR/template`）
+6. ファイルコピー: `.mcp.json`, `CLAUDE.md`, `openspec/` ディレクトリ
+7. スラッシュコマンドのインストール
+
+## 主要な変更点
+
+- openspec/ の初期化をテンプレートコピーから `openspec init` CLI 呼び出しに変更
+- 引数パース: `<project-name>`, `--dir <path>`, `--update` の 3 系統
+- インタラクティブ設定: プロジェクト名確認、エージェント選択
+- .specflow/config.env の生成
+- .gitignore の冪等な更新
+- サブディレクトリ init の検出と拒否
+
+## テンプレートの扱い
+
+- `openspec init` CLI が openspec/ を作成するため、テンプレートから openspec/ コピーは不要になる
+- `.mcp.json`, `CLAUDE.md`, スラッシュコマンドのインストールは引き続き specflow-init が担当
+- `.specflow/config.env` は specflow-init が新規作成
+
+## config.yaml name フィールド
+
+- `openspec init` はプロジェクト名オプションを持たない
+- `openspec init` 後に `openspec/config.yaml` を読み込み、`name:` 行を追加/上書きする
+- sed or awk で先頭に `name: <project-name>` を挿入する方式

--- a/openspec/changes/improve-init-command/review-ledger-plan.json
+++ b/openspec/changes/improve-init-command/review-ledger-plan.json
@@ -1,0 +1,154 @@
+{
+  "feature_id": "improve-init-command",
+  "phase": "plan",
+  "current_round": 3,
+  "status": "all_resolved",
+  "max_finding_id": 8,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "plan.md",
+      "title": "Required preflight validation is missing and partially misordered",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "ordering",
+      "file": "tasks.md",
+      "title": "Project-name resolution is not wired into the execution flow",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "consistency",
+      "file": "tasks.md",
+      "title": "Subdirectory validation is scoped more broadly than the spec allows",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R2-F04",
+      "severity": "high",
+      "category": "completeness",
+      "file": "plan.md",
+      "title": "No-arg flow does not explicitly resolve to git root",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "R2-F05",
+      "severity": "high",
+      "category": "ordering",
+      "file": "tasks.md",
+      "title": "Specflow setup can run before OpenSpec init",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "R2-F06",
+      "severity": "medium",
+      "category": "consistency",
+      "file": "tasks.md",
+      "title": "Agent selection is underspecified for two roles and defaults",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "R2-F07",
+      "severity": "medium",
+      "category": "ordering",
+      "file": "tasks.md",
+      "title": "Phase dependencies are inconsistent across CLI patterns",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "R2-F08",
+      "severity": "low",
+      "category": "scope",
+      "file": "tasks.md",
+      "title": "Exact .gitignore constraint is not called out in the tasks",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 8,
+      "open": 0,
+      "new": 5,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 1, "new": 2, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 2, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 }
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 0,
+      "new": 0,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 3, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 4, "new": 0, "overridden": 0 },
+        "low": { "open": 0, "resolved": 1, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/improve-init-command/review-ledger-plan.json.bak
+++ b/openspec/changes/improve-init-command/review-ledger-plan.json.bak
@@ -1,0 +1,63 @@
+{
+  "feature_id": "improve-init-command",
+  "phase": "plan",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "plan.md",
+      "title": "Required preflight validation is missing and partially misordered",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 1
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "ordering",
+      "file": "tasks.md",
+      "title": "Project-name resolution is not wired into the execution flow",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 1
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "consistency",
+      "file": "tasks.md",
+      "title": "Subdirectory validation is scoped more broadly than the spec allows",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 1
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/improve-init-command/review-ledger-spec.json
+++ b/openspec/changes/improve-init-command/review-ledger-spec.json
@@ -1,0 +1,117 @@
+{
+  "feature_id": "improve-init-command",
+  "phase": "spec",
+  "current_round": 3,
+  "status": "has_open_high",
+  "max_finding_id": 5,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Project name and target directory semantics are not defined",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Agent support and OpenSpec mapping are underspecified",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 3
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Git and .gitignore behavior relies on unconfirmed assumptions",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R2-F04",
+      "severity": "medium",
+      "category": "edge_case",
+      "file": "proposal.md",
+      "title": "--dir inside an existing repository does not define which .gitignore file to update",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "R3-F05",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Chosen project name is never mapped to OpenSpec or persisted",
+      "detail": "The issue requires project-name-based initialization, and the spec adds prompts that let the user confirm or override the directory-derived name. However, the OpenSpec integration only defines `openspec init [path] --tools <main>,<review>` and never states where the confirmed project name goes. In the --dir and no-arg flows, if the user enters a name different from the directory name, implementation cannot tell whether it should rename the directory, pass an explicit OpenSpec argument or config field, or reject the mismatch.",
+      "suggested_resolution": "Specify the exact OpenSpec argument or config field that receives the selected project name, and define the required behavior when the entered name differs from the directory basename or is not OpenSpec-compliant.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 3,
+      "latest_round": 3
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 4,
+      "open": 1,
+      "new": 1,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 1, "resolved": 1, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 1, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 3,
+      "total": 5,
+      "open": 0,
+      "new": 1,
+      "resolved": 4,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 2, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 2, "new": 0, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/improve-init-command/review-ledger-spec.json.bak
+++ b/openspec/changes/improve-init-command/review-ledger-spec.json.bak
@@ -1,0 +1,89 @@
+{
+  "feature_id": "improve-init-command",
+  "phase": "spec",
+  "current_round": 2,
+  "status": "has_open_high",
+  "max_finding_id": 4,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Project name and target directory semantics are not defined",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Agent support and OpenSpec mapping are underspecified",
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Git and .gitignore behavior relies on unconfirmed assumptions",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R2-F04",
+      "severity": "medium",
+      "category": "edge_case",
+      "file": "proposal.md",
+      "title": "--dir inside an existing repository does not define which .gitignore file to update",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 2
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 4,
+      "open": 1,
+      "new": 1,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 1, "resolved": 1, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 1, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/improve-init-command/review-ledger.json
+++ b/openspec/changes/improve-init-command/review-ledger.json
@@ -1,0 +1,102 @@
+{
+  "feature_id": "improve-init-command",
+  "phase": "impl",
+  "current_round": 2,
+  "status": "in_progress",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "bin/specflow-init",
+      "title": "Agent selection uses Bash 4 namerefs on a Bash 3.2 script baseline",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "correctness",
+      "file": "bin/specflow-init",
+      "title": "Nonexistent nested --dir paths bypass the repository-root guard",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "testing",
+      "file": "bin/specflow-init",
+      "title": "No test coverage was added for the new init flows",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "Shell script project without test framework. Acknowledged.",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "bin/specflow-init",
+      "title": "--update no longer preserves repo-root behavior",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 2
+    },
+    {
+      "id": "R2-F02",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "bin/specflow-init",
+      "title": "Project names are injected into sed unsafely",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 2
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 5,
+      "open": 0,
+      "new": 0,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 2, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 3, "new": 0, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/improve-init-command/tasks.md
+++ b/openspec/changes/improve-init-command/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: improve-init-command
+
+## Phase 1: 引数パース & Preflight & バリデーション
+
+### Task 1.1: 引数パース（--update 早期 exit を含む）
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Description**: `--update` / `-h` / `--help` / `--dir <path>` / 位置引数 `<project-name>` を解析。`--update` の場合は既存のコマンド更新ロジックを実行して早期 exit（preflight/target-dir 以降の全ステップをバイパス）。
+- **Acceptance Criteria**:
+  - `specflow-init --update` → コマンド更新のみ実行して exit（preflight/openspec init は実行しない）
+  - `specflow-init my-project` → `PROJECT_NAME=my-project`, `TARGET_DIR=""`
+  - `specflow-init --dir /tmp/foo` → `PROJECT_NAME=""`, `TARGET_DIR=/tmp/foo`
+  - `specflow-init --dir /tmp/foo my-project` → `PROJECT_NAME=my-project`, `TARGET_DIR=/tmp/foo`
+  - `specflow-init` → `PROJECT_NAME=""`, `TARGET_DIR=""`
+  - 不明なオプションはエラー
+
+### Task 1.2: Preflight バリデーション
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 1.1
+- **Description**: ファイル書き込み前に前提条件をチェック。
+- **Checks**:
+  1. `command -v openspec` — openspec CLI の存在
+  2. `$CONFIG_DIR/template` — specflow-install 済み
+- **Acceptance Criteria**:
+  - チェック失敗 → エラーメッセージ + exit 1（ディレクトリ作成なし）
+
+### Task 1.3: ターゲットパス解決（ディレクトリ作成なし）
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 1.2
+- **Description**: パターン別にターゲットパスを**解決するだけ**。mkdir は行わない。
+- **Acceptance Criteria**:
+  - パターン 1: `TARGET_PATH="./<project-name>"`
+  - パターン 2/3: `TARGET_PATH="<path>"`
+  - パターン 4: `TARGET_PATH=$(git rev-parse --show-toplevel 2>/dev/null)`, 空なら `"Error: not inside a git repository."` + exit 1
+
+### Task 1.4: ターゲットパスバリデーション
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 1.3
+- **Description**: ファイルシステム変更前にバリデーション。
+- **Checks**:
+  1. `--dir` フローのみ: `check_not_subdirectory()` — サブディレクトリチェック
+  2. TARGET_PATH が既存の場合: `openspec/config.yaml` 存在チェック（already initialized）
+- **Acceptance Criteria**:
+  - `--dir` でサブディレクトリ → エラー + exit 1（ディレクトリ作成なし）
+  - already initialized → エラー + exit 1（ディレクトリ作成なし）
+
+### Task 1.5: ターゲットディレクトリ作成 & 移動
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 1.4
+- **Description**: バリデーション通過後にディレクトリ作成と cd を実行。
+- **Acceptance Criteria**:
+  - パターン 1: `mkdir <project-name> && cd <project-name>`
+  - パターン 2/3: `mkdir -p <path> && cd <path>`（必要な場合のみ作成）
+  - パターン 4: `cd $TARGET_PATH`
+
+## Phase 2: git init & インタラクティブ設定（順次実行）
+
+### Task 2.1: git init の自動実行
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 1.5
+- **Description**: ターゲットディレクトリに git リポジトリがない場合、`git init` を自動実行。パターン 4 では既に git ルートのため実行されない。
+
+### Task 2.2: プロジェクト名解決
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 1.5
+- **Description**: `prompt_project_name(default)` ヘルパー関数。PROJECT_NAME が未設定の場合にディレクトリ名をデフォルトとして対話入力。**2.1 と直列に実行**（対話プロンプトの競合を防ぐ）。
+- **Acceptance Criteria**:
+  - パターン 1/3: プロンプトなし
+  - パターン 2/4: プロンプト表示
+
+### Task 2.3: エージェント選択 UI（2 回順次実行）
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 2.2（対話プロンプトは直列実行）
+- **Description**: `select_agent(agents_array, default_index, role_name)` ヘルパー関数。main → review の順に呼び出す。
+- **Acceptance Criteria**:
+  - main → review の順でプロンプト表示
+  - Enter → デフォルト値選択
+  - TOOLS_ARG="${MAIN_AGENT},${REVIEW_AGENT}" が正しく構築される
+
+## Phase 3: openspec init & 設定（Phase 2 完了後）
+
+### Task 3.1: openspec init 呼び出し
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 2.1, 2.3
+- **Description**: `openspec init . --tools $TOOLS_ARG` を実行
+- **Acceptance Criteria**:
+  - 非ゼロ終了の場合、エラーメッセージ + exit 1
+
+### Task 3.2: config.yaml に name フィールドを追加
+- **Priority**: P1
+- **File**: `bin/specflow-init`
+- **Depends on**: 3.1, 2.2
+- **Description**: `inject_config_name(name)` ヘルパー関数
+
+## Phase 4: specflow 固有セットアップ（Phase 3 完了後）
+
+### Task 4.1: .specflow/config.env の生成
+- **Priority**: P0
+- **File**: `bin/specflow-init`
+- **Depends on**: 3.2
+
+### Task 4.2: .gitignore の冪等な更新
+- **Priority**: P1
+- **File**: `bin/specflow-init`
+- **Depends on**: 4.1
+- **Description**: `ensure_gitignore_entry(".specflow/config.env")`。`.specflow/config.env` のみ追加。他のエントリは一切追加しない。
+
+### Task 4.3: .mcp.json / CLAUDE.md テンプレートコピー
+- **Priority**: P1
+- **Depends on**: 3.2
+
+### Task 4.4: スラッシュコマンドインストール
+- **Priority**: P1
+- **Depends on**: 3.2
+
+## Phase 5: ヘルプ・仕上げ
+
+### Task 5.1: ヘルプメッセージ更新
+- **Priority**: P1
+
+### Task 5.2: 完了メッセージ更新
+- **Priority**: P2
+
+## Execution Order
+
+```
+1.1 (arg parse + --update early exit)
+  → 1.2 (preflight)
+    → 1.3 (path resolve, no mkdir)
+      → 1.4 (validation)
+        → 1.5 (mkdir + cd)
+          → 2.1 (git init) → 2.2 (project name prompt) → 2.3 (agent selection)
+            → 3.1 (openspec init) → 3.2 (name injection)
+              → 4.1 (config.env) → 4.2 (.gitignore)
+              → 4.3 (.mcp.json/CLAUDE.md)
+              → 4.4 (slash commands)
+                → 5.1 (help) + 5.2 (completion msg)
+```
+
+Note: 全ての対話プロンプト（2.2, 2.3）は直列実行。並行実行しない。


### PR DESCRIPTION
…ection (#36)

Rewrite specflow-init to support:
- specflow-init <project-name>: create new directory and initialize
- specflow-init --dir <path>: initialize in specified directory
- Interactive agent selection (main/review) with numbered UI
- OpenSpec CLI integration (openspec init --tools)
- .specflow/config.env for agent configuration persistence
- .gitignore idempotent update for config.env
- Subdirectory init prevention for --dir flow
- Bash 3.2 compatible (no namerefs)
- Project name validation and safe config.yaml injection

Issue: https://github.com/skr19930617/specflow/issues/36