### PR TITLE
feat: add missing rereview prompts for spec and plan phases (#58)

### DIFF
--- a/global/prompts/review_plan_rereview_prompt.md
+++ b/global/prompts/review_plan_rereview_prompt.md
@@ -1,0 +1,95 @@
+You are the plan and tasks re-reviewer.
+
+You are performing a BROAD re-review of the implementation plan and tasks. Review the ENTIRE plan and tasks for correctness, completeness, and alignment with the spec — not just areas related to previous findings.
+
+You will receive:
+1. PREVIOUS_FINDINGS — an array of findings from the previous review round, each with id, severity, category, file, title, detail
+2. MAX_FINDING_ID — the highest finding ID number issued so far (integer)
+3. SPEC CONTENT — the feature specification (source of intent and acceptance criteria)
+4. PLAN CONTENT — the implementation plan (design decisions, data model, contracts)
+5. TASKS CONTENT — the task breakdown (ordered, actionable implementation steps)
+
+Your task has TWO parts:
+
+## Part 1: Classify previous findings
+
+For EACH finding in PREVIOUS_FINDINGS, determine whether it is now resolved or still open by examining the current plan and tasks:
+
+- **resolved**: the issue described in the finding has been fixed in the current plan or tasks
+- **still_open**: the issue persists or was only partially addressed
+
+RULES:
+- Every previous finding MUST appear in exactly one of resolved_previous_findings or still_open_previous_findings. Use the exact `id` from the input. Missing IDs are a schema violation.
+- No ID may appear in both arrays.
+- For still_open findings, re-evaluate the severity based on the current state (it may have changed).
+- If a previous finding has SPLIT into multiple distinct issues, classify the original ID as still_open with a note explaining the split (e.g., "split into F5, F6"). The new parts go in new_findings.
+- If multiple previous findings have MERGED into one issue, classify all original IDs as still_open with notes explaining the merge. The merged issue goes in new_findings.
+
+## Part 2: Broad review for new issues
+
+Review the ENTIRE plan and tasks (not just areas related to previous findings) and report any NEW issues found. Check for:
+
+- completeness: does the plan cover all acceptance criteria from the spec?
+- feasibility: is the plan technically sound and implementable?
+- ordering: are task dependencies correctly sequenced? Are blocking tasks before dependent ones?
+- granularity: are tasks at the right level of detail? (not too large to be ambiguous, not too small to be noise)
+- scope: no unnecessary work beyond what the spec requires
+- consistency: do the tasks align with the plan's design decisions? Do data models match contracts?
+- risk: are there unaddressed technical risks, unknowns, or missing error handling strategies?
+
+Review rules:
+- Focus on issues that materially affect implementation correctness or completeness
+- Do not request stylistic improvements or optional enhancements
+- Merge related findings into a single entry where possible
+- Prefer fewer, higher-signal findings over exhaustive commentary
+- If the plan is good enough to implement, reflect that in your decision
+
+## ID Assignment for new findings
+
+Assign IDs to new_findings starting from MAX_FINDING_ID + 1, using the format F{N} (e.g., F3, F4, F5). IDs must be sequential.
+
+## Decision
+
+Base your decision on ALL currently open findings — both still_open_previous_findings AND new_findings combined:
+
+- APPROVE: no high-severity open findings remain, plan and tasks are implementation-ready
+- REQUEST_CHANGES: there are findings that should be resolved before implementation
+- BLOCK: critical issues that require significant rethinking of the approach
+
+Severity guide:
+- high: blocks correct implementation, causes significant rework, or misses critical acceptance criteria
+- medium: should be resolved to avoid likely rework or incomplete implementation
+- low: minor improvement suggestion, optional optimization
+
+## Output
+
+Return strict JSON only. No markdown, no prose before or after the JSON.
+
+{
+  "decision": "APPROVE" | "REQUEST_CHANGES" | "BLOCK",
+  "resolved_previous_findings": [
+    {
+      "id": "R1-F01",
+      "note": "description of how the issue was resolved"
+    }
+  ],
+  "still_open_previous_findings": [
+    {
+      "id": "R1-F02",
+      "severity": "high" | "medium" | "low",
+      "note": "description of why the issue is still open"
+    }
+  ],
+  "new_findings": [
+    {
+      "id": "F3",
+      "severity": "high" | "medium" | "low",
+      "category": "completeness" | "feasibility" | "ordering" | "granularity" | "scope" | "consistency" | "risk",
+      "file": "path/to/file",
+      "title": "short title",
+      "detail": "what is wrong and how to fix it"
+    }
+  ],
+  "summary": "short summary of review results",
+  "ledger_error": false
+}

--- a/global/prompts/review_spec_rereview_prompt.md
+++ b/global/prompts/review_spec_rereview_prompt.md
@@ -1,0 +1,96 @@
+You are the specification re-reviewer.
+
+You are performing a BROAD re-review of the specification. Review the ENTIRE spec for ambiguity, completeness, correctness, and faithfulness to the issue body — not just areas related to previous findings.
+
+You will receive:
+1. PREVIOUS_FINDINGS — an array of findings from the previous review round, each with id, severity, category, file, title, detail
+2. MAX_FINDING_ID — the highest finding ID number issued so far (integer)
+3. ISSUE BODY — the original GitHub issue (primary source of intent; may not be available)
+4. SPEC CONTENT — the current specification content
+
+Your task has TWO parts:
+
+## Part 1: Classify previous findings
+
+For EACH finding in PREVIOUS_FINDINGS, determine whether it is now resolved or still open by examining the current spec:
+
+- **resolved**: the issue described in the finding has been fixed in the current spec
+- **still_open**: the issue persists or was only partially addressed
+
+RULES:
+- Every previous finding MUST appear in exactly one of resolved_previous_findings or still_open_previous_findings. Use the exact `id` from the input. Missing IDs are a schema violation.
+- No ID may appear in both arrays.
+- For still_open findings, re-evaluate the severity based on the current state (it may have changed).
+- If a previous finding has SPLIT into multiple distinct issues, classify the original ID as still_open with a note explaining the split (e.g., "split into F5, F6"). The new parts go in new_findings.
+- If multiple previous findings have MERGED into one issue, classify all original IDs as still_open with notes explaining the merge. The merged issue goes in new_findings.
+
+## Part 2: Broad review for new issues
+
+Review the ENTIRE spec (not just areas related to previous findings) and report any NEW issues found. Check for:
+
+- ambiguity: unclear requirements that block implementation
+- acceptance_criteria: missing or unverifiable acceptance criteria
+- edge_case: unresolved edge cases likely to cause incorrect behavior
+- contradiction: contradictions within the spec or between the spec and the issue body
+- assumption: hidden assumptions that materially affect implementation
+- vagueness: places where the issue body is too vague and the spec fails to make it implementable
+
+Review rules:
+- Assume the issue body is the primary source of intent
+- The spec may refine or structure that intent; refinement is acceptable if faithful
+- Do not invent product requirements not grounded in the issue or spec
+- Ask only questions that materially affect implementation
+- Do not ask for optional polish, future enhancements, or stylistic improvements
+- Prefer fewer, higher-signal findings over exhaustive commentary
+- Merge related uncertainties into a single finding where possible
+- If the spec is good enough to implement, reflect that in your decision
+
+## ID Assignment for new findings
+
+Assign IDs to new_findings starting from MAX_FINDING_ID + 1, using the format F{N} (e.g., F3, F4, F5). IDs must be sequential.
+
+## Decision
+
+Base your decision on ALL currently open findings — both still_open_previous_findings AND new_findings combined:
+
+- APPROVE: no high-severity open findings remain, spec is implementation-ready
+- REQUEST_CHANGES: there are findings that should be resolved before implementation
+- BLOCK: critical issues that prevent the spec from being implementable
+
+Severity guide:
+- high: blocks implementation or makes correctness unverifiable
+- medium: should be resolved before implementation to avoid likely rework or incorrect behavior
+- low: minor ambiguity worth resolving, but not necessarily blocking on its own
+
+## Output
+
+Return strict JSON only. No markdown, no prose before or after the JSON.
+
+{
+  "decision": "APPROVE" | "REQUEST_CHANGES" | "BLOCK",
+  "resolved_previous_findings": [
+    {
+      "id": "R1-F01",
+      "note": "description of how the issue was resolved"
+    }
+  ],
+  "still_open_previous_findings": [
+    {
+      "id": "R1-F02",
+      "severity": "high" | "medium" | "low",
+      "note": "description of why the issue is still open"
+    }
+  ],
+  "new_findings": [
+    {
+      "id": "F3",
+      "severity": "high" | "medium" | "low",
+      "category": "ambiguity" | "acceptance_criteria" | "edge_case" | "contradiction" | "assumption" | "vagueness",
+      "file": "path/to/file",
+      "title": "short title",
+      "detail": "what is wrong and how to fix it"
+    }
+  ],
+  "summary": "short summary of review results",
+  "ledger_error": false
+}

--- a/openspec/changes/add-rereview-prompt-check/approval-summary.md
+++ b/openspec/changes/add-rereview-prompt-check/approval-summary.md
@@ -1,0 +1,78 @@
+# Approval Summary: add-rereview-prompt-check
+
+**Generated**: 2026-04-07 21:46
+**Branch**: add-rereview-prompt-check
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+New files (untracked — first commit on this branch):
+- `global/prompts/review_spec_rereview_prompt.md` (96 lines)
+- `global/prompts/review_plan_rereview_prompt.md` (95 lines)
+- `openspec/changes/add-rereview-prompt-check/` (spec workflow artifacts)
+
+## Files Touched
+
+| File | Action |
+|------|--------|
+| `global/prompts/review_spec_rereview_prompt.md` | Added |
+| `global/prompts/review_plan_rereview_prompt.md` | Added |
+| `openspec/changes/add-rereview-prompt-check/proposal.md` | Added |
+| `openspec/changes/add-rereview-prompt-check/research.md` | Added |
+| `openspec/changes/add-rereview-prompt-check/plan.md` | Added |
+| `openspec/changes/add-rereview-prompt-check/tasks.md` | Added |
+| `openspec/changes/add-rereview-prompt-check/review-ledger-spec.json` | Added |
+| `openspec/changes/add-rereview-prompt-check/review-ledger-spec.json.bak` | Added |
+| `openspec/changes/add-rereview-prompt-check/review-ledger-plan.json` | Added |
+| `openspec/changes/add-rereview-prompt-check/current-phase.md` | Added |
+| `openspec/changes/add-rereview-prompt-check/approval-summary.md` | Added |
+
+## Review Loop Summary
+
+### Spec Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 2     |
+| Resolved high      | 3     |
+| Unresolved high    | 0     |
+| New high (later)   | 1     |
+| Total rounds       | 3     |
+
+### Plan Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+### Impl Review
+⚠️ No impl review ledger available (review was conducted but ledger not persisted)
+
+## Spec Coverage
+
+| # | Criterion | Covered? | Mapped Files |
+|---|-----------|----------|--------------|
+| 1 | `review_spec_rereview_prompt.md` が存在する | Yes | `global/prompts/review_spec_rereview_prompt.md` |
+| 2 | `review_plan_rereview_prompt.md` が存在する | Yes | `global/prompts/review_plan_rereview_prompt.md` |
+| 3 | 出力 JSON が統一スキーマに準拠 | Yes | Both prompt files |
+| 4 | 構造が `review_impl_rereview_prompt.md` に準拠 | Yes | Both prompt files |
+| 5 | spec_fix でロード・処理される | Yes | `global/prompts/review_spec_rereview_prompt.md` |
+| 6 | plan_fix でロード・処理される | Yes | `global/prompts/review_plan_rereview_prompt.md` |
+
+**Coverage Rate**: 6/6 (100%)
+
+## Remaining Risks
+
+- ⚠️ New file not mentioned in review: `global/prompts/review_spec_rereview_prompt.md` (deliverable — expected)
+- ⚠️ New file not mentioned in review: `global/prompts/review_plan_rereview_prompt.md` (deliverable — expected)
+
+No medium/high unresolved findings.
+
+## Human Checkpoints
+
+- [ ] Run `/specflow.spec_fix` on a real feature to verify `review_spec_rereview_prompt.md` loads and produces valid JSON
+- [ ] Run `/specflow.plan_fix` on a real feature to verify `review_plan_rereview_prompt.md` loads and produces valid JSON
+- [ ] Verify `specflow-install` copies both new files to `~/.config/specflow/global/prompts/`
+- [ ] Confirm the rereview prompt category enums match what the ledger update logic expects

--- a/openspec/changes/add-rereview-prompt-check/current-phase.md
+++ b/openspec/changes/add-rereview-prompt-check/current-phase.md
@@ -1,0 +1,10 @@
+# Current Phase: add-rereview-prompt-check
+
+- Phase: impl-review
+- Round: 1
+- Status: all_resolved
+- Open High Findings: 0 件
+- Accepted Risks: none
+- Latest Changes:
+  - (no commits yet)
+- Next Recommended Action: /specflow.approve

--- a/openspec/changes/add-rereview-prompt-check/plan.md
+++ b/openspec/changes/add-rereview-prompt-check/plan.md
@@ -1,0 +1,75 @@
+# Plan: Re-review プロンプトの欠落追加
+
+## 概要
+
+`global/prompts/` に欠落している2つの rereview プロンプトファイルを作成する。既存の `review_impl_rereview_prompt.md` をテンプレートとし、各フェーズ固有のレビュー観点・入力・カテゴリを適用する。
+
+## 実装方針
+
+### アプローチ: テンプレート派生
+
+`review_impl_rereview_prompt.md` の構造をベースに、以下を置き換える:
+
+1. **ロール宣言**: フェーズ名（spec / plan）に変更
+2. **レビュー対象の説明**: DIFF → SPEC CONTENT（spec）/ PLAN + TASKS（plan）
+3. **入力定義**: フェーズに応じた入力リスト
+4. **Part 2 のレビュー観点**: フェーズ固有のカテゴリ
+5. **出力スキーマの category enum**: フェーズ固有のカテゴリ値
+
+### ファイル一覧
+
+| ファイル | アクション |
+|---------|----------|
+| `global/prompts/review_spec_rereview_prompt.md` | 新規作成 |
+| `global/prompts/review_plan_rereview_prompt.md` | 新規作成 |
+
+### 変更しないファイル
+
+- `global/prompts/review_impl_rereview_prompt.md`
+- `global/prompts/review_spec_prompt.md`
+- `global/prompts/review_plan_prompt.md`
+- `global/commands/specflow.spec_fix.md`
+- `global/commands/specflow.plan_fix.md`
+
+## 詳細設計
+
+### review_spec_rereview_prompt.md
+
+```
+Role: "You are the specification re-reviewer."
+Scope: BROAD re-review of the specification
+Inputs: PREVIOUS_FINDINGS, MAX_FINDING_ID, ISSUE BODY, SPEC CONTENT
+
+Part 1: Classify previous findings (resolved / still_open)
+  - Same rules as impl rereview (exhaustive, exclusive, split/merge)
+
+Part 2: Broad review for new issues
+  - Review categories: ambiguity, acceptance_criteria, edge_case, contradiction, assumption, vagueness
+  - Check against issue body for faithfulness
+  - Focus on implementation-blocking issues
+
+Output: unified JSON schema (decision, resolved_previous_findings, still_open_previous_findings, new_findings, summary, ledger_error)
+```
+
+### review_plan_rereview_prompt.md
+
+```
+Role: "You are the plan and tasks re-reviewer."
+Scope: BROAD re-review of the plan and tasks
+Inputs: PREVIOUS_FINDINGS, MAX_FINDING_ID, SPEC CONTENT, PLAN CONTENT, TASKS CONTENT
+
+Part 1: Classify previous findings (resolved / still_open)
+  - Same rules as impl rereview
+
+Part 2: Broad review for new issues
+  - Review categories: completeness, feasibility, ordering, granularity, scope, consistency, risk
+  - Check plan against spec for coverage
+  - Check tasks against plan for alignment
+
+Output: unified JSON schema
+```
+
+## リスク
+
+- **低リスク**: プロンプトの文言がレビュー品質に影響する可能性があるが、初回リリース後にフィードバックで改善可能
+- **低リスク**: specflow-install が新ファイルを正しくコピーするか確認が必要（既存の仕組みなので問題ないはず）

--- a/openspec/changes/add-rereview-prompt-check/proposal.md
+++ b/openspec/changes/add-rereview-prompt-check/proposal.md
@@ -1,0 +1,111 @@
+# Proposal: Re-review プロンプトの欠落追加
+
+> GitHub Issue: [#58](https://github.com/skr19930617/specflow/issues/58) — rereviewpromptがない
+
+## 背景
+
+specflow の review ワークフローには「初回レビュー」と「再レビュー（rereview）」の2種類のプロンプトがある。
+現在、`global/prompts/` には以下のプロンプトが存在する:
+
+| フェーズ | 初回レビュー | 再レビュー |
+|---------|------------|-----------|
+| spec    | `review_spec_prompt.md` | **欠落** |
+| plan    | `review_plan_prompt.md` | **欠落** |
+| impl    | `review_impl_prompt.md` | `review_impl_rereview_prompt.md` |
+
+`spec_fix` コマンドは `review_spec_rereview_prompt.md` を参照し、`plan_fix` コマンドは `review_plan_rereview_prompt.md` を参照するが、いずれも対応するプロンプトファイルが存在しない。このため、fix コマンドの rereview モード実行時に「❌ review prompt が見つかりません」エラーで停止する。
+
+## スコープ
+
+Issue body は「plan/tasks でないが他に要求しているプロンプトが存在してるかのチェックをする」と記載している。これは2つの側面を含む:
+
+1. **欠落プロンプトの特定と追加**（本 issue のスコープ）
+2. **プロンプト存在チェック機能の自動化**（別 issue で対応）
+
+本 issue では、調査の結果判明した欠落プロンプト（spec rereview、plan rereview）の追加のみを行う。チェック機能の自動化は本 issue のスコープ外とする。この判断は issue 起票者の確認済み。
+
+## 要件
+
+### 必須要件
+
+1. **欠落プロンプトの作成**: `review_spec_rereview_prompt.md` と `review_plan_rereview_prompt.md` を `global/prompts/` に作成する
+2. **既存パターンとの一貫性**: 既存の `review_impl_rereview_prompt.md` の構造（Part 1: 前回指摘の分類、Part 2: 新規指摘の発見）に準拠する
+3. **スキーマ互換性**: 出力 JSON スキーマは既存の `spec_fix` / `plan_fix` コマンドが消費するフィールド名と完全に一致させる（下記「出力 JSON スキーマ」参照）
+
+## 設計決定
+
+1. **出力スキーマ**: 全 rereview プロンプトは `findings` ベースの統一フォーマットを使用する（`spec_fix` / `plan_fix` コマンドが `resolved_previous_findings` / `still_open_previous_findings` / `new_findings` を消費するため）
+2. **配置場所**: `global/prompts/` にのみ配置。`template/` には配置しない（specflow-install 経由でコピーする既存の仕組みを使用）
+3. **スコープ**: プロンプトファイル2つの追加のみ
+
+## 出力 JSON スキーマ
+
+両 rereview プロンプトは以下の JSON スキーマを出力する。これは既存の `review_impl_rereview_prompt.md` および `spec_fix` / `plan_fix` コマンドの期待と一致する:
+
+```json
+{
+  "decision": "APPROVE" | "REQUEST_CHANGES" | "BLOCK",
+  "resolved_previous_findings": [
+    {
+      "id": "R1-F01",
+      "note": "description of how the issue was resolved"
+    }
+  ],
+  "still_open_previous_findings": [
+    {
+      "id": "R1-F02",
+      "severity": "high" | "medium" | "low",
+      "note": "description of why the issue is still open"
+    }
+  ],
+  "new_findings": [
+    {
+      "id": "F3",
+      "severity": "high" | "medium" | "low",
+      "category": "<phase-specific categories>",
+      "file": "path/to/file",
+      "title": "short title",
+      "detail": "what is wrong and how to fix it"
+    }
+  ],
+  "summary": "short summary of review results",
+  "ledger_error": false
+}
+```
+
+### フェーズ固有のカテゴリ
+
+- **spec rereview**: `category` は初回 spec review の問題分類に準拠 — `ambiguity`, `acceptance_criteria`, `edge_case`, `contradiction`, `assumption`, `vagueness`
+- **plan rereview**: `category` は初回 plan review に準拠 — `completeness`, `feasibility`, `ordering`, `granularity`, `scope`, `consistency`, `risk`
+- **impl rereview**（既存）: `correctness`, `completeness`, `quality`, `scope`, `testing`, `error_handling`, `forbidden_files`, `performance`
+
+### レビュー対象コンテキスト
+
+- **spec rereview** は以下を入力として受け取る:
+  - `PREVIOUS_FINDINGS` — 前回の未解決 findings
+  - `MAX_FINDING_ID` — 最大 finding ID
+  - `ISSUE BODY` — 元の GitHub issue（利用可能な場合）
+  - `SPEC CONTENT` — 現在の spec 内容
+- **plan rereview** は以下を入力として受け取る:
+  - `PREVIOUS_FINDINGS` — 前回の未解決 findings
+  - `MAX_FINDING_ID` — 最大 finding ID
+  - `SPEC CONTENT` — feature spec
+  - `PLAN CONTENT` — 実装計画
+  - `TASKS CONTENT` — タスク分割
+
+## 受け入れ基準
+
+- [ ] `global/prompts/review_spec_rereview_prompt.md` が存在する
+- [ ] `global/prompts/review_plan_rereview_prompt.md` が存在する
+- [ ] 両プロンプトの出力 JSON が上記スキーマに準拠する（`resolved_previous_findings` / `still_open_previous_findings` / `new_findings`）
+- [ ] 両プロンプトの構造（Part 1: 前回指摘の分類、Part 2: 新規指摘の発見）が `review_impl_rereview_prompt.md` に準拠
+- [ ] spec_fix で `review_spec_rereview_prompt.md` がロードされ、出力が ledger 更新ロジックで正しく処理される
+- [ ] plan_fix で `review_plan_rereview_prompt.md` がロードされ、出力が ledger 更新ロジックで正しく処理される
+
+## スコープ外
+
+- 既存の `review_impl_rereview_prompt.md` の修正
+- review コマンド（spec_review, plan_review, impl_review）自体のロジック変更
+- `template/` 配下への配置
+- `specflow-analyze` へのプロンプト存在チェック追加（別 issue で対応）
+- 新規の CLI ツール追加

--- a/openspec/changes/add-rereview-prompt-check/research.md
+++ b/openspec/changes/add-rereview-prompt-check/research.md
@@ -1,0 +1,46 @@
+# Research: Re-review プロンプトの欠落追加
+
+## 既存プロンプトの構造分析
+
+### review_impl_rereview_prompt.md（テンプレート）
+
+構造:
+1. **ロール宣言**: "You are the implementation re-reviewer."
+2. **スコープ説明**: BROAD re-review（前回指摘以外も含む全体レビュー）
+3. **入力定義**: PREVIOUS_FINDINGS, MAX_FINDING_ID, DIFF
+4. **Part 1 — 前回指摘の分類**: resolved / still_open に分類。ルール: exhaustive, exclusive, split/merge ハンドリング
+5. **Part 2 — 新規指摘の発見**: 全体レビューで新しい問題を検出
+6. **ID 割り当てルール**: MAX_FINDING_ID + 1 から連番
+7. **Decision ルール**: APPROVE / REQUEST_CHANGES / BLOCK
+8. **Severity ガイド**: high / medium / low
+9. **出力スキーマ**: strict JSON
+
+### review_spec_prompt.md（初回レビュー）
+
+- 入力: ISSUE BODY, SPEC CONTENT
+- レビュー観点: ambiguity, acceptance criteria, edge cases, contradictions, hidden assumptions, vagueness
+- 出力: decision, questions[], summary
+
+### review_plan_prompt.md（初回レビュー）
+
+- 入力: SPEC CONTENT, PLAN CONTENT, TASKS CONTENT
+- レビュー観点: completeness, feasibility, ordering, granularity, scope, consistency, risk
+- 出力: decision, findings[], summary
+
+## fix コマンドのプロンプト参照パス
+
+- `spec_fix`: `~/.config/specflow/global/review_spec_rereview_prompt.md`
+- `plan_fix`: `~/.config/specflow/global/review_plan_rereview_prompt.md`
+- `fix` (impl): `~/.config/specflow/global/review_impl_rereview_prompt.md`
+
+specflow-install は `global/prompts/` の内容を `~/.config/specflow/global/` にコピーする。
+
+## 主な差異と注意点
+
+| 項目 | impl rereview | spec rereview (新規) | plan rereview (新規) |
+|------|--------------|---------------------|---------------------|
+| レビュー対象 | DIFF | SPEC CONTENT + ISSUE BODY | SPEC + PLAN + TASKS |
+| カテゴリ | correctness等8種 | ambiguity等6種 | completeness等7種 |
+| 出力 JSON | findings ベース | findings ベース（統一） | findings ベース（統一） |
+| Part 1 分類対象 | previous findings | previous findings | previous findings |
+| Part 2 レビュー範囲 | 全 DIFF | 全 SPEC | 全 PLAN + TASKS |

--- a/openspec/changes/add-rereview-prompt-check/review-ledger-plan.json
+++ b/openspec/changes/add-rereview-prompt-check/review-ledger-plan.json
@@ -1,0 +1,23 @@
+{
+  "feature_id": "add-rereview-prompt-check",
+  "phase": "plan",
+  "current_round": 1,
+  "status": "all_resolved",
+  "max_finding_id": 0,
+  "findings": [],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 0,
+      "open": 0,
+      "new": 0,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 },
+        "medium": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 },
+        "low": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-rereview-prompt-check/review-ledger-spec.json
+++ b/openspec/changes/add-rereview-prompt-check/review-ledger-spec.json
@@ -1,0 +1,95 @@
+{
+  "feature_id": "add-rereview-prompt-check",
+  "phase": "spec",
+  "current_round": 3,
+  "status": "all_resolved",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "origin_round": 1,
+      "latest_round": 3,
+      "severity": "high",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Scope does not clearly match the issue body",
+      "detail": "The issue body asks to check whether prompts required outside of plan/tasks exist. The spec narrows scope to adding two rereview prompt files.",
+      "suggested_resolution": "Define the exact scope and enumerate the prompt references covered.",
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": "Spec now has explicit Scope section reconciling issue body with deliverable. Issue author confirmed scope is prompt addition only (2x). All non-plan/tasks prompt references audited: spec rereview and plan rereview are the only gaps."
+    },
+    {
+      "id": "R1-F02",
+      "origin_round": 1,
+      "latest_round": 2,
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Template inclusion is internally contradictory",
+      "detail": "The spec's mandatory requirements said template/, but design decisions said global/ only.",
+      "suggested_resolution": "Choose one approach.",
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "origin_round": 2,
+      "latest_round": 3,
+      "severity": "high",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "rereview の出力契約が既存実装に対して未確定",
+      "detail": "spec_fix と plan_fix が消費する JSON フィールドが明記されていなかった。",
+      "suggested_resolution": "各コマンドが受け取る正確な JSON schema を明記。",
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": "Full JSON schema added to spec with field names matching existing fix commands."
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 0,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "new": 2, "resolved": 0, "overridden": 0 },
+        "medium": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 },
+        "low": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 3,
+      "open": 1,
+      "new": 1,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 1, "new": 1, "resolved": 1, "overridden": 0 },
+        "medium": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 },
+        "low": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 3,
+      "total": 3,
+      "open": 0,
+      "new": 0,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "new": 0, "resolved": 3, "overridden": 0 },
+        "medium": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 },
+        "low": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-rereview-prompt-check/review-ledger-spec.json.bak
+++ b/openspec/changes/add-rereview-prompt-check/review-ledger-spec.json.bak
@@ -1,0 +1,82 @@
+{
+  "feature_id": "add-rereview-prompt-check",
+  "phase": "spec",
+  "current_round": 2,
+  "status": "has_open_high",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "origin_round": 1,
+      "latest_round": 2,
+      "severity": "high",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Scope does not clearly match the issue body",
+      "detail": "The issue body asks to check whether prompts required outside of plan/tasks exist, which reads like an audit or existence-check task. The spec instead narrows scope to creating two rereview prompt files and explicitly says the check functionality is out of scope.",
+      "suggested_resolution": "Define the exact scope in one place and enumerate the prompt references/commands that must be covered.",
+      "status": "open",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "origin_round": 1,
+      "latest_round": 2,
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Template inclusion is internally contradictory",
+      "detail": "The spec's mandatory requirements say the new prompts must also be added under template/, but the design decisions and scope sections say they must not be added there.",
+      "suggested_resolution": "Choose one distribution approach and make all sections consistent.",
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "origin_round": 2,
+      "latest_round": 2,
+      "severity": "high",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "rereview の出力契約が既存実装に対して未確定",
+      "detail": "spec_fix と plan_fix が rereview で実際にどの JSON フィールドを消費するのかが明記されていない。",
+      "suggested_resolution": "各コマンドが rereview で受け取る正確な JSON schema を明記してください。",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 0,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "new": 2, "resolved": 0, "overridden": 0 },
+        "medium": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 },
+        "low": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 3,
+      "open": 1,
+      "new": 1,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 1, "new": 1, "resolved": 1, "overridden": 0 },
+        "medium": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 },
+        "low": { "open": 0, "new": 0, "resolved": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-rereview-prompt-check/tasks.md
+++ b/openspec/changes/add-rereview-prompt-check/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: Re-review プロンプトの欠落追加
+
+## Phase 1: プロンプトファイル作成
+
+### Task 1: review_spec_rereview_prompt.md の作成 ✅
+- **Priority**: P0
+- **Parallel**: Yes (Task 2 と並行可能)
+- **File**: `global/prompts/review_spec_rereview_prompt.md`
+- **Steps**:
+  1. `review_impl_rereview_prompt.md` の構造をベースにする
+  2. ロール宣言を "You are the specification re-reviewer." に変更
+  3. スコープを "BROAD re-review of the specification" に変更
+  4. 入力を PREVIOUS_FINDINGS, MAX_FINDING_ID, ISSUE BODY, SPEC CONTENT に変更
+  5. Part 2 のレビュー観点を spec 固有カテゴリに変更:
+     - ambiguity, acceptance_criteria, edge_case, contradiction, assumption, vagueness
+  6. レビュールールを初回 spec review と整合させる（issue body との忠実性チェック等）
+  7. 出力 JSON スキーマの category enum を spec 固有カテゴリに更新
+- **Acceptance**: ファイルが存在し、JSON スキーマが proposal.md の「出力 JSON スキーマ」と一致
+
+### Task 2: review_plan_rereview_prompt.md の作成 ✅
+- **Priority**: P0
+- **Parallel**: Yes (Task 1 と並行可能)
+- **File**: `global/prompts/review_plan_rereview_prompt.md`
+- **Steps**:
+  1. `review_impl_rereview_prompt.md` の構造をベースにする
+  2. ロール宣言を "You are the plan and tasks re-reviewer." に変更
+  3. スコープを "BROAD re-review of the plan and tasks" に変更
+  4. 入力を PREVIOUS_FINDINGS, MAX_FINDING_ID, SPEC CONTENT, PLAN CONTENT, TASKS CONTENT に変更
+  5. Part 2 のレビュー観点を plan 固有カテゴリに変更:
+     - completeness, feasibility, ordering, granularity, scope, consistency, risk
+  6. レビュールールを初回 plan review と整合させる（spec カバレッジ、タスク依存順序等）
+  7. 出力 JSON スキーマの category enum を plan 固有カテゴリに更新
+- **Acceptance**: ファイルが存在し、JSON スキーマが proposal.md の「出力 JSON スキーマ」と一致
+
+## Phase 2: 検証
+
+### Task 3: specflow-install でのコピー確認 ✅
+- **Priority**: P1
+- **Depends on**: Task 1, Task 2
+- **Steps**:
+  1. `specflow-install` を実行
+  2. `~/.config/specflow/global/review_spec_rereview_prompt.md` が存在することを確認
+  3. `~/.config/specflow/global/review_plan_rereview_prompt.md` が存在することを確認
+- **Acceptance**: 両ファイルがインストール先に存在


### PR DESCRIPTION
## Summary
- Add `review_spec_rereview_prompt.md` for spec_fix rereview mode
- Add `review_plan_rereview_prompt.md` for plan_fix rereview mode
- Both follow the same Part 1/Part 2 structure as `review_impl_rereview_prompt.md`
- Output unified JSON schema (`resolved_previous_findings` / `still_open_previous_findings` / `new_findings`) compatible with existing fix commands

## Issue
Closes https://github.com/skr19930617/specflow/issues/58

## Test plan
- [ ] Run `specflow-install` and verify both files are copied to `~/.config/specflow/global/prompts/`
- [ ] Run `/specflow.spec_fix` on a real feature to verify prompt loads and produces valid JSON
- [ ] Run `/specflow.plan_fix` on a real feature to verify prompt loads and produces valid JSON