### PR TITLE
feat: add .gitignore and .claude/ tracking option to init

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(wc -l /Users/sakurayuki/work/spec-scripts/global/*.md)",
-      "Bash(grep -o \"\"AskUserQuestion\"\"[^}]*} /Users/sakurayuki/.claude/projects/-Users-sakurayuki-work-spec-scripts/c3127e73-4586-48e0-a1e2-d2fca1b1a006.jsonl)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Claude Code - local settings
+.claude/settings.json
+.claude/settings.local.json
+
+# MCP server config (local paths/tools)
+.mcp.json
+
+# Specflow local env
+.specflow/config.env

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "codex": {
-      "command": "codex",
-      "args": ["mcp-server"]
-    }
-  }
-}

--- a/.specflow/config.env
+++ b/.specflow/config.env
@@ -1,9 +1,0 @@
-# specflow configuration
-# このファイルは specflow 実行時に source される
-# プロジェクト固有の環境変数をここに追加する
-
-# 例: Codex のモデルを変更する場合
-# export CODEX_MODEL="gpt-5.4"
-
-# Auto-fix loop の最大ラウンド数（デフォルト: 4、範囲: 1〜10）
-# export SPECFLOW_MAX_AUTOFIX_ROUNDS=4

--- a/bin/specflow-init
+++ b/bin/specflow-init
@@ -81,6 +81,29 @@ ensure_gitignore_entry() {
   echo "Added $entry to $gitignore"
 }
 
+prompt_yes_no() {
+  local question=$1
+  local default=$2  # "y" or "n"
+
+  local hint="[Y/n]"
+  if [[ "$default" == "n" ]]; then
+    hint="[y/N]"
+  fi
+
+  while true; do
+    read -rp "$question $hint: " answer
+    answer="${answer,,}"  # lowercase
+    if [[ -z "$answer" ]]; then
+      answer="$default"
+    fi
+    case "$answer" in
+      y|yes) echo "y"; return ;;
+      n|no)  echo "n"; return ;;
+      *) echo "  Please enter y or n." >&2 ;;
+    esac
+  done
+}
+
 check_not_subdirectory() {
   local target_path=$1
   local check_dir="$target_path"
@@ -353,6 +376,15 @@ echo
 TOOLS_ARG="${MAIN_AGENT},${REVIEW_AGENT}"
 
 # -------------------------------------------------------
+# 2.4: .claude/ git tracking preference
+# -------------------------------------------------------
+
+echo "Track .claude/ in git? (commands/ and skills/ will be shared with the team)"
+TRACK_CLAUDE_DIR="$(prompt_yes_no "Include .claude/ in git?" "y")"
+echo "  → track .claude/: $TRACK_CLAUDE_DIR"
+echo
+
+# -------------------------------------------------------
 # 3.1: openspec init
 # -------------------------------------------------------
 
@@ -386,6 +418,15 @@ echo "Created .specflow/config.env"
 # 4.2: .gitignore idempotent update
 # -------------------------------------------------------
 
+if [[ "$TRACK_CLAUDE_DIR" == "y" ]]; then
+  # Track commands/ and skills/, ignore local settings only
+  ensure_gitignore_entry ".claude/settings.json"
+  ensure_gitignore_entry ".claude/settings.local.json"
+else
+  # Ignore entire .claude/ directory
+  ensure_gitignore_entry ".claude/"
+fi
+ensure_gitignore_entry ".mcp.json"
 ensure_gitignore_entry ".specflow/config.env"
 
 # -------------------------------------------------------


### PR DESCRIPTION
- Create .gitignore to exclude local config files (.claude/settings.json, .claude/settings.local.json, .mcp.json, .specflow/config.env)
- Untrack already-committed local config files
- Add interactive prompt in specflow-init to choose whether .claude/ directory should be git-tracked (commands/skills shared) or fully ignored