### PR TITLE
feat: add specflow-readme command for OSS-style README generation (#56)

### DIFF
--- a/bin/specflow-analyze
+++ b/bin/specflow-analyze
@@ -1,0 +1,535 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# specflow-analyze: Collect project information as JSON for README generation
+# Usage: specflow-analyze [path]
+# Output: JSON to stdout, errors to stderr
+
+ROOT="${1:-.}"
+cd "$ROOT"
+
+# -------------------------------------------------------
+# jq check
+# -------------------------------------------------------
+HAS_JQ=false
+if command -v jq &>/dev/null; then
+  HAS_JQ=true
+fi
+
+# -------------------------------------------------------
+# Helper: JSON-escape a string (no jq fallback)
+# -------------------------------------------------------
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+# -------------------------------------------------------
+# Helper: read file content or return empty
+# -------------------------------------------------------
+read_file_or_null() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    cat "$path"
+  else
+    echo ""
+  fi
+}
+
+# -------------------------------------------------------
+# 1. Project name
+# -------------------------------------------------------
+PROJECT_NAME="$(basename "$(pwd)")"
+
+# -------------------------------------------------------
+# 2. Git remote → owner/repo
+# -------------------------------------------------------
+GIT_REMOTE_URL=""
+GIT_OWNER=""
+GIT_REPO=""
+
+if git rev-parse --is-inside-work-tree &>/dev/null; then
+  GIT_REMOTE_URL="$(git remote get-url origin 2>/dev/null || true)"
+  if [[ -n "$GIT_REMOTE_URL" ]]; then
+    # Extract owner/repo from SSH or HTTPS URL
+    local_path="${GIT_REMOTE_URL%.git}"
+    local_path="${local_path##*:}"
+    local_path="${local_path##*/}"
+    # For HTTPS: https://github.com/owner/repo.git
+    if [[ "$GIT_REMOTE_URL" =~ https?://[^/]+/([^/]+)/([^/]+) ]]; then
+      GIT_OWNER="${BASH_REMATCH[1]}"
+      GIT_REPO="${BASH_REMATCH[2]%.git}"
+    # For SSH: git@github.com:owner/repo.git
+    elif [[ "$GIT_REMOTE_URL" =~ :([^/]+)/([^/]+) ]]; then
+      GIT_OWNER="${BASH_REMATCH[1]}"
+      GIT_REPO="${BASH_REMATCH[2]%.git}"
+    fi
+  fi
+fi
+
+# -------------------------------------------------------
+# 3. Package manifest detection
+# -------------------------------------------------------
+DESCRIPTION=""
+LANGUAGES="[]"
+FRAMEWORKS="[]"
+PACKAGE_MANAGER=""
+BUILD_TOOLS="[]"
+TEST_TOOLS="[]"
+SCRIPTS="{}"
+BIN_ENTRIES="[]"
+KEYWORDS="[]"
+
+detect_languages=()
+detect_frameworks=()
+detect_build=()
+detect_test=()
+detect_bin=()
+detect_keywords=()
+scripts_json="{}"
+
+# package.json
+if [[ -f "package.json" ]]; then
+  detect_languages+=("JavaScript")
+  if [[ -f "tsconfig.json" ]]; then
+    detect_languages+=("TypeScript")
+  fi
+
+  if [[ "$HAS_JQ" == true ]]; then
+    DESCRIPTION="$(jq -r '.description // empty' package.json 2>/dev/null || true)"
+
+    # scripts
+    scripts_json="$(jq -c '.scripts // {}' package.json 2>/dev/null || echo '{}')"
+
+    # bin entries
+    bin_raw="$(jq -r '.bin // empty' package.json 2>/dev/null || true)"
+    if [[ -n "$bin_raw" ]]; then
+      if jq -e 'type == "object"' <<< "$bin_raw" &>/dev/null; then
+        while IFS= read -r bk; do [[ -n "$bk" ]] && detect_bin+=("$bk"); done < <(jq -r 'keys[]' <<< "$bin_raw" 2>/dev/null)
+      elif jq -e 'type == "string"' <<< "$bin_raw" &>/dev/null; then
+        detect_bin+=("$(jq -r '.' <<< "$bin_raw")")
+      fi
+    fi
+
+    # keywords
+    while IFS= read -r kw; do [[ -n "$kw" ]] && detect_keywords+=("$kw"); done < <(jq -r '.keywords // [] | .[]' package.json 2>/dev/null)
+
+    # framework detection from dependencies
+    deps="$(jq -r '(.dependencies // {}) + (.devDependencies // {}) | keys[]' package.json 2>/dev/null || true)"
+    for dep in $deps; do
+      case "$dep" in
+        react) detect_frameworks+=("React") ;;
+        next) detect_frameworks+=("Next.js") ;;
+        vue) detect_frameworks+=("Vue.js") ;;
+        nuxt) detect_frameworks+=("Nuxt") ;;
+        svelte) detect_frameworks+=("Svelte") ;;
+        express) detect_frameworks+=("Express") ;;
+        fastify) detect_frameworks+=("Fastify") ;;
+        nestjs|@nestjs/*) detect_frameworks+=("NestJS") ;;
+      esac
+    done
+
+    # build/test tool detection
+    for dep in $deps; do
+      case "$dep" in
+        vite) detect_build+=("vite") ;;
+        webpack) detect_build+=("webpack") ;;
+        esbuild) detect_build+=("esbuild") ;;
+        rollup) detect_build+=("rollup") ;;
+        vitest) detect_test+=("vitest") ;;
+        jest) detect_test+=("jest") ;;
+        mocha) detect_test+=("mocha") ;;
+        playwright|@playwright/*) detect_test+=("playwright") ;;
+      esac
+    done
+
+    # package manager from packageManager field
+    pm_field="$(jq -r '.packageManager // empty' package.json 2>/dev/null || true)"
+    if [[ -n "$pm_field" ]]; then
+      PACKAGE_MANAGER="${pm_field%%@*}"
+    fi
+  fi
+fi
+
+# Cargo.toml
+if [[ -f "Cargo.toml" ]]; then
+  detect_languages+=("Rust")
+  if [[ -z "$DESCRIPTION" ]]; then
+    DESCRIPTION="$(grep -m1 '^description' Cargo.toml 2>/dev/null | sed 's/.*= *"\(.*\)"/\1/' || true)"
+  fi
+fi
+
+# go.mod
+if [[ -f "go.mod" ]]; then
+  detect_languages+=("Go")
+fi
+
+# pyproject.toml / requirements.txt
+if [[ -f "pyproject.toml" ]] || [[ -f "requirements.txt" ]]; then
+  detect_languages+=("Python")
+fi
+
+# Gemfile
+if [[ -f "Gemfile" ]]; then
+  detect_languages+=("Ruby")
+fi
+
+# build.gradle / build.gradle.kts / pom.xml
+if [[ -f "build.gradle" ]] || [[ -f "build.gradle.kts" ]]; then
+  detect_languages+=("Java")
+  if [[ -f "build.gradle.kts" ]]; then
+    detect_languages+=("Kotlin")
+  fi
+fi
+if [[ -f "pom.xml" ]]; then
+  detect_languages+=("Java")
+fi
+
+# composer.json
+if [[ -f "composer.json" ]]; then
+  detect_languages+=("PHP")
+fi
+
+# Shell scripts detection
+if compgen -G "bin/*" > /dev/null 2>&1; then
+  for f in bin/*; do
+    if head -1 "$f" 2>/dev/null | grep -q "bash\|sh" 2>/dev/null; then
+      detect_languages+=("Bash")
+      detect_bin+=("$(basename "$f")")
+    fi
+  done
+fi
+
+# -------------------------------------------------------
+# 4. Lockfile → package manager
+# -------------------------------------------------------
+if [[ -z "$PACKAGE_MANAGER" ]]; then
+  if [[ -f "pnpm-lock.yaml" ]]; then
+    PACKAGE_MANAGER="pnpm"
+  elif [[ -f "yarn.lock" ]]; then
+    PACKAGE_MANAGER="yarn"
+  elif [[ -f "bun.lockb" ]] || [[ -f "bun.lock" ]]; then
+    PACKAGE_MANAGER="bun"
+  elif [[ -f "package-lock.json" ]]; then
+    PACKAGE_MANAGER="npm"
+  elif [[ -f "Cargo.lock" ]]; then
+    PACKAGE_MANAGER="cargo"
+  elif [[ -f "go.sum" ]]; then
+    PACKAGE_MANAGER="go"
+  elif [[ -f "poetry.lock" ]]; then
+    PACKAGE_MANAGER="poetry"
+  elif [[ -f "Pipfile.lock" ]]; then
+    PACKAGE_MANAGER="pipenv"
+  elif [[ -f "Gemfile.lock" ]]; then
+    PACKAGE_MANAGER="bundler"
+  elif [[ -f "composer.lock" ]]; then
+    PACKAGE_MANAGER="composer"
+  fi
+fi
+
+# -------------------------------------------------------
+# 5. CI detection
+# -------------------------------------------------------
+CI_PROVIDER=""
+CI_WORKFLOWS="[]"
+
+if [[ -d ".github/workflows" ]]; then
+  CI_PROVIDER="github-actions"
+  wf_json="["
+  first=true
+  for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [[ -f "$wf" ]] || continue
+    wf_base="$(basename "$wf")"
+    wf_name="${wf_base%.*}"
+    wf_ext=".${wf_base##*.}"
+    if [[ "$first" == true ]]; then
+      first=false
+    else
+      wf_json+=","
+    fi
+    wf_json+="{\"name\":\"$wf_name\",\"extension\":\"$wf_ext\"}"
+  done
+  wf_json+="]"
+  CI_WORKFLOWS="$wf_json"
+elif [[ -f ".gitlab-ci.yml" ]]; then
+  CI_PROVIDER="gitlab-ci"
+elif [[ -f ".circleci/config.yml" ]]; then
+  CI_PROVIDER="circleci"
+fi
+
+# -------------------------------------------------------
+# 6. LICENSE detection
+# -------------------------------------------------------
+LICENSE_TYPE=""
+if [[ -f "LICENSE" ]] || [[ -f "LICENSE.md" ]] || [[ -f "LICENSE.txt" ]]; then
+  license_file="$(ls LICENSE* 2>/dev/null | head -1)"
+  license_content="$(head -5 "$license_file" 2>/dev/null || true)"
+  case "$license_content" in
+    *"MIT License"*|*"MIT"*) LICENSE_TYPE="MIT" ;;
+    *"Apache License"*) LICENSE_TYPE="Apache-2.0" ;;
+    *"GNU General Public License"*) LICENSE_TYPE="GPL-3.0" ;;
+    *"BSD 2-Clause"*) LICENSE_TYPE="BSD-2-Clause" ;;
+    *"BSD 3-Clause"*) LICENSE_TYPE="BSD-3-Clause" ;;
+    *"ISC License"*) LICENSE_TYPE="ISC" ;;
+    *"Mozilla Public License"*) LICENSE_TYPE="MPL-2.0" ;;
+    *) LICENSE_TYPE="other" ;;
+  esac
+fi
+
+# -------------------------------------------------------
+# 7. Config files
+# -------------------------------------------------------
+config_files=()
+for cf in .env.example .env.sample .editorconfig biome.json .eslintrc* .prettierrc* prettier.config.* tsconfig.json jest.config.* vitest.config.* vite.config.* webpack.config.* rollup.config.* next.config.* nuxt.config.*; do
+  compgen -G "$cf" > /dev/null 2>&1 && config_files+=("$cf")
+done
+
+# -------------------------------------------------------
+# 8. CONTRIBUTING.md
+# -------------------------------------------------------
+CONTRIBUTING=""
+if [[ -f "CONTRIBUTING.md" ]]; then
+  CONTRIBUTING="$(cat CONTRIBUTING.md)"
+fi
+
+# -------------------------------------------------------
+# 9. OpenSpec info
+# -------------------------------------------------------
+OPENSPEC_HAS_CONFIG=false
+OPENSPEC_PROJECT_NAME=""
+OPENSPEC_CONTEXT=""
+OPENSPEC_SPECS="[]"
+OPENSPEC_CHANGES="[]"
+
+if [[ -f "openspec/config.yaml" ]]; then
+  OPENSPEC_HAS_CONFIG=true
+  if command -v yq &>/dev/null; then
+    OPENSPEC_PROJECT_NAME="$(yq -r '.name // empty' openspec/config.yaml 2>/dev/null || true)"
+    OPENSPEC_CONTEXT="$(yq -r '.context // empty' openspec/config.yaml 2>/dev/null || true)"
+  else
+    OPENSPEC_PROJECT_NAME="$(grep -m1 '^name:' openspec/config.yaml 2>/dev/null | sed 's/^name: *//' || true)"
+    # Parse multiline context: block scalar after "context: |" or "context: >"
+    if grep -q '^context:' openspec/config.yaml 2>/dev/null; then
+      OPENSPEC_CONTEXT="$(sed -n '/^context:/,/^[^ ]/{ /^context:/d; /^[^ ]/d; s/^  //; p; }' openspec/config.yaml 2>/dev/null | head -20 || true)"
+    fi
+  fi
+
+  if [[ -d "openspec/specs" ]]; then
+    specs=()
+    for d in openspec/specs/*/; do
+      [[ -d "$d" ]] && specs+=("$(basename "$d")")
+    done
+    if [[ ${#specs[@]} -gt 0 ]]; then
+      if [[ "$HAS_JQ" == true ]]; then
+        OPENSPEC_SPECS="$(printf '%s\n' "${specs[@]}" | jq -R . | jq -sc .)"
+      else
+        OPENSPEC_SPECS="["
+        local_first=true
+        for s in "${specs[@]}"; do
+          [[ "$local_first" == true ]] && local_first=false || OPENSPEC_SPECS+=","
+          OPENSPEC_SPECS+="\"$s\""
+        done
+        OPENSPEC_SPECS+="]"
+      fi
+    fi
+  fi
+
+  if [[ -d "openspec/changes" ]]; then
+    changes=()
+    for d in openspec/changes/*/; do
+      [[ -d "$d" ]] && changes+=("$(basename "$d")")
+    done
+    if [[ ${#changes[@]} -gt 0 ]]; then
+      if [[ "$HAS_JQ" == true ]]; then
+        OPENSPEC_CHANGES="$(printf '%s\n' "${changes[@]}" | jq -R . | jq -sc .)"
+      else
+        OPENSPEC_CHANGES="["
+        local_first=true
+        for c in "${changes[@]}"; do
+          [[ "$local_first" == true ]] && local_first=false || OPENSPEC_CHANGES+=","
+          OPENSPEC_CHANGES+="\"$c\""
+        done
+        OPENSPEC_CHANGES+="]"
+      fi
+    fi
+  fi
+fi
+
+# -------------------------------------------------------
+# 10. Existing README
+# -------------------------------------------------------
+EXISTING_README=""
+if [[ -f "README.md" ]]; then
+  EXISTING_README="$(cat README.md)"
+fi
+
+# -------------------------------------------------------
+# 11. File structure
+# -------------------------------------------------------
+FILE_STRUCTURE=""
+if command -v tree &>/dev/null; then
+  FILE_STRUCTURE="$(tree -L 2 --gitignore -I .git 2>/dev/null || tree -L 2 -I .git 2>/dev/null || true)"
+else
+  FILE_STRUCTURE="$(find . -maxdepth 2 -not -path './.git/*' -not -path './.git' | sort 2>/dev/null || true)"
+fi
+
+# -------------------------------------------------------
+# Deduplicate arrays
+# -------------------------------------------------------
+dedup_array() {
+  printf '%s\n' "$@" | sort -u | grep -v '^$'
+}
+
+uniq_langs=()
+while IFS= read -r line; do [[ -n "$line" ]] && uniq_langs+=("$line"); done < <(dedup_array "${detect_languages[@]+"${detect_languages[@]}"}")
+uniq_frameworks=()
+while IFS= read -r line; do [[ -n "$line" ]] && uniq_frameworks+=("$line"); done < <(dedup_array "${detect_frameworks[@]+"${detect_frameworks[@]}"}")
+uniq_build=()
+while IFS= read -r line; do [[ -n "$line" ]] && uniq_build+=("$line"); done < <(dedup_array "${detect_build[@]+"${detect_build[@]}"}")
+uniq_test=()
+while IFS= read -r line; do [[ -n "$line" ]] && uniq_test+=("$line"); done < <(dedup_array "${detect_test[@]+"${detect_test[@]}"}")
+uniq_bin=()
+while IFS= read -r line; do [[ -n "$line" ]] && uniq_bin+=("$line"); done < <(dedup_array "${detect_bin[@]+"${detect_bin[@]}"}")
+uniq_keywords=()
+while IFS= read -r line; do [[ -n "$line" ]] && uniq_keywords+=("$line"); done < <(dedup_array "${detect_keywords[@]+"${detect_keywords[@]}"}")
+
+# -------------------------------------------------------
+# Build JSON output
+# -------------------------------------------------------
+if [[ "$HAS_JQ" == true ]]; then
+  to_json_array() {
+    if [[ $# -eq 0 ]]; then
+      echo "[]"
+    else
+      printf '%s\n' "$@" | jq -R . | jq -sc .
+    fi
+  }
+
+  LANGUAGES="$(to_json_array "${uniq_langs[@]+"${uniq_langs[@]}"}")"
+  FRAMEWORKS="$(to_json_array "${uniq_frameworks[@]+"${uniq_frameworks[@]}"}")"
+  BUILD_TOOLS="$(to_json_array "${uniq_build[@]+"${uniq_build[@]}"}")"
+  TEST_TOOLS="$(to_json_array "${uniq_test[@]+"${uniq_test[@]}"}")"
+  BIN_ENTRIES="$(to_json_array "${uniq_bin[@]+"${uniq_bin[@]}"}")"
+  KEYWORDS="$(to_json_array "${uniq_keywords[@]+"${uniq_keywords[@]}"}")"
+  CONFIG_FILES="$(to_json_array "${config_files[@]+"${config_files[@]}"}")"
+
+  jq -n \
+    --arg project_name "$PROJECT_NAME" \
+    --arg description "$DESCRIPTION" \
+    --argjson languages "$LANGUAGES" \
+    --argjson frameworks "$FRAMEWORKS" \
+    --arg package_manager "$PACKAGE_MANAGER" \
+    --argjson build_tools "$BUILD_TOOLS" \
+    --argjson test_tools "$TEST_TOOLS" \
+    --arg ci_provider "$CI_PROVIDER" \
+    --argjson ci_workflows "$CI_WORKFLOWS" \
+    --arg license "$LICENSE_TYPE" \
+    --arg git_owner "$GIT_OWNER" \
+    --arg git_repo "$GIT_REPO" \
+    --arg git_url "$GIT_REMOTE_URL" \
+    --argjson openspec_has_config "$OPENSPEC_HAS_CONFIG" \
+    --arg openspec_project_name "$OPENSPEC_PROJECT_NAME" \
+    --arg openspec_context "$OPENSPEC_CONTEXT" \
+    --argjson openspec_specs "$OPENSPEC_SPECS" \
+    --argjson openspec_changes "$OPENSPEC_CHANGES" \
+    --arg existing_readme "$EXISTING_README" \
+    --arg file_structure "$FILE_STRUCTURE" \
+    --argjson bin_entries "$BIN_ENTRIES" \
+    --argjson scripts "$scripts_json" \
+    --argjson config_files "$CONFIG_FILES" \
+    --arg contributing "$CONTRIBUTING" \
+    --argjson keywords "$KEYWORDS" \
+    '{
+      project_name: $project_name,
+      description: (if $description == "" then null else $description end),
+      languages: $languages,
+      frameworks: $frameworks,
+      package_manager: (if $package_manager == "" then null else $package_manager end),
+      build_tools: $build_tools,
+      test_tools: $test_tools,
+      ci: {
+        provider: (if $ci_provider == "" then null else $ci_provider end),
+        workflows: $ci_workflows
+      },
+      license: (if $license == "" then null else $license end),
+      git_remote: {
+        owner: (if $git_owner == "" then null else $git_owner end),
+        repo: (if $git_repo == "" then null else $git_repo end),
+        url: (if $git_url == "" then null else $git_url end)
+      },
+      openspec: {
+        has_config: $openspec_has_config,
+        project_name: (if $openspec_project_name == "" then null else $openspec_project_name end),
+        context: (if $openspec_context == "" then null else $openspec_context end),
+        specs: $openspec_specs,
+        active_changes: $openspec_changes
+      },
+      existing_readme: (if $existing_readme == "" then null else $existing_readme end),
+      file_structure: $file_structure,
+      bin_entries: $bin_entries,
+      scripts: $scripts,
+      config_files: $config_files,
+      contributing: (if $contributing == "" then null else $contributing end),
+      keywords: $keywords
+    }'
+else
+  # Fallback: printf-based JSON (no jq)
+  echo >&2 "Warning: jq not found. Using simplified JSON output."
+
+  arr_to_json() {
+    local result="["
+    local first=true
+    for item in "$@"; do
+      [[ -z "$item" ]] && continue
+      if [[ "$first" == true ]]; then first=false; else result+=","; fi
+      result+="\"$(json_escape "$item")\""
+    done
+    result+="]"
+    printf '%s' "$result"
+  }
+
+  null_or_str() {
+    if [[ -z "$1" ]]; then echo "null"; else printf '"%s"' "$(json_escape "$1")"; fi
+  }
+
+  cat <<ENDJSON
+{
+  "project_name": "$(json_escape "$PROJECT_NAME")",
+  "description": $(null_or_str "$DESCRIPTION"),
+  "languages": $(arr_to_json "${uniq_langs[@]+"${uniq_langs[@]}"}"),
+  "frameworks": $(arr_to_json "${uniq_frameworks[@]+"${uniq_frameworks[@]}"}"),
+  "package_manager": $(null_or_str "$PACKAGE_MANAGER"),
+  "build_tools": $(arr_to_json "${uniq_build[@]+"${uniq_build[@]}"}"),
+  "test_tools": $(arr_to_json "${uniq_test[@]+"${uniq_test[@]}"}"),
+  "ci": {
+    "provider": $(null_or_str "$CI_PROVIDER"),
+    "workflows": $CI_WORKFLOWS
+  },
+  "license": $(null_or_str "$LICENSE_TYPE"),
+  "git_remote": {
+    "owner": $(null_or_str "$GIT_OWNER"),
+    "repo": $(null_or_str "$GIT_REPO"),
+    "url": $(null_or_str "$GIT_REMOTE_URL")
+  },
+  "openspec": {
+    "has_config": $OPENSPEC_HAS_CONFIG,
+    "project_name": $(null_or_str "$OPENSPEC_PROJECT_NAME"),
+    "context": $(null_or_str "$OPENSPEC_CONTEXT"),
+    "specs": $OPENSPEC_SPECS,
+    "active_changes": $OPENSPEC_CHANGES
+  },
+  "existing_readme": $(null_or_str "$EXISTING_README"),
+  "file_structure": "$(json_escape "$FILE_STRUCTURE")",
+  "bin_entries": $(arr_to_json "${uniq_bin[@]+"${uniq_bin[@]}"}"),
+  "scripts": $scripts_json,
+  "config_files": $(arr_to_json "${config_files[@]+"${config_files[@]}"}"),
+  "contributing": $(null_or_str "$CONTRIBUTING"),
+  "keywords": $(arr_to_json "${uniq_keywords[@]+"${uniq_keywords[@]}"}")
+}
+ENDJSON
+fi

--- a/global/commands/specflow.readme.md
+++ b/global/commands/specflow.readme.md
@@ -1,0 +1,135 @@
+---
+description: プロジェクト解析に基づいて OSS 風 README を生成・更新
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Prerequisites
+
+1. Run `which specflow-analyze` via Bash to confirm `specflow-analyze` is installed.
+   - If missing:
+     ```
+     ❌ `specflow-analyze` が見つかりません。
+     `specflow-install` を実行してパスを通してください。
+     ```
+     → **STOP**.
+
+## Step 1: Analyze Project
+
+Run via Bash:
+```bash
+specflow-analyze .
+```
+
+If the command fails (non-zero exit), display the error and **STOP**.
+
+Store the JSON output as `ANALYZE_RESULT`.
+
+Report:
+```
+Step 1: Project analyzed
+  Languages: <languages>
+  Frameworks: <frameworks>
+  Package Manager: <package_manager>
+```
+
+## Step 2: Generate README
+
+Using `ANALYZE_RESULT`, generate the README following these rules:
+
+### Grounding Policy (Source-of-Truth)
+
+Each section and badge MUST be backed by evidence from `ANALYZE_RESULT`. If evidence is insufficient, OMIT the section (do not guess).
+
+**Exception: Template sections** — Contributing may use a generic template when no CONTRIBUTING.md exists.
+
+### Section-Evidence Requirements
+
+| Section | Required Evidence | No Evidence → |
+|---------|------------------|---------------|
+| Badges (tech stack) | `languages` / `frameworks` | Omit |
+| Badges (license) | `license` | Omit |
+| Badges (CI) | `ci.provider` + `ci.workflows` | Omit |
+| Overview | `description` or `existing_readme` | Project name only + placeholder |
+| Features | `openspec.specs` or `keywords` | Omit |
+| Installation | `package_manager` + `scripts` | Omit |
+| Usage | `bin_entries` + `scripts` | Omit |
+| Configuration | `config_files` | Omit |
+| Architecture | `openspec.specs` (2+) or `file_structure` | Omit |
+| Contributing | `contributing` | Generic template |
+| License | `license` | Omit |
+
+### Badge Rules
+
+**Static badges** (tech stack, license):
+- Use shields.io static badge URLs
+- Example: `https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white`
+
+**Dynamic badges** (CI):
+- **GitHub Actions**: Use actual workflow filename: `https://img.shields.io/github/actions/workflow/status/{owner}/{repo}/{workflow_name}{extension}`
+- **GitLab CI**: `https://img.shields.io/gitlab/pipeline-status/{owner}%2F{repo}`
+- Other CI: Omit
+- Requires `git_remote.owner` and `git_remote.repo`; omit if missing
+
+### Emoji Section Headings
+
+Use emoji prefixes for section headings:
+- `✨ Features`
+- `📦 Installation`
+- `🚀 Usage`
+- `⚙️ Configuration`
+- `🏗️ Architecture`
+- `🤝 Contributing`
+- `📄 License`
+
+### Existing README Merge Strategy
+
+Check `ANALYZE_RESULT.existing_readme`:
+
+**If null (no existing README):**
+- Generate a complete new README
+- Display the generated README to the user
+
+**If non-null (existing README):**
+
+Apply the merge strategy:
+
+0. **Preamble handling**: Content before the first `##` heading (H1 title, badge row, overview paragraph) is treated as a special "preamble" merge unit. The preamble is always classified as **Improve** — regenerate title, badges, and overview from evidence while preserving any non-standard content as protected blocks.
+1. Split the rest of existing README by `##` headings into sections
+2. Classify each section using the Section-Evidence table:
+   - **Improve**: Section heading matches an entry in the table AND evidence exists → regenerate
+   - **Preserve**: Section heading does NOT match any entry → keep verbatim
+3. Within "Improve" sections, classify content blocks:
+   - **Generate target**: Content that can be derived from evidence (install commands, badge URLs, etc.)
+   - **Protected block**: Everything else (notes, caveats, subsections not matching evidence). When ambiguous, classify as protected (conservative approach).
+4. For each "Improve" section: generate new content, then append protected blocks in original order
+5. Insert "Preserve" sections in their original positions
+6. Add new sections (evidence exists but no existing heading) at appropriate positions
+
+**CRITICAL**: Preserve sections and protected blocks MUST be kept VERBATIM — do not modify a single character.
+
+## Step 3: Review and Approve
+
+**New README (no existing):**
+- Display the full generated README
+- Use `AskUserQuestion` with options: "適用" / "再生成" / "キャンセル"
+
+**Updated README (existing):**
+- Display the full diff between existing and generated README (no line limit)
+- Use `AskUserQuestion` with options: "適用" / "再生成" / "キャンセル"
+
+On "適用": Write the README to `README.md` via Write tool. Report: `README.md updated`
+On "再生成": Ask for feedback, add to prompt context, and re-run Step 2
+On "キャンセル": Report: `Cancelled. No changes made.`
+
+## Important Rules
+
+- Use the git repository root as the base for all paths
+- All evidence must come from `specflow-analyze` output — do not read additional files
+- Never generate content without evidence (except template sections)
+- Protected blocks and preserve sections are VERBATIM — zero modifications
+- When evidence is ambiguous, omit rather than guess

--- a/openspec/changes/add-readme-command/approval-summary.md
+++ b/openspec/changes/add-readme-command/approval-summary.md
@@ -1,0 +1,77 @@
+# Approval Summary: add-readme-command
+
+**Generated**: 2026-04-07 20:03
+**Branch**: add-readme-command
+**Status**: ⚠️ 1 unresolved high (plan review — accepted risk for implementation)
+
+## What Changed
+
+New files for this feature:
+- `bin/specflow-analyze` — 511 lines added (bash project analyzer)
+- `global/commands/specflow.readme.md` — 134 lines added (slash command)
+
+## Files Touched
+
+- `bin/specflow-analyze` (new)
+- `global/commands/specflow.readme.md` (new)
+- `openspec/changes/add-readme-command/` (proposal, plan, tasks, research, review artifacts)
+
+## Review Loop Summary
+
+### Spec Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 1     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 3     |
+
+### Plan Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 2     |
+| Unresolved high    | 1     |
+| New high (later)   | 2     |
+| Total rounds       | 4     |
+
+### Impl Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 1     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+## Spec Coverage
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | specflow-analyze がプロジェクト情報を JSON 収集 | Yes | bin/specflow-analyze |
+| 2 | /specflow.readme で Claude が README.md を生成 | Yes | global/commands/specflow.readme.md |
+| 3 | 既存 README は diff 表示後にユーザー承認で適用 | Yes | global/commands/specflow.readme.md (Step 3) |
+| 4 | 新規プロジェクトでは README.md を新規作成 | Yes | global/commands/specflow.readme.md (Step 2/3) |
+| 5 | tech stack に応じた shields.io バッジ | Yes | global/commands/specflow.readme.md (Badge Rules) |
+| 6 | 絵文字付きセクション見出し | Yes | global/commands/specflow.readme.md (Emoji) |
+| 7 | specflow-analyze 単体でも JSON 出力利用可能 | Yes | bin/specflow-analyze |
+| 8 | エビデンスベース生成（推測で埋めない） | Yes | global/commands/specflow.readme.md (Grounding Policy) |
+| 9 | OpenSpec 非依存 | Yes | bin/specflow-analyze (optional openspec/) |
+
+**Coverage Rate**: 9/9 (100%)
+
+## Remaining Risks
+
+- R3-F01 (plan): 改善対象セクション直下の手書き本文が上書きされうる (severity: high) — ユーザーが実装進行を選択
+- R4-F01 (plan): Protected blocks の位置が移動する可能性 (severity: medium)
+- R1-F05 (impl): No test coverage for specflow-analyze (severity: medium) — deferred to manual verification
+- R3-F01 (spec): Install/Usage sections can require guessed commands (severity: medium)
+- R3-F02 (spec): GitHub Actions badge rule can generate broken badges (severity: medium)
+
+## Human Checkpoints
+
+- [ ] `specflow-analyze` を実際のプロジェクト（Node.js, Rust, Go 等）で実行し、JSON 出力が正確か確認
+- [ ] `/specflow.readme` で既存 README があるプロジェクトに対して実行し、ユーザー記述セクションが保持されるか確認
+- [ ] jq が入っていない環境で `specflow-analyze` のフォールバック JSON 出力が有効な JSON か検証
+- [ ] 生成された shields.io バッジ URL がブラウザで正しくレンダリングされるか確認

--- a/openspec/changes/add-readme-command/current-phase.md
+++ b/openspec/changes/add-readme-command/current-phase.md
@@ -1,0 +1,10 @@
+# Current Phase: add-readme-command
+
+- Phase: impl-review
+- Round: 1
+- Status: in_progress
+- Open High Findings: 0 件
+- Accepted Risks: none
+- Latest Changes:
+  - (no commits yet — staged changes only)
+- Next Recommended Action: /specflow.approve

--- a/openspec/changes/add-readme-command/plan.md
+++ b/openspec/changes/add-readme-command/plan.md
@@ -1,0 +1,217 @@
+# Plan: add-readme-command
+
+**Change ID**: add-readme-command
+**Created**: 2026-04-07
+
+## Overview
+
+`/specflow.readme` slash コマンドと `bin/specflow-analyze` スクリプトを実装する。
+bash スクリプトがプロジェクト情報を JSON で収集し、slash コマンドが Claude に README 生成を委任する。
+
+## Architecture
+
+```
+User → /specflow.readme → Bash(specflow-analyze) → JSON → Claude → README.md
+                                                              ↓
+                                                     diff 表示 → 承認 → Write
+```
+
+### コンポーネント
+
+1. **`bin/specflow-analyze`** (bash script, ~200行)
+   - プロジェクトルートで実行
+   - JSON を stdout に出力
+   - 終了コード: 0=成功, 1=エラー
+
+2. **`global/commands/specflow.readme.md`** (slash command, ~150行)
+   - `specflow-analyze` を Bash ツールで実行
+   - JSON を解析し Claude にプロンプトとして渡す
+   - 既存 README の有無で分岐（新規生成 / 改善版生成+diff）
+   - AskUserQuestion で承認後に Write
+
+## Existing README Merge Strategy
+
+既存 README がある場合の保持・マージ戦略:
+
+### 基本方針: 既存全文を保持ベースとする
+AI は既存 README を**ベース**として扱い、セクション単位で「改善」「追加」「保持」のいずれかを行う。既存テキストのデフォルト動作は「保持」であり、明示的にエビデンスがあるセクションのみ改善対象とする。
+
+### セクション-エビデンス対応テーブル
+以下のテーブルで、既存 README のセクション見出しと specflow-analyze のエビデンスフィールドを対応付ける。
+
+| README セクション見出しパターン | エビデンスフィールド | 動作 |
+|------------------------------|-------------------|------|
+| バッジ行（`![` で始まる行群） | `languages`, `frameworks`, `license`, `ci` | 改善: エビデンスに基づきバッジ行を再生成 |
+| `# <project>` (h1 タイトル) | `project_name`, `description` | 改善: タイトルと説明文を更新 |
+| `## Features` / `## 機能` | `openspec.specs`, `keywords` | 改善: エビデンスがあれば更新 |
+| `## Installation` / `## インストール` | `package_manager`, `scripts` | 改善: パッケージマネージャに基づき更新 |
+| `## Usage` / `## 使い方` | `bin_entries`, `scripts` | 改善: bin/scripts に基づき更新 |
+| `## Configuration` / `## 設定` | `config_files` | 改善: 設定ファイル情報で更新 |
+| `## Architecture` / `## アーキテクチャ` | `openspec.specs` (2+), `file_structure` | 改善: 構造情報で更新 |
+| `## Contributing` | `contributing` | 改善: CONTRIBUTING.md があれば参照、なければ汎用テンプレート |
+| `## License` | `license` | 改善: ライセンス情報で更新 |
+| 上記に該当しない見出し | — | **保持**: 原文を一字一句変更しない |
+
+### 混在コンテンツの保護ルール
+「改善」対象セクション内にユーザーが追加したコンテンツがある場合、以下のルールで保護する。
+
+#### 保護対象の定義
+改善対象 `##` セクション内のコンテンツを以下の 2 種類に分類する:
+
+1. **生成対象ブロック**: エビデンス対応テーブルの該当フィールドから生成できる内容（例: `## Installation` 内のインストールコマンド）
+2. **保護対象ブロック**: 以下のいずれかに該当するもの
+   - `###` 以下のサブセクションで、エビデンス対応テーブルに該当しないもの（例: `### Troubleshooting`）
+   - `###` に包まれていない自由記述テキスト（段落、箇条書き、注意書きなど）で、生成対象ブロックの内容と明らかに異なるもの
+
+#### 判定方法
+AI がセクション内容を解析し、以下の手順で分類する:
+1. 既存セクションの各段落・箇条書き・サブセクションを個別に識別
+2. エビデンスから生成可能な内容（インストールコマンド、使用例等）を「生成対象」とマーク
+3. それ以外のテキスト（注意書き、補足説明、トラブルシューティング等）を「保護対象」とマーク
+4. 判定が曖昧な場合は**保護対象**とする（保守的アプローチ）
+
+#### マージ順序
+改善セクションの出力構成:
+1. AI が生成した新しい内容（生成対象ブロック）
+2. 保護対象の自由記述テキスト（元の順序を維持）
+3. 保護対象のサブセクション（元の順序を維持）
+
+#### 例
+`## Installation` に以下の既存内容がある場合:
+```
+## Installation
+npm install my-package    ← 生成対象（パッケージマネージャコマンド）
+
+> Note: requires Node 18+  ← 保護対象（自由記述注意書き）
+
+### Troubleshooting         ← 保護対象（サブセクション）
+If you get error X...
+```
+→ AI は `npm install` 部分を `pnpm add` に更新し、Note と Troubleshooting は原文保持して末尾に付加
+
+### マージ手順
+1. 既存 README 全文を読み取り
+2. `##` 見出しでセクション分割
+3. 各セクションをエビデンス対応テーブルで分類（改善 / 保持）
+4. 改善セクション内のコンテンツを「生成対象ブロック」と「保護対象ブロック」に分類（自由記述テキスト・サブセクションの両方を対象）
+5. 改善セクション: AI が生成対象ブロックを再生成し、保護対象ブロック（自由記述 + サブセクション）を元の順序で末尾に付加
+6. 保持セクションは原文をそのまま挿入
+7. エビデンスがあるが既存にないセクションは適切な位置に新規追加
+8. 全体を結合して最終 README を生成
+
+### プロンプトへの指示
+slash コマンドのプロンプトに以下を含める:
+- 既存 README の全文
+- セクション分類結果（改善 / 保持 / 保護サブセクション）
+- エビデンス対応テーブル
+- 「保持セクション・保護対象ブロック（自由記述テキスト・サブセクション）は原文を一字一句変更するな」という明示的指示
+- 「判定が曖昧な場合は保護対象とせよ」という保守的アプローチの指示
+
+## Data Model
+
+### specflow-analyze 出力 JSON スキーマ
+
+```json
+{
+  "project_name": "string",
+  "description": "string | null",
+  "languages": ["string"],
+  "frameworks": ["string"],
+  "package_manager": "string | null",
+  "build_tools": ["string"],
+  "test_tools": ["string"],
+  "ci": {
+    "provider": "string | null",
+    "workflows": [{ "name": "string", "extension": "string" }]
+  },
+  "license": "string | null",
+  "git_remote": {
+    "owner": "string | null",
+    "repo": "string | null",
+    "url": "string | null"
+  },
+  "openspec": {
+    "has_config": "boolean",
+    "project_name": "string | null",
+    "context": "string | null",
+    "specs": ["string"],
+    "active_changes": ["string"]
+  },
+  "existing_readme": "string | null",
+  "file_structure": "string",
+  "bin_entries": ["string"],
+  "scripts": { "key": "value" },
+  "config_files": ["string"],
+  "contributing": "string | null",
+  "keywords": ["string"]
+}
+```
+
+## Implementation Phases
+
+### Phase 1: specflow-analyze (bin/specflow-analyze)
+
+bash スクリプト。プロジェクト情報を JSON 収集して stdout 出力。
+
+**検出順序:**
+1. git remote URL → owner/repo
+2. パッケージマニフェスト検出 (package.json, Cargo.toml, go.mod, pyproject.toml, etc.)
+3. lockfile → パッケージマネージャ推定
+4. tsconfig.json / 言語拡張子 → 言語一覧
+5. dependencies → フレームワーク検出
+6. scripts / bin → ビルド/テストツール, 実行可能ファイル
+7. CI 設定検出 (.github/workflows/, .gitlab-ci.yml)
+8. LICENSE ファイル解析
+9. openspec/ 情報読み取り (config.yaml, specs/, changes/)
+10. 既存 README.md 読み取り
+11. ファイル構造 (tree -L 2, .git 除外)
+12. 設定ファイル一覧 (.env.example, *.config.* 等)
+13. CONTRIBUTING.md の有無と内容（存在すれば全文読み取り）
+14. パッケージマニフェストの keywords / features フィールド
+
+**jq 依存:**
+- JSON 構築に jq を使用
+- jq がない場合: printf + エスケープで簡易 JSON 生成（フォールバック）
+
+### Phase 2: specflow.readme.md (global/commands/specflow.readme.md)
+
+slash コマンド定義。
+
+**フロー:**
+1. `specflow-analyze` を実行し JSON を取得
+2. JSON をパースして README 生成プロンプトを構築
+3. エビデンステーブル（proposal.md の Grounding Policy）をプロンプトに含める
+4. 既存 README がある場合:
+   a. `##` 見出しでセクション分割
+   b. セクション-エビデンス対応テーブルで「改善」/「保持」に分類
+   c. 改善セクション内の `###` サブセクションを「改善」/「保護」に分類
+   d. 分類結果（改善/保持/保護サブセクション）、エビデンス対応テーブル、既存全文をプロンプトに含める
+   e. 「保持セクション・保護サブセクションは原文を一字一句変更するな」と指示
+5. Claude が README を生成
+6. 既存 README がある場合: 全文 diff を表示し AskUserQuestion で承認
+7. 新規の場合: 生成結果を表示し AskUserQuestion で承認
+8. 承認後に Write ツールで README.md に書き込み
+
+### Phase 3: テスト・検証
+
+- 複数プロジェクトタイプでの動作確認
+  - Node.js/TypeScript プロジェクト
+  - 言語検出なしプロジェクト（bash のみ）
+  - OpenSpec ありプロジェクト
+  - OpenSpec なしプロジェクト
+
+## Risks & Mitigations
+
+| リスク | 影響 | 対策 |
+|-------|------|------|
+| jq 未インストール | specflow-analyze が動作しない | printf フォールバック実装 |
+| tree 未インストール | ファイル構造取得失敗 | `find . -maxdepth 2` フォールバック |
+| 大きな README | diff が見づらい | 全文 diff を表示。Claude の出力で自然にページングされるため制限不要。ユーザーはスクロールで全体を確認可能 |
+| 複数 workflow ファイル | どれを CI バッジにするか不明 | アルファベット順最初のファイルを使用 |
+
+## Dependencies
+
+- `jq` (推奨、フォールバックあり)
+- `tree` (推奨、フォールバックあり)
+- `git` (必須)
+- OpenSpec CLI (オプション — specflow-analyze は直接ファイル読み取りで動作)

--- a/openspec/changes/add-readme-command/proposal.md
+++ b/openspec/changes/add-readme-command/proposal.md
@@ -1,0 +1,147 @@
+# Proposal: READMEを改善するコマンドの追加
+
+**Change ID**: add-readme-command
+**Status**: Draft
+**Created**: 2026-04-07
+**Issue**: https://github.com/skr19930617/specflow/issues/56
+
+## Purpose
+
+プロジェクトの技術スタックを解析し、人気のあるOSS風のREADMEを自動生成・更新する slash コマンド `/specflow.readme` を追加する。バッジ、絵文字、セクション構成などを活用し、プロフェッショナルなREADMEを生成する。
+
+## Background
+
+- 現状、specflow で初期化したプロジェクトには `CLAUDE.md` はあるが、README の自動生成・改善機能がない
+- OpenSpec CLI には `openspec validate`, `openspec show`, `openspec instructions` 等があるが、**プロジェクトの tech stack を解析する専用コマンドは存在しない**。そのため、プロジェクト解析は新規の bash スクリプト `specflow-analyze` で独自に実装する。ただし、`openspec/config.yaml` や `openspec/changes/` などの OpenSpec 成果物は解析対象に含める
+- 人気のある OSS プロジェクトは、バッジ（CI/CD、カバレッジ、ライセンス等）、絵文字付きセクション見出し、インストール手順、使用例、コントリビューションガイドなど標準的な構成を持つ
+
+## Decisions (Clarify Results)
+
+1. **実装方式**: AI 委任方式。bash スクリプト（`specflow-analyze`）がプロジェクト情報を収集し、その結果を slash コマンドのプロンプト経由で Claude に渡して README を生成する。
+2. **セクション構成**: 全部入り。バッジ, 概要, 機能, インストール, 使い方, 設定, アーキテクチャ, Contributing, License を含む。プロジェクト内容に応じて AI が不要なセクションを自動判断して省略。
+3. **既存 README の扱い**: 確認付き上書き。既存 README を解析し改善版を生成。diff 表示後にユーザーが承認して適用。
+4. **実行方法**: slash コマンド `/specflow.readme` として実装。bash スクリプト `bin/specflow-analyze` はプロジェクト解析のみ担当し、Claude が README の生成・書き込みを行う。
+5. **解析範囲**: 幅広く収集。ファイル構造、パッケージマニフェスト（package.json, Cargo.toml, go.mod 等）、CI 設定、LICENSE、既存 README、git リモート URL、openspec 情報を全て収集し、AI が取捨選択する。
+
+## Content Generation Rules (Grounding Policy)
+
+Claude が README を生成する際、以下のルールに従う。
+
+### Source-of-Truth ルール
+- README の各セクション・バッジは、`specflow-analyze` が収集したエビデンスに**明示的に裏付けられる場合のみ**生成する
+- エビデンスが不十分なセクションは省略する（推測で埋めない）
+- 既存 README にユーザーが記述したセクションがある場合、そのセクションは原文を保持する（AI が勝手に書き換えない）
+- **例外: テンプレートセクション** — 下表で「汎用テンプレートを挿入」と記載されたセクションは、エビデンスなしでも定型文を挿入してよい。これは推測ではなくプロジェクト非依存の定型コンテンツである
+
+### セクション別エビデンス要件
+
+| セクション | 必須エビデンス | エビデンスなし時の動作 |
+|-----------|--------------|---------------------|
+| バッジ（tech stack） | `specflow-analyze` の `languages` / `frameworks` フィールド | 省略 |
+| バッジ（license） | LICENSE ファイルの存在 | 省略 |
+| バッジ（CI） | `.github/workflows/` 等の CI 設定ファイル | 省略 |
+| 概要 | パッケージマニフェストの description、または既存 README | プロジェクト名のみ表示し、ユーザーに記述を促す placeholder を挿入 |
+| インストール | パッケージマニフェスト（package.json の scripts、Cargo.toml 等） | 省略 |
+| 使い方 | パッケージマニフェストの bin/scripts、または既存 README | 省略 |
+| 設定 | 設定ファイルの存在（.env.example, config.yaml 等） | 省略 |
+| 機能 (Features) | `openspec/specs/` の capability spec、またはパッケージマニフェストの keywords/features フィールド | 省略 |
+| アーキテクチャ | `openspec/specs/` が 2 つ以上存在する、または `src/` 配下に明確なモジュール分割がある場合 | 省略 |
+| Contributing | CONTRIBUTING.md の存在 | 汎用テンプレートを挿入（テンプレートセクション例外） |
+| License | LICENSE ファイル | 省略 |
+
+### バッジ生成ルール
+
+バッジは以下の 2 種類に分類し、それぞれ異なるルールを適用する。
+
+**Static バッジ（tech stack, license 等）:**
+- shields.io の static badge URL を使用（例: `https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white`）
+- `specflow-analyze` の出力フィールドに基づいて生成。エビデンスがない言語・フレームワークのバッジは生成しない
+
+**Dynamic バッジ（CI status）:**
+- CI 設定ファイルが存在する場合のみ生成
+- **GitHub Actions**: `.github/workflows/` 内の最初の workflow ファイル名を使用して `github/actions/workflow/status/{owner}/{repo}/{workflow}.yml` バッジを生成
+- **GitLab CI**: `.gitlab-ci.yml` が存在する場合、`https://img.shields.io/gitlab/pipeline-status/{project-path}` バッジを生成
+- **その他の CI**: CI 設定ファイルは存在するが上記に該当しない場合、CI バッジは省略（shields.io が直接サポートする CI のみ対象）
+- リポジトリの owner/repo 情報は git remote URL から取得。取得できない場合は CI バッジを省略
+
+## OpenSpec Integration Contract
+
+### 統合方針
+OpenSpec CLI には tech stack 解析の専用コマンドが存在しないため、`specflow-analyze` が独自にプロジェクト解析を行う。ただし、OpenSpec の成果物は解析対象として積極的に活用する。
+
+### OpenSpec から読み取る情報
+| データソース | 取得情報 | 用途 |
+|------------|---------|------|
+| `openspec/config.yaml` | プロジェクト名、context（tech stack, conventions） | README の概要・tech stack セクション |
+| `openspec/specs/` | capability spec 一覧 | 機能セクションの生成 |
+| `openspec/changes/` | active change 一覧 | 開発状況の把握（オプション） |
+
+### OpenSpec が存在しない場合のフォールバック
+- `openspec/config.yaml` が存在しない場合: OpenSpec 関連情報をスキップし、パッケージマニフェスト等の他のエビデンスのみで README を生成する
+- `specflow-analyze` は OpenSpec の有無に関わらず動作する（OpenSpec は optional dependency）
+
+## Architecture
+
+### コンポーネント構成
+
+```
+/specflow.readme (slash コマンド)
+  │
+  ├── 1. bash: specflow-analyze を実行してプロジェクト情報を JSON で収集
+  │     ├── ファイル構造 (tree)
+  │     ├── パッケージマニフェスト (package.json, Cargo.toml, go.mod, etc.)
+  │     ├── CI 設定 (.github/workflows/, .gitlab-ci.yml, etc.)
+  │     ├── LICENSE ファイル
+  │     ├── 既存 README.md
+  │     ├── git リモート URL
+  │     └── openspec/ 情報
+  │
+  ├── 2. Claude: 収集した情報を元に OSS 風 README を生成
+  │     ├── shields.io バッジ (tech stack, license, CI status)
+  │     ├── 絵文字付きセクション見出し
+  │     └── プロジェクト固有の内容
+  │
+  └── 3. 適用: diff 表示 → ユーザー承認 → README.md に書き込み
+```
+
+### ファイル構成
+
+| ファイル | 役割 |
+|---------|------|
+| `bin/specflow-analyze` | プロジェクト解析スクリプト（JSON 出力） |
+| `global/commands/specflow.readme.md` | slash コマンド定義 |
+| `bin/specflow-install` | インストールスクリプト（specflow-analyze の PATH 登録追加） |
+
+## Scope
+
+### 変更対象
+- `bin/specflow-analyze` — 新規: プロジェクト解析スクリプト
+- `global/commands/specflow.readme.md` — 新規: slash コマンド定義
+- `bin/specflow-install` — 変更: `specflow-analyze` のインストール対応
+
+### 変更内容
+1. **プロジェクト解析スクリプト** (`specflow-analyze`): tech stack（言語、フレームワーク、ビルドツール）、ファイル構造、CI 設定、LICENSE、既存 README、git リモート URL、openspec 情報を JSON で出力
+2. **slash コマンド** (`/specflow.readme`): `specflow-analyze` を実行し、結果を元に Claude が OSS 風 README を生成。既存 README がある場合は diff を表示してユーザー承認後に適用
+3. **バッジ生成**: tech stack に応じた shields.io バッジを AI が自動選択・挿入
+4. **インストール対応**: `specflow-install` に `specflow-analyze` を追加
+
+## Out of Scope
+
+- OpenSpec CLI 自体の変更
+- CLAUDE.md の自動生成・更新（既存の init で対応済み）
+- GitHub Pages や Wiki の自動生成
+- 多言語 README（i18n）対応
+- Claude API の直接呼び出し（slash コマンド経由で Claude を利用するため不要）
+
+## Completion Criteria
+
+- `/specflow.readme` を実行すると、`specflow-analyze` がプロジェクト情報を収集し、Claude が README.md を生成する
+- 既存の README.md がある場合、改善版を生成し diff 表示後にユーザー承認で適用
+- 新規プロジェクトでは README.md を新規作成
+- tech stack に応じた shields.io バッジが自動挿入される
+- 絵文字付きセクション見出しが使用される
+- `specflow-install` 実行後に `specflow-analyze` が PATH で利用可能になる
+- `specflow-analyze` 単体でも JSON 出力として利用可能
+- **エビデンスベース生成**: 各セクション・バッジは `specflow-analyze` の収集結果に裏付けられた情報のみで生成される（推測で埋めない）
+- **エビデンス不足時**: 該当セクションが省略されるか、placeholder が挿入される
+- **OpenSpec 非依存**: `openspec/config.yaml` が存在しないプロジェクトでも動作する

--- a/openspec/changes/add-readme-command/research.md
+++ b/openspec/changes/add-readme-command/research.md
@@ -1,0 +1,96 @@
+# Research: add-readme-command
+
+## 既存コード解析
+
+### specflow-install (bin/specflow-install)
+- `bin/specflow-*` パターンで全スクリプトを `~/bin` にシンボリックリンク
+- 新規スクリプト `bin/specflow-analyze` を追加すれば自動でリンクされる
+- 変更不要（既存のワイルドカードパターンで対応済み）
+
+### specflow.setup.md (global/commands/specflow.setup.md)
+- 既に tech stack 検出ロジックが定義されている（package.json, tsconfig.json, pyproject.toml, Cargo.toml, go.mod, Gemfile, *.csproj, build.gradle, pom.xml）
+- `specflow-analyze` はこの検出パターンを bash で再実装する
+
+### slash コマンドフォーマット
+- `global/commands/specflow.*.md` 形式
+- frontmatter に `description` フィールド
+- `## User Input` + `$ARGUMENTS` でユーザー入力を受け取る
+- Bash / Read / Write ツールを使った手順記述
+
+## Tech Stack 検出方法
+
+### パッケージマニフェスト → 言語/フレームワーク検出
+| ファイル | 言語 | 追加情報 |
+|---------|------|---------|
+| `package.json` | JavaScript/TypeScript | dependencies, scripts, bin, description, packageManager |
+| `tsconfig.json` | TypeScript | - |
+| `Cargo.toml` | Rust | [package] name, description, [dependencies] |
+| `go.mod` | Go | module name |
+| `pyproject.toml` | Python | [project] description, dependencies |
+| `requirements.txt` | Python | - |
+| `Gemfile` | Ruby | - |
+| `build.gradle` / `build.gradle.kts` | Java/Kotlin | - |
+| `pom.xml` | Java | - |
+| `*.csproj` / `*.sln` | C#/.NET | - |
+| `composer.json` | PHP | - |
+
+### lockfile → パッケージマネージャ検出
+| lockfile | パッケージマネージャ |
+|---------|-------------------|
+| `package-lock.json` | npm |
+| `yarn.lock` | yarn |
+| `pnpm-lock.yaml` | pnpm |
+| `bun.lockb` / `bun.lock` | bun |
+| `Cargo.lock` | cargo |
+| `go.sum` | go |
+| `Pipfile.lock` | pipenv |
+| `poetry.lock` | poetry |
+| `Gemfile.lock` | bundler |
+| `composer.lock` | composer |
+
+### CI 設定検出
+| パス | CI プロバイダ |
+|-----|-------------|
+| `.github/workflows/*.yml` / `.yaml` | GitHub Actions |
+| `.gitlab-ci.yml` | GitLab CI |
+| `.circleci/config.yml` | CircleCI |
+| `Jenkinsfile` | Jenkins |
+| `.travis.yml` | Travis CI |
+
+## specflow-analyze JSON 出力スキーマ案
+
+```json
+{
+  "project_name": "string",
+  "description": "string or null",
+  "languages": ["TypeScript", "JavaScript"],
+  "frameworks": ["React", "Next.js"],
+  "package_manager": "pnpm",
+  "build_tools": ["vite"],
+  "test_tools": ["vitest"],
+  "ci": {
+    "provider": "github-actions",
+    "workflows": ["ci.yml"]
+  },
+  "license": "MIT",
+  "git_remote": {
+    "owner": "skr19930617",
+    "repo": "specflow",
+    "url": "https://github.com/skr19930617/specflow"
+  },
+  "openspec": {
+    "has_config": true,
+    "specs_count": 3,
+    "changes_count": 2,
+    "context": "Tech stack: bash, TypeScript..."
+  },
+  "existing_readme": "string or null",
+  "file_structure": "tree output",
+  "bin_entries": ["specflow-init", "specflow-analyze"],
+  "scripts": { "build": "...", "test": "..." }
+}
+```
+
+## specflow-install への影響
+
+**変更不要**。`bin/specflow-install` は `for script in "$REPO_ROOT/bin"/specflow-*` パターンでシンボリックリンクを作成するため、`bin/specflow-analyze` を追加するだけで自動的にインストールされる。

--- a/openspec/changes/add-readme-command/review-ledger-plan.json
+++ b/openspec/changes/add-readme-command/review-ledger-plan.json
@@ -1,0 +1,21 @@
+{
+  "feature_id": "add-readme-command",
+  "phase": "plan",
+  "current_round": 4,
+  "status": "has_open_high",
+  "max_finding_id": 6,
+  "findings": [
+    {"id":"R1-F01","severity":"high","category":"consistency","file":"plan.md","title":"既存 README の原文保持要件が未設計","status":"resolved","relation":"new","supersedes":null,"notes":"","origin_round":1,"latest_round":2},
+    {"id":"R1-F02","severity":"medium","category":"completeness","file":"plan.md","title":"セクション生成に必要なエビデンス収集が不足している","status":"resolved","relation":"new","supersedes":null,"notes":"","origin_round":1,"latest_round":3},
+    {"id":"R1-F03","severity":"medium","category":"risk","file":"plan.md","title":"承認前 diff の確認方法が要件を満たしていない","status":"resolved","relation":"new","supersedes":null,"notes":"","origin_round":1,"latest_round":2},
+    {"id":"R2-F01","severity":"high","category":"risk","file":"plan.md","title":"生成可能セクション配下の手書きサブセクションが失われる設計","status":"resolved","relation":"new","supersedes":null,"notes":"","origin_round":2,"latest_round":3},
+    {"id":"R3-F01","severity":"high","category":"risk","file":"plan.md","title":"改善対象セクション直下の手書き本文が依然として上書きされうる","status":"open","relation":"new","supersedes":null,"notes":"","origin_round":3,"latest_round":4},
+    {"id":"R4-F01","severity":"medium","category":"risk","file":"plan.md","title":"Protected blocks are preserved but can be moved out of context","status":"new","relation":"new","supersedes":null,"notes":"","origin_round":4,"latest_round":4}
+  ],
+  "round_summaries": [
+    {"round":1,"total":3,"open":0,"new":3,"resolved":0,"overridden":0,"by_severity":{"high":{"open":0,"resolved":0,"new":1,"overridden":0},"medium":{"open":0,"resolved":0,"new":2,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":2,"total":4,"open":1,"new":1,"resolved":2,"overridden":0,"by_severity":{"high":{"open":0,"resolved":1,"new":1,"overridden":0},"medium":{"open":1,"resolved":1,"new":0,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":3,"total":5,"open":0,"new":1,"resolved":4,"overridden":0,"by_severity":{"high":{"open":0,"resolved":2,"new":1,"overridden":0},"medium":{"open":0,"resolved":2,"new":0,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":4,"total":6,"open":1,"new":1,"resolved":4,"overridden":0,"by_severity":{"high":{"open":1,"resolved":2,"new":0,"overridden":0},"medium":{"open":0,"resolved":2,"new":1,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}}
+  ]
+}

--- a/openspec/changes/add-readme-command/review-ledger-plan.json.bak
+++ b/openspec/changes/add-readme-command/review-ledger-plan.json.bak
@@ -1,0 +1,19 @@
+{
+  "feature_id": "add-readme-command",
+  "phase": "plan",
+  "current_round": 3,
+  "status": "has_open_high",
+  "max_finding_id": 5,
+  "findings": [
+    {"id":"R1-F01","severity":"high","category":"consistency","file":"plan.md","title":"既存 README の原文保持要件が未設計","status":"resolved","relation":"new","supersedes":null,"notes":"","origin_round":1,"latest_round":2},
+    {"id":"R1-F02","severity":"medium","category":"completeness","file":"plan.md","title":"セクション生成に必要なエビデンス収集が不足している","status":"resolved","relation":"new","supersedes":null,"notes":"","origin_round":1,"latest_round":3},
+    {"id":"R1-F03","severity":"medium","category":"risk","file":"plan.md","title":"承認前 diff の確認方法が要件を満たしていない","status":"resolved","relation":"new","supersedes":null,"notes":"","origin_round":1,"latest_round":2},
+    {"id":"R2-F01","severity":"high","category":"risk","file":"plan.md","title":"生成可能セクション配下の手書きサブセクションが失われる設計","status":"resolved","relation":"new","supersedes":null,"notes":"","origin_round":2,"latest_round":3},
+    {"id":"R3-F01","severity":"high","category":"risk","file":"plan.md","title":"改善対象セクション直下の手書き本文が依然として上書きされうる","status":"new","relation":"new","supersedes":null,"notes":"","origin_round":3,"latest_round":3}
+  ],
+  "round_summaries": [
+    {"round":1,"total":3,"open":0,"new":3,"resolved":0,"overridden":0,"by_severity":{"high":{"open":0,"resolved":0,"new":1,"overridden":0},"medium":{"open":0,"resolved":0,"new":2,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":2,"total":4,"open":1,"new":1,"resolved":2,"overridden":0,"by_severity":{"high":{"open":0,"resolved":1,"new":1,"overridden":0},"medium":{"open":1,"resolved":1,"new":0,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":3,"total":5,"open":0,"new":1,"resolved":4,"overridden":0,"by_severity":{"high":{"open":0,"resolved":2,"new":1,"overridden":0},"medium":{"open":0,"resolved":2,"new":0,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}}
+  ]
+}

--- a/openspec/changes/add-readme-command/review-ledger-spec.json
+++ b/openspec/changes/add-readme-command/review-ledger-spec.json
@@ -1,0 +1,140 @@
+{
+  "feature_id": "add-readme-command",
+  "phase": "spec",
+  "current_round": 3,
+  "status": "in_progress",
+  "max_finding_id": 6,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Grounding rules for generated README content",
+      "detail": "The spec requires badges plus sections such as Install, Usage, Config, and Architecture, but the collected inputs will often be insufficient to derive those sections accurately for every project.",
+      "suggested_resolution": "Define a strict source-of-truth rule.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 3
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Required OpenSpec integration is not specified",
+      "detail": "The issue explicitly asks to leverage an existing OpenSpec project-analysis command if one exists.",
+      "suggested_resolution": "Specify the integration contract with OpenSpec.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "contradiction",
+      "file": "proposal.md",
+      "title": "CI badge rules conflict and do not cover non-GitHub CI",
+      "detail": "The badge rules say only static shields.io badge URLs may be used, but then require a GitHub Actions workflow status badge.",
+      "suggested_resolution": "Choose one contract for badge types.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "R2-F02",
+      "severity": "medium",
+      "category": "missing_criteria",
+      "file": "proposal.md",
+      "title": "Features section lacks section-level evidence and fallback rules",
+      "detail": "The evidence table does not define when Features may be emitted.",
+      "suggested_resolution": "Add a Features row to the evidence table.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "R3-F01",
+      "severity": "medium",
+      "category": "missing_criteria",
+      "file": "proposal.md",
+      "title": "Install and usage sections can still require guessed commands",
+      "detail": "The section table treats package manifests, scripts, or bin entries as sufficient evidence for Installation and Usage, but those sources often do not identify the correct package manager, install command, or executable invocation. As written, implementers will either guess commands (violating the grounding policy) or invent their own omission heuristics.",
+      "suggested_resolution": "Define the exact evidence that permits emitting concrete install/usage commands, such as lockfiles or explicit packageManager/bin metadata, and require omission or a placeholder when that evidence is missing.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 3,
+      "latest_round": 3
+    },
+    {
+      "id": "R3-F02",
+      "severity": "medium",
+      "category": "edge_case",
+      "file": "proposal.md",
+      "title": "GitHub Actions badge rule can generate broken or arbitrary badges",
+      "detail": "The spec says to use the first workflow file and then build a badge URL with {workflow}.yml. That breaks for repositories using .yaml workflow files and is ambiguous when multiple workflows exist, because 'first' is not defined and may select a deploy-only or non-primary workflow.",
+      "suggested_resolution": "Require using the actual discovered workflow filename including its real extension, and define a deterministic selection rule for multiple workflows or an omission rule when a primary workflow cannot be identified.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 3,
+      "latest_round": 3
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 0,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 4,
+      "open": 1,
+      "new": 2,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 1, "resolved": 0, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 1, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 3,
+      "total": 6,
+      "open": 0,
+      "new": 2,
+      "resolved": 4,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 1, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 3, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-readme-command/review-ledger-spec.json.bak
+++ b/openspec/changes/add-readme-command/review-ledger-spec.json.bak
@@ -1,0 +1,97 @@
+{
+  "feature_id": "add-readme-command",
+  "phase": "spec",
+  "current_round": 2,
+  "status": "has_open_high",
+  "max_finding_id": 4,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Grounding rules for generated README content",
+      "detail": "The spec requires badges plus sections such as Install, Usage, Config, and Architecture, but the collected inputs will often be insufficient to derive those sections accurately for every project. It does not state whether Claude must limit itself to information explicitly present in project files, existing README content, and OpenSpec metadata, or whether it may infer missing details. This matters because otherwise the command can generate incorrect commands, configuration, or broken badges, and there is no acceptance criterion to tell whether the output is correct.",
+      "suggested_resolution": "Define a strict source-of-truth rule: sections and badges may only be generated when supported by collected evidence; otherwise they must be omitted or preserved from the existing README. Call out how to handle missing usage examples, missing install steps, and badges that require repo/CI metadata not available from analysis.",
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "ambiguity",
+      "file": "proposal.md",
+      "title": "Required OpenSpec integration is not specified",
+      "detail": "The issue explicitly asks to leverage an existing OpenSpec project-analysis command if one exists, but the spec introduces a new specflow-analyze script without defining whether it must call a specific OpenSpec command, read openspec/ files directly, or perform an independent scan. That hidden assumption materially affects implementation approach, dependency behavior, and whether the delivered feature is faithful to the original request.",
+      "suggested_resolution": "Specify the integration contract with OpenSpec: which existing command or data source should be reused, what information must come from it, and what fallback behavior is allowed when that command or data is unavailable.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "contradiction",
+      "file": "proposal.md",
+      "title": "CI badge rules conflict and do not cover non-GitHub CI",
+      "detail": "The badge rules say only static shields.io badge URLs may be used, but then require a GitHub Actions workflow status badge, which is dynamic and also needs a specific workflow identifier. The evidence table also treats any CI config as sufficient for a CI badge, while the generation rule only defines behavior for GitHub Actions, leaving GitLab and other CI providers undefined.",
+      "suggested_resolution": "Choose one contract: either allow dynamic status badges and define how to select workflow/provider-specific badges, or restrict CI badges to static provider badges and update the evidence and generation rules to match.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 2
+    },
+    {
+      "id": "R2-F02",
+      "severity": "medium",
+      "category": "missing_criteria",
+      "file": "proposal.md",
+      "title": "Features section lacks section-level evidence and fallback rules",
+      "detail": "The default README structure includes a Features section, and OpenSpec specs/ are described as an input for generating it, but the section-by-section evidence table does not define when Features may be emitted or what happens when openspec/ is absent. Implementers cannot tell whether non-OpenSpec projects should omit Features or derive it from other evidence.",
+      "suggested_resolution": "Add a Features row to the evidence table that defines allowed evidence sources and the fallback behavior when no qualifying evidence is present.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 2
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 0,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 4,
+      "open": 1,
+      "new": 2,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 1, "resolved": 0, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 1, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-readme-command/review-ledger.json
+++ b/openspec/changes/add-readme-command/review-ledger.json
@@ -1,0 +1,17 @@
+{
+  "feature_id": "add-readme-command",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "in_progress",
+  "max_finding_id": 5,
+  "findings": [
+    {"id":"R1-F01","severity":"high","category":"correctness","file":"bin/specflow-analyze","title":"jq fallback drops required analyzer data","status":"resolved","relation":"new","supersedes":null,"notes":"Fixed: OpenSpec arrays now use bash fallback, scripts passed to fallback output","origin_round":1,"latest_round":1},
+    {"id":"R1-F02","severity":"medium","category":"completeness","file":"bin/specflow-analyze","title":"OpenSpec context lost without yq","status":"resolved","relation":"new","supersedes":null,"notes":"Fixed: Added sed-based YAML parsing fallback for context field","origin_round":1,"latest_round":1},
+    {"id":"R1-F03","severity":"medium","category":"correctness","file":"bin/specflow-analyze","title":"Cargo description skipped when jq present","status":"resolved","relation":"new","supersedes":null,"notes":"Fixed: Parse Cargo.toml description regardless of jq flag","origin_round":1,"latest_round":1},
+    {"id":"R1-F04","severity":"medium","category":"completeness","file":"global/commands/specflow.readme.md","title":"Merge rules dont cover preamble","status":"resolved","relation":"new","supersedes":null,"notes":"Fixed: Added step 0 preamble handling in merge strategy","origin_round":1,"latest_round":1},
+    {"id":"R1-F05","severity":"medium","category":"testing","file":"bin/specflow-analyze","title":"No test coverage","status":"open","relation":"new","supersedes":null,"notes":"Deferred to Task 3.1 manual verification","origin_round":1,"latest_round":1}
+  ],
+  "round_summaries": [
+    {"round":1,"total":5,"open":1,"new":0,"resolved":4,"overridden":0,"by_severity":{"high":{"open":0,"resolved":1,"new":0,"overridden":0},"medium":{"open":1,"resolved":3,"new":0,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}}
+  ]
+}

--- a/openspec/changes/add-readme-command/tasks.md
+++ b/openspec/changes/add-readme-command/tasks.md
@@ -1,0 +1,134 @@
+# Tasks: add-readme-command
+
+**Change ID**: add-readme-command
+**Created**: 2026-04-07
+
+## Phase 1: specflow-analyze スクリプト
+
+### Task 1.1: スクリプト骨格と git remote 解析 ✅
+**Priority**: P0 (blocker)
+**Depends on**: none
+**Parallel**: no
+
+- `bin/specflow-analyze` を作成（`#!/usr/bin/env bash`, `set -euo pipefail`）
+- jq 存在チェック（なければ警告を stderr に出力し簡易 JSON モードで動作）
+- git remote URL から owner/repo を抽出
+- 空の JSON オブジェクトを構築開始
+
+**Acceptance**: `specflow-analyze` 実行で `{"project_name": "...", "git_remote": {...}}` が stdout に出力される
+
+### Task 1.2: パッケージマニフェスト・lockfile 検出 ✅
+**Priority**: P0
+**Depends on**: 1.1
+**Parallel**: no
+
+- package.json, Cargo.toml, go.mod, pyproject.toml, Gemfile, build.gradle, pom.xml, composer.json の存在チェック
+- 検出したマニフェストから description, scripts, bin, dependencies, keywords/features を抽出
+- lockfile (package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb, bun.lock 等) からパッケージマネージャを推定
+- `languages`, `frameworks`, `package_manager`, `scripts`, `bin_entries`, `keywords` フィールドを JSON に追加
+
+**Acceptance**: Node.js プロジェクトで `languages: ["JavaScript"]`, `package_manager: "npm"` 等が出力される
+
+### Task 1.3: CI 設定・LICENSE・設定ファイル検出 ✅
+**Priority**: P0
+**Depends on**: 1.1
+**Parallel**: Task 1.2 と並行可能
+
+- `.github/workflows/`, `.gitlab-ci.yml`, `.circleci/config.yml` 等をスキャン
+- workflow ファイルをアルファベット順でソートし、ファイル名と拡張子を記録
+- LICENSE ファイルを読み取り、ライセンスタイプを判定 (MIT, Apache-2.0, etc.)
+- 設定ファイル一覧 (.env.example, *.config.*, etc.) を収集
+- CONTRIBUTING.md の有無チェック（存在すれば全文読み取り）
+- `ci`, `license`, `config_files`, `contributing` フィールドを JSON に追加
+
+**Acceptance**: GitHub Actions プロジェクトで `ci.provider: "github-actions"`, `ci.workflows: [{"name": "ci", "extension": ".yml"}]` が出力される
+
+### Task 1.4: OpenSpec 情報・既存 README・ファイル構造 ✅
+**Priority**: P0
+**Depends on**: 1.1
+**Parallel**: Task 1.2, 1.3 と並行可能
+
+- `openspec/config.yaml` が存在すれば読み取り（project_name, context）
+- `openspec/specs/` の capability spec 一覧
+- `openspec/changes/` の active change 一覧
+- 既存 `README.md` を読み取り（存在しなければ null）
+- `tree -L 2 --gitignore -I .git` でファイル構造取得（tree なければ `find . -maxdepth 2` フォールバック）
+- `openspec`, `existing_readme`, `file_structure` フィールドを JSON に追加
+
+**Acceptance**: OpenSpec ありプロジェクトで `openspec.has_config: true`, `openspec.specs: [...]` が出力される。OpenSpec なしプロジェクトで `openspec.has_config: false`
+
+### Task 1.5: JSON 出力の統合とバリデーション ✅
+**Priority**: P0
+**Depends on**: 1.2, 1.3, 1.4
+**Parallel**: no
+
+- 各検出結果を統合した完全な JSON オブジェクトを stdout に出力
+- jq ありの場合: jq で JSON 構築
+- jq なしの場合: printf による簡易 JSON 生成
+- エラー時は stderr にメッセージを出力し exit 1
+- `chmod +x bin/specflow-analyze`
+
+**Acceptance**: `specflow-analyze | jq .` がバリデーション OK。全フィールドが存在する
+
+## Phase 2: slash コマンド
+
+### Task 2.1: specflow.readme.md 骨格 ✅
+**Priority**: P0
+**Depends on**: Phase 1 完了
+**Parallel**: no
+
+- `global/commands/specflow.readme.md` を作成
+- frontmatter: `description: プロジェクト解析に基づいて OSS 風 README を生成・更新`
+- Prerequisites: `specflow-analyze` の存在チェック
+- Step 1: `specflow-analyze` を Bash ツールで実行し JSON を取得
+
+**Acceptance**: `/specflow.readme` 実行で `specflow-analyze` が呼ばれ JSON が取得できる
+
+### Task 2.2: README 生成プロンプト構築 ✅
+**Priority**: P0
+**Depends on**: 2.1
+**Parallel**: no
+
+- JSON 解析結果からプロンプトを構築
+- Grounding Policy（エビデンステーブル）をプロンプトに埋め込み
+- バッジ生成ルール（Static/Dynamic 分類）をプロンプトに含める
+- 絵文字付きセクション見出しの指示
+- 既存 README がある場合:
+  - `##` 見出しでセクション分割
+  - セクション-エビデンス対応テーブルで各セクションを「改善」/「保持」に分類
+  - 改善セクション内のコンテンツを「生成対象ブロック」/「保護対象ブロック」に分類（サブセクションだけでなく自由記述テキストも対象）
+  - 分類結果（改善/保持/保護対象ブロック）と既存全文をプロンプトに含める
+  - エビデンス対応テーブルをプロンプトに埋め込み
+  - 「保持セクション・保護対象ブロック（自由記述テキスト・サブセクション）は原文を一字一句変更するな」と明示指示
+  - 「判定が曖昧な場合は保護対象とせよ」と保守的アプローチを指示
+
+**Acceptance**: プロンプトに JSON 解析結果、Grounding Policy、バッジルール、セクション-エビデンス対応テーブル、混在コンテンツ保護ルールが含まれる。既存 README がある場合は3段階分類（改善/保持/保護）が含まれる
+
+### Task 2.3: 承認フローと書き込み ✅
+**Priority**: P0
+**Depends on**: 2.2
+**Parallel**: no
+
+- 生成された README を表示
+- 既存 README がある場合: 全文 diff を表示（行数制限なし）
+- AskUserQuestion で承認（「適用」/「再生成」/「キャンセル」）
+- 承認後に Write ツールで README.md に書き込み
+- 「再生成」選択時: フィードバックをプロンプトに追加して再生成
+
+**Acceptance**: 承認フローが動作し、README.md が書き込まれる
+
+## Phase 3: 検証
+
+### Task 3.1: 自プロジェクトでの動作確認
+**Priority**: P1
+**Depends on**: Phase 2 完了
+**Parallel**: no
+
+- spec-scripts リポジトリ自体で `/specflow.readme` を実行
+- 生成された README の品質確認:
+  - バッジが tech stack に基づいている
+  - エビデンスなしセクションが省略されている
+  - 絵文字付きセクション見出し
+  - shields.io バッジ URL が有効
+
+**Acceptance**: spec-scripts プロジェクトで適切な README が生成される


### PR DESCRIPTION
## Summary
- `bin/specflow-analyze` を追加: プロジェクトの tech stack、CI 設定、LICENSE、OpenSpec 情報などを JSON で収集する bash スクリプト
- `/specflow.readme` slash コマンドを追加: `specflow-analyze` の結果をもとに Claude が OSS 風 README を生成。エビデンスベースの Grounding Policy と既存 README のマージ戦略を実装
- jq なし環境でのフォールバック対応、OpenSpec は optional dependency として動作

## Issue
Closes https://github.com/skr19930617/specflow/issues/56

## Test plan
- [ ] `specflow-analyze .` を複数プロジェクトタイプ（Node.js, Rust, Go, bash-only）で実行し JSON 出力を確認
- [ ] `/specflow.readme` で既存 README のあるプロジェクトで実行し、保持セクションが原文保持されるか確認
- [ ] jq 未インストール環境でのフォールバック JSON 出力を検証
- [ ] `specflow-install` 後に `specflow-analyze` が PATH で利用可能か確認