### PR TITLE
feat: add specflow-license command for license file generation (#57)

### DIFF
--- a/global/commands/specflow.license.md
+++ b/global/commands/specflow.license.md
@@ -1,0 +1,346 @@
+---
+description: プロジェクト解析に基づいてライセンスファイルを生成
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Prerequisites
+
+1. Run `which specflow-analyze` via Bash to confirm `specflow-analyze` is installed.
+   - If missing:
+     ```
+     ❌ `specflow-analyze` が見つかりません。
+     `specflow-install` を実行してパスを通してください。
+     ```
+     → **STOP**.
+
+2. Run `which gh` via Bash to confirm `gh` CLI is installed.
+   - If missing:
+     ```
+     ❌ `gh` CLI が見つかりません。
+     `brew install gh && gh auth login` を実行してください。
+     ```
+     → **STOP**.
+
+## Step 1: Analyze Project
+
+Run via Bash:
+```bash
+specflow-analyze .
+```
+
+If the command fails (non-zero exit), display the error and **STOP**.
+
+Store the JSON output as `ANALYZE_RESULT`.
+
+Report:
+```
+Step 1: Project analyzed
+  Languages: <languages>
+  Frameworks: <frameworks>
+  Package Manager: <package_manager>
+  Existing License: <license or "none">
+```
+
+## Step 2: Existing License Check
+
+### 2a: LICENSE file check
+
+If `ANALYZE_RESULT.license` is non-null:
+- Display: `"既存の LICENSE ファイルが検出されました: <license>"`
+- Use `AskUserQuestion` with options: "上書きする" / "キャンセル"
+- On "キャンセル": Display `"キャンセルしました。"` → **STOP**.
+- On "上書きする": Continue.
+
+### 2b: Manifest license reference info
+
+Check each manifest file via Read tool (skip silently if file does not exist):
+- `package.json` — look for `"license"` field
+- `Cargo.toml` — look for `license` in `[package]`
+- `pyproject.toml` — look for `license` in `[project]`
+
+If any manifest has a license field, display:
+```
+参考: マニフェストの既存 license フィールド:
+  - <filename>: <value>
+```
+
+Store any found manifest license values as `MANIFEST_LICENSE_INFO` for display in Step 3.
+
+## Step 3: Display License Options
+
+Display the license comparison table:
+
+```
+## 対応ライセンス一覧
+
+| ライセンス | 種類 | 説明 |
+|-----------|------|------|
+| MIT | 寛容系 | 商用利用可、改変可、再配布可。著作権表示のみ必須 |
+| Apache 2.0 | 寛容系 | 特許権の明示的許諾。商標の保護 |
+| BSD 2-Clause | 寛容系 | MIT に近い。条件が2つだけ |
+| ISC | 寛容系 | MIT/BSD と同等で最も短い。Node.js エコシステムで一般的 |
+| GPL 3.0 | コピーレフト | 派生物も同じライセンスで公開が必要 |
+| AGPL 3.0 | コピーレフト | SaaS でも公開義務あり |
+| Unlicense | パブリックドメイン | 一切の制約なし |
+```
+
+If `MANIFEST_LICENSE_INFO` exists, remind the user:
+```
+※ マニフェストの既存 license: <values>
+```
+
+## Step 4: Recommend and Select License
+
+### 4a: Determine recommendation
+
+Apply the following rules in priority order (first match wins):
+
+1. If `ANALYZE_RESULT.package_manager` == `"npm"` OR `ANALYZE_RESULT.languages` contains `"JavaScript"` or `"TypeScript"`:
+   - Recommend: **MIT** — "npm エコシステムで最も一般的なライセンスです"
+   - Recommended category: 寛容系
+
+2. If `ANALYZE_RESULT.languages` contains `"Rust"`:
+   - Recommend: **MIT または Apache 2.0** — "Rust エコシステムでは MIT または Apache 2.0 が一般的です（デュアルライセンスは本コマンドのスコープ外）"
+   - Recommended category: 寛容系
+
+3. If `ANALYZE_RESULT.languages` contains `"Go"`:
+   - Recommend: **BSD 2-Clause** — "Go 標準ライブラリと同じライセンスです"
+   - Recommended category: 寛容系
+
+4. If `ANALYZE_RESULT.frameworks` is non-empty:
+   - Recommend: **MIT** — "ライブラリ/フレームワーク依存プロジェクトに最適です"
+   - Recommended category: 寛容系
+
+5. Default:
+   - Recommend: **MIT** — "最も広く採用されている OSS ライセンスです"
+   - Recommended category: 寛容系
+
+Display the recommendation:
+```
+おすすめ: <recommended license> — <reason>
+```
+
+### 4b: Stage 1 — Category Selection
+
+Use `AskUserQuestion` with 3 options. Mark the recommended category with (Recommended):
+
+- "寛容系ライセンス (Recommended)" — MIT, Apache 2.0, BSD 2-Clause, ISC (description: "商用利用可、最も自由度が高い")
+- "コピーレフト系ライセンス" — GPL 3.0, AGPL 3.0 (description: "派生物も同じライセンスで公開が必要")
+- "パブリックドメイン" — Unlicense (description: "一切の制約なし")
+
+(Adjust Recommended marker based on the recommendation logic above. Default is 寛容系.)
+
+Store the user's selection as `SELECTED_CATEGORY`.
+
+### 4c: Stage 2 — Individual License Selection
+
+Based on `SELECTED_CATEGORY`:
+
+**If 寛容系:**
+Use `AskUserQuestion` with 4 options:
+- "MIT" (description: "最も寛容。著作権表示のみ必須")
+- "Apache 2.0" (description: "特許権の明示的許諾。エンタープライズ向け")
+- "BSD 2-Clause" (description: "MIT に近い。条件2つだけ")
+- "ISC" (description: "MIT/BSD 同等で最も短い")
+
+Mark recommended license with (Recommended). For Rust projects, mark MIT as (Recommended) and note Apache 2.0 as an alternative in the description.
+
+**If コピーレフト系:**
+Use `AskUserQuestion` with 2 options:
+- "GPL 3.0" (description: "派生物も同じライセンスで公開が必要")
+- "AGPL 3.0" (description: "ネットワーク越しの使用にも適用")
+
+**If パブリックドメイン:**
+Use `AskUserQuestion` with 2 options:
+- "Unlicense" (description: "パブリックドメイン相当。一切の制約なし")
+- "戻る" (description: "カテゴリ選択に戻る")
+
+On "戻る": Re-run Stage 1 (Step 4b).
+
+Store the user's selection as `SELECTED_LICENSE`.
+
+### 4d: Resolve license metadata
+
+Map `SELECTED_LICENSE` to its metadata:
+
+| Selection | GitHub API ID | SPDX ID |
+|-----------|---------------|---------|
+| MIT | `mit` | `MIT` |
+| Apache 2.0 | `apache-2.0` | `Apache-2.0` |
+| BSD 2-Clause | `bsd-2-clause` | `BSD-2-Clause` |
+| ISC | `isc` | `ISC` |
+| GPL 3.0 | `gpl-3.0` | `GPL-3.0-only` |
+| AGPL 3.0 | `agpl-3.0` | `AGPL-3.0-only` |
+| Unlicense | `unlicense` | `Unlicense` |
+
+Store `API_ID` and `SPDX_ID`.
+
+## Step 5: Get Author Name and Year
+
+### 5a: Get year
+
+Run via Bash:
+```bash
+date +%Y
+```
+Store as `YEAR`.
+
+### 5b: Get author name
+
+Run via Bash:
+```bash
+git config user.name
+```
+
+If the output is non-empty, store as `AUTHOR_NAME`.
+
+If the output is empty or the command fails:
+1. Use `AskUserQuestion` (no options — free-text input mode) with question:
+   ```
+   LICENSE ファイルに記載する著者名を入力してください。
+   例: git config user.name "Your Name" で設定すると次回から自動取得されます。
+   ```
+2. If the user enters a non-empty value, store as `AUTHOR_NAME`.
+3. If the user enters empty text, retry (up to 3 attempts total).
+4. After 3 empty attempts OR if the user cancels/dismisses:
+   - Set `AUTHOR_NAME` = `<AUTHOR>`
+   - Display: `"⚠ 著者名が未設定のため <AUTHOR> プレースホルダーを使用しました。LICENSE ファイル内の <AUTHOR> を手動で置換してください"`
+
+## Step 6: Fetch License Text
+
+Run via Bash:
+```bash
+gh api /licenses/<API_ID> --jq '.body'
+```
+
+If the command fails (non-zero exit or empty output):
+- Display: `"❌ GitHub Licenses API からのライセンス取得に失敗しました。ネットワーク接続と gh auth status を確認してください。"`
+- Use `AskUserQuestion` with options: "リトライ" / "キャンセル"
+- On "リトライ": Re-run the command.
+- On "キャンセル": **STOP**.
+
+Store the output as `LICENSE_BODY`.
+
+### Placeholder substitution
+
+If `LICENSE_BODY` contains `[year]`, replace all occurrences with `YEAR`.
+If `LICENSE_BODY` contains `[fullname]`, replace all occurrences with `AUTHOR_NAME`.
+
+Store the result as `LICENSE_TEXT`.
+
+## Step 7: Write LICENSE File
+
+Write `LICENSE_TEXT` to `LICENSE` at the project root via Write tool.
+
+Report:
+```
+Step 7: LICENSE ファイルを生成しました
+  ライセンス: <SELECTED_LICENSE> (<SPDX_ID>)
+  著者: <AUTHOR_NAME>
+  年: <YEAR>
+```
+
+## Step 8: Update Manifest Files
+
+For each manifest file, apply the following logic:
+
+### 8a: package.json
+
+1. Attempt to Read `package.json`. If file does not exist → skip silently.
+2. Check if file contains a `"license"` field.
+3. If `"license"` field exists:
+   - If the value equals `SPDX_ID` → skip (display: `"package.json: license は既に <SPDX_ID> です。スキップ"`)
+   - If the value differs → Use `AskUserQuestion` with options: "上書きする" / "スキップ"
+     - On "スキップ" → skip
+     - On "上書きする" → Edit the `"license"` field to `SPDX_ID`
+4. If `"license"` field does not exist:
+   - Edit to add `"license": "<SPDX_ID>"` after the `"name"` field (or at top level).
+5. Report what was done.
+
+### 8b: Cargo.toml
+
+1. Attempt to Read `Cargo.toml`. If file does not exist → skip silently.
+2. Check if file contains `[package]` table.
+   - If `[package]` does not exist → skip (display: `"Cargo.toml: [package] テーブルが見つかりません。スキップ"`)
+3. Check if `[package]` contains `license` field.
+4. If `license` field exists:
+   - If the value equals `SPDX_ID` → skip
+   - If the value differs → Use `AskUserQuestion` with options: "上書きする" / "スキップ"
+     - On "スキップ" → skip
+     - On "上書きする" → Edit the `license` field to `SPDX_ID`
+5. If `license` field does not exist:
+   - Edit to add `license = "<SPDX_ID>"` in the `[package]` section.
+6. Report what was done.
+
+### 8c: pyproject.toml
+
+1. Attempt to Read `pyproject.toml`. If file does not exist → skip silently.
+2. Check if file contains `[project]` table.
+   - If `[project]` does not exist → skip (display: `"pyproject.toml: [project] テーブルが見つかりません。スキップ"`)
+3. Check if `[project]` contains `license` field.
+4. If `license` field exists:
+   - If it is a table form (e.g., `license = {text = "..."}` or `license = {file = "..."}`) → skip + display: `"⚠ pyproject.toml の license フィールドがレガシー形式のためスキップしました"`
+   - If it is a string form and equals `SPDX_ID` → skip
+   - If it is a string form and differs → Use `AskUserQuestion` with options: "上書きする" / "スキップ"
+     - On "スキップ" → skip
+     - On "上書きする" → Edit the `license` field to `SPDX_ID`
+5. If `license` field does not exist:
+   - Edit to add `license = "<SPDX_ID>"` in the `[project]` section.
+6. Report what was done.
+
+## Step 9: Report Results
+
+Display a summary:
+
+```
+✅ ライセンス生成完了
+
+  ライセンス: <SELECTED_LICENSE> (<SPDX_ID>)
+  ファイル: LICENSE
+  著者: <AUTHOR_NAME>
+  年: <YEAR>
+
+  マニフェスト更新:
+  - package.json: <updated / skipped / not found>
+  - Cargo.toml: <updated / skipped / not found>
+  - pyproject.toml: <updated / skipped / not found>
+```
+
+If `AUTHOR_NAME` is `<AUTHOR>`, append:
+```
+⚠ LICENSE ファイル内の <AUTHOR> を手動で置換してください
+```
+
+## Verification Checklist
+
+Manual verification scenarios:
+
+- [ ] New project (no LICENSE, no manifests) → recommend MIT, generate LICENSE
+- [ ] Existing LICENSE → overwrite confirmation, then generate
+- [ ] Existing LICENSE → cancel overwrite → command stops, no changes
+- [ ] Node.js project → MIT recommendation
+- [ ] Rust project → MIT recommendation (Apache 2.0 noted as alternative)
+- [ ] Go project → BSD 2-Clause recommendation
+- [ ] Author name from git config → embedded in LICENSE
+- [ ] Author name missing → free-text prompt → embedded
+- [ ] Author name missing → 3 empty retries → `<AUTHOR>` placeholder + warning
+- [ ] Author name missing → cancel → `<AUTHOR>` placeholder + warning
+- [ ] GitHub API failure → retry prompt
+- [ ] package.json exists, same license → skip
+- [ ] package.json exists, different license → overwrite confirmation
+- [ ] Cargo.toml exists, no [package] → skip
+- [ ] pyproject.toml exists, legacy table form → skip + warning
+- [ ] pyproject.toml exists, string form, different → overwrite confirmation
+
+## Important Rules
+
+- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all paths
+- All evidence for recommendations must come from `specflow-analyze` output
+- Never modify manifests that do not exist — only update existing files
+- When the user cancels at the existing LICENSE check, stop the entire command
+- When the user cancels LICENSE overwrite, also skip all manifest updates

--- a/openspec/changes/add-license-generator/approval-summary.md
+++ b/openspec/changes/add-license-generator/approval-summary.md
@@ -1,0 +1,75 @@
+# Approval Summary: add-license-generator
+
+**Generated**: 2026-04-08 00:18
+**Branch**: add-license-generator
+**Status**: ⚠️ 1 unresolved high (spec ledger stale — F7 was fixed in-place but ledger not re-reviewed)
+
+## What Changed
+
+```
+ global/commands/specflow.license.md                | 346 +++++++++++++++++++++
+ openspec/changes/add-license-generator/            | 755 +++++++++++++++++++++
+ 10 files changed, 1101 insertions(+)
+```
+
+## Files Touched
+
+- `global/commands/specflow.license.md` (NEW — main deliverable)
+- `openspec/changes/add-license-generator/proposal.md`
+- `openspec/changes/add-license-generator/research.md`
+- `openspec/changes/add-license-generator/plan.md`
+- `openspec/changes/add-license-generator/tasks.md`
+- `openspec/changes/add-license-generator/current-phase.md`
+- `openspec/changes/add-license-generator/review-ledger-spec.json` + `.bak`
+- `openspec/changes/add-license-generator/review-ledger-plan.json` + `.bak`
+
+## Review Loop Summary
+
+### Spec Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 2     |
+| Unresolved high    | 1 (stale — fixed in-place) |
+| New high (later)   | 2     |
+| Total rounds       | 3     |
+
+### Plan Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 1     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 2     |
+
+### Impl Review
+⚠️ No impl review ledger (implementation is a Markdown command definition, not executable code)
+
+## Spec Coverage
+
+| # | Criterion | Covered? | Mapped Files |
+|---|-----------|----------|--------------|
+| 1 | `specflow.license.md` が存在する | Yes | `global/commands/specflow.license.md` |
+| 2 | `specflow-analyze` でプロジェクトを解析する | Yes | Step 1 in command |
+| 3 | 各ライセンスの説明がコンソールに表示される | Yes | Step 3 in command |
+| 4 | おすすめライセンスが理由とともに提示される | Yes | Step 4a in command |
+| 5 | AskUserQuestion でボタン形式のライセンス選択ができる（7種類固定） | Yes | Step 4b/4c — 2-stage selection |
+| 6 | GitHub Licenses API からライセンス全文を取得し LICENSE ファイルに書き込まれる | Yes | Step 6/7 in command |
+| 7 | 年と著者名がライセンステキストに正しく埋め込まれる | Yes | Step 5/6 in command |
+| 8 | 既存の LICENSE ファイルがある場合は上書き確認が行われる | Yes | Step 2a in command |
+| 9 | package.json / Cargo.toml / pyproject.toml の license フィールドが自動更新される | Yes | Step 8a/8b/8c in command |
+
+**Coverage Rate**: 9/9 (100%)
+
+## Remaining Risks
+
+- ⚠️ Spec ledger F7 ("Supported license identifiers and template handling are underspecified") is marked as `new` in ledger but was fixed in the proposal during the same round. Ledger status is stale.
+- ⚠️ No impl review ledger — the deliverable is a Markdown command definition (no executable code to review)
+
+## Human Checkpoints
+
+- [ ] `specflow-install` を実行後、`~/.claude/commands/specflow.license.md` が正しくコピーされることを確認する
+- [ ] 実際のプロジェクトで `/specflow.license` を実行し、ライセンス選択 → LICENSE 生成 → マニフェスト更新の一連のフローが動作することを確認する
+- [ ] `gh api /licenses/mit --jq '.body'` が正しくライセンス全文を返すことを確認する（GitHub 認証状態に依存）
+- [ ] pyproject.toml にレガシー形式の license フィールドがあるプロジェクトでスキップ + 警告が正しく表示されることを確認する

--- a/openspec/changes/add-license-generator/current-phase.md
+++ b/openspec/changes/add-license-generator/current-phase.md
@@ -1,0 +1,10 @@
+# Current Phase: add-license-generator
+
+- Phase: impl-review
+- Round: 1
+- Status: in_progress
+- Open High Findings: 0 件 (F1 は 2-stage 設計が spec/plan で承認済みのため対応不要、F2 は修正済み)
+- Accepted Risks: none
+- Latest Changes:
+  - (no commits yet)
+- Next Recommended Action: /specflow.approve

--- a/openspec/changes/add-license-generator/plan.md
+++ b/openspec/changes/add-license-generator/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: specflow.license コマンド
+
+## 概要
+
+`global/commands/specflow.license.md` に Markdown ベースのスラッシュコマンドを1ファイル作成する。既存の `specflow.readme.md` と同じパターンに従い、`specflow-analyze` → UI 表示 → ユーザー選択 → ファイル生成の流れを実装する。
+
+## 成果物
+
+| ファイル | 種類 | 説明 |
+|---------|------|------|
+| `global/commands/specflow.license.md` | 新規作成 | スラッシュコマンド定義（唯一の成果物） |
+
+## 設計
+
+### コマンド構造
+
+```
+---
+description: プロジェクト解析に基づいてライセンスファイルを生成
+---
+
+## User Input
+$ARGUMENTS
+
+## Prerequisites
+- specflow-analyze の存在確認
+
+## Step 1: Analyze Project
+- specflow-analyze . を実行
+- JSON 出力を ANALYZE_RESULT に格納
+
+## Step 2: Existing License Check
+- ANALYZE_RESULT.license が非 null → 上書き確認
+- マニフェストの既存 license フィールドも参考情報として表示
+
+## Step 3: Display License Options
+- 7種類のライセンス説明テーブルを表示
+- おすすめロジックに基づき推奨を提示
+
+## Step 4: License Selection (2-stage)
+- Stage 1: AskUserQuestion でカテゴリ選択（寛容系 / コピーレフト系 / パブリックドメイン）
+- Stage 2: AskUserQuestion でカテゴリ内の個別ライセンス選択
+- おすすめを (Recommended) 付きで配置
+
+## Step 5: Author & Year
+- git config user.name で取得
+- 不在時は AskUserQuestion フリーテキスト
+
+## Step 6: Fetch License Text
+- gh api /licenses/{key} でライセンス全文取得
+- [year] / [fullname] プレースホルダー置換
+
+## Step 7: Write LICENSE
+- Write ツールで LICENSE ファイルを生成
+
+## Step 8: Update Manifests
+- package.json / Cargo.toml / pyproject.toml の license フィールド更新
+
+## Step 9: Report
+- 結果報告
+```
+
+### AskUserQuestion の制約対応（2段階グループ選択）
+
+AskUserQuestion は最大4オプション。7種類のライセンスを2段階の固定ボタン選択で対応:
+
+**ステージ1: カテゴリ選択**
+1. 全7種類の説明テーブルをコンソールに表示
+2. おすすめライセンスを理由とともに提示
+3. AskUserQuestion で以下の3カテゴリから選択:
+   - 「寛容系ライセンス」— MIT, Apache 2.0, BSD 2-Clause, ISC
+   - 「コピーレフト系ライセンス」— GPL 3.0, AGPL 3.0
+   - 「パブリックドメイン」— Unlicense
+   - おすすめカテゴリに (Recommended) を付与
+
+**ステージ2: 個別ライセンス選択**
+- 選択されたカテゴリの全ライセンスを AskUserQuestion のボタンで表示（最大4つ以内に収まる）
+  - 寛容系: MIT / Apache 2.0 / BSD 2-Clause / ISC（4つ）
+  - コピーレフト系: GPL 3.0 / AGPL 3.0（2つ）
+  - パブリックドメイン: Unlicense（1つ → 確認のみ）
+- おすすめライセンスに (Recommended) を付与
+- Rust プロジェクトの場合は寛容系カテゴリ内で MIT と Apache 2.0 の両方に推奨理由を表示
+
+この設計により、全7種類が固定ボタン選択で完結し、フリーテキスト入力に依存しない。
+
+### おすすめロジックの実装
+
+Markdown の条件分岐（If/Otherwise）で実装:
+1. `ANALYZE_RESULT.license` が非 null → 上書き確認フローへ
+2. `ANALYZE_RESULT.package_manager == "npm"` OR languages に JS/TS → MIT 推奨
+3. languages に "Rust" → MIT OR Apache 2.0 推奨
+4. languages に "Go" → BSD 2-Clause 推奨
+5. frameworks が非空 → MIT 推奨
+6. デフォルト → MIT 推奨
+
+### GitHub API 呼び出し
+
+```bash
+gh api /licenses/{key} --jq '.body'
+```
+
+- `gh` CLI は specflow の前提ツール（README に記載済み）
+- 認証済み（`gh auth login` が前提）
+- `--jq '.body'` でライセンス全文のみ抽出
+
+### マニフェスト更新ロジック
+
+各ファイルに対して:
+1. Read ツールでファイルを読む
+2. 対象テーブル/セクションが存在するか確認
+3. 既存の license フィールドがある場合:
+   - SPDX が同一 → スキップ
+   - SPDX が異なる → AskUserQuestion で確認
+   - pyproject.toml でテーブル形式 → スキップ + 警告
+4. Edit ツールで license フィールドを更新
+
+## リスク
+
+| リスク | 影響 | 対策 |
+|--------|------|------|
+| GitHub API レート制限 | ライセンス取得失敗 | エラー表示でリトライ案内 |
+| gh CLI 未インストール | API 呼び出し失敗 | Prerequisites で which gh チェック |
+| マニフェストの複雑なフォーマット | Edit 失敗 | Read で構造確認後に Edit |
+
+## 依存関係
+
+- `specflow-analyze` — プロジェクト解析
+- `gh` CLI — GitHub Licenses API アクセス
+- 既存の AskUserQuestion / Read / Write / Edit / Bash ツール

--- a/openspec/changes/add-license-generator/proposal.md
+++ b/openspec/changes/add-license-generator/proposal.md
@@ -1,0 +1,109 @@
+# Proposal: ライセンスを生成するコマンドの追加
+
+> GitHub Issue: [#57](https://github.com/skr19930617/specflow/issues/57) — ライセンスを生成するコマンドの追加
+
+## 背景
+
+OSS プロジェクトにはライセンスファイルが必須だが、適切なライセンスの選定は開発者にとって判断が難しい。specflow にはプロジェクト解析機能（`specflow-analyze`）が既にあるため、プロジェクトの特性に基づいたライセンス推奨が可能である。
+
+## スコープ
+
+スラッシュコマンド `/specflow.license` を追加し、以下の機能を提供する:
+
+1. `specflow-analyze` でプロジェクトを解析
+2. プロジェクト特性に基づいたおすすめライセンスを提示
+3. `AskUserQuestion` で UI ボタンによるライセンス選択
+4. 選択されたライセンスの `LICENSE` ファイルを生成
+
+## 要件
+
+### 必須要件
+
+1. **コマンド定義**: `global/commands/specflow.license.md` にスラッシュコマンドを作成する
+2. **プロジェクト解析**: `specflow-analyze` を使用してプロジェクトの言語・フレームワーク・既存ライセンスを取得する
+3. **ライセンス選択 UI**: `AskUserQuestion` でボタン形式のライセンス選択を提供する
+4. **ライセンス説明表示**: 選択前に各ライセンスの概要・特徴をコンソールに表示する
+5. **おすすめ表示**: プロジェクト特性に基づいた推奨ライセンスを理由とともに提示する
+6. **LICENSE ファイル生成**: 選択されたライセンスの正式な全文を `LICENSE` ファイルとして生成する
+7. **年・著者名の自動取得**: `git config user.name` と現在の年を使用してライセンステキストに埋め込む。`git config user.name` が空または未設定の場合は `AskUserQuestion` をオプションなし（フリーテキスト入力モード）で呼び出し、著者名の入力を求める。質問テキストに `git config user.name` の例を提示する。ユーザーが空文字を入力した場合は再度入力を求める（最大3回、その後は `"<AUTHOR>"` プレースホルダーを使用し手動置換を求める）。ユーザーがプロンプトをキャンセル/dismiss した場合も `"<AUTHOR>"` プレースホルダーを使用する
+8. **マニフェストファイルの license フィールド更新**: LICENSE ファイル生成後、以下のマニフェストファイルが存在する場合のみ、license フィールドを SPDX 識別子で更新する:
+   - `package.json` — トップレベルの `"license": "<SPDX-ID>"` フィールドを設定（JSON の Edit）
+   - `Cargo.toml` — `[package]` テーブル内の `license = "<SPDX-ID>"` フィールドを設定。`[package]` テーブルが存在しない場合はスキップ
+   - `pyproject.toml` — `[project]` テーブル内の `license` フィールドを設定。`[project]` テーブルが存在しない場合はスキップ。`[tool.poetry]` 等のバックエンド固有テーブルは対応しない（`[project]` のみ）。既存の `license` フィールドがテーブル形式（`license = {text = "..."}` 等の PEP 639 以前の形式）の場合は更新をスキップし、`"⚠ pyproject.toml の license フィールドがレガシー形式のためスキップしました"` と表示する。文字列形式の場合のみ SPDX 識別子で上書きする
+   - 上記以外のマニフェストファイルは対応しない
+   - マニフェストファイルが存在しない場合はスキップ（新規作成しない）
+   - 既存の license フィールドがあり、選択したライセンスの SPDX 識別子と異なる場合は `AskUserQuestion` で確認（「上書きする」/「スキップ」）。同一の場合はスキップ
+   - LICENSE ファイルが存在しなかったがマニフェストに license フィールドが存在する場合、ライセンス選択画面で現在のマニフェスト値を参考情報として表示する
+   - ユーザーが LICENSE ファイルの上書きをキャンセルした場合はマニフェスト更新もスキップする
+
+### 対応ライセンス
+
+| UI ラベル | GitHub API ID | SPDX 識別子 | 説明 | 年/著者の置換 |
+|----------|---------------|-------------|------|--------------|
+| MIT | `mit` | `MIT` | 最も寛容なライセンス | `[year]` → 年, `[fullname]` → 著者名 |
+| Apache 2.0 | `apache-2.0` | `Apache-2.0` | エンタープライズ向け寛容ライセンス | 置換なし（テンプレートに年/著者プレースホルダーなし） |
+| GPL 3.0 | `gpl-3.0` | `GPL-3.0-only` | コピーレフトライセンス | 置換なし（前文に年/著者の指示あるが本文には含まない） |
+| BSD 2-Clause | `bsd-2-clause` | `BSD-2-Clause` | MIT に近いシンプルなライセンス | `[year]` → 年, `[fullname]` → 著者名 |
+| ISC | `isc` | `ISC` | MIT/BSD と同等で最も短い | `[year]` → 年, `[fullname]` → 著者名 |
+| AGPL 3.0 | `agpl-3.0` | `AGPL-3.0-only` | ネットワーク越しの使用にも適用されるコピーレフト | 置換なし |
+| Unlicense | `unlicense` | `Unlicense` | パブリックドメイン相当 | 置換なし |
+
+**置換ルール**: GitHub Licenses API レスポンスの `body` フィールドに `[year]` / `[fullname]` プレースホルダーが含まれる場合のみ置換する。含まれない場合はそのまま出力する。
+
+### おすすめロジック
+
+`specflow-analyze` の JSON 出力フィールドに基づき、以下の優先順位で決定する（最初にマッチしたルールを採用）:
+
+| 優先度 | 条件（`specflow-analyze` フィールド） | 推奨ライセンス | 理由 |
+|--------|--------------------------------------|---------------|------|
+| 1 | `license` が非 null（※ `specflow-analyze` は LICENSE ファイルの存在から検出する。マニフェストの license フィールドは参照しない） | 現在のライセンスを表示し `AskUserQuestion` で上書き確認（「上書きする」/「キャンセル」）。キャンセル時はコマンド全体を終了する | 既存選択を尊重 |
+| 2 | `package_manager` が `"npm"` または `languages` に `"JavaScript"` / `"TypeScript"` を含む | MIT | npm エコシステムで最も一般的 |
+| 3 | `languages` に `"Rust"` を含む | MIT OR Apache 2.0 | Rust エコシステムのデュアルライセンス慣習 |
+| 4 | `languages` に `"Go"` を含む | BSD 2-Clause | Go 標準ライブラリと同じ |
+| 5 | `frameworks` が非空（何らかのフレームワーク使用） | MIT | ライブラリ/フレームワーク依存プロジェクトに最適 |
+| 6 | 上記いずれにも該当しない | MIT | 最も広く採用されている OSS ライセンス |
+
+**注意**: 推奨はあくまで提案であり、ユーザーは AskUserQuestion で任意の7種類から自由に選択できる。
+
+## 設計決定
+
+1. **コマンド名**: `specflow.license`（既存の `specflow.*` 命名規則に準拠）
+2. **配置場所**: `global/commands/specflow.license.md`
+3. **ライセンス全文**: GitHub Licenses API（`api.github.com/licenses/{spdx-id}`）から動的に取得する
+4. **出力先**: プロジェクトルートの `LICENSE` ファイル
+5. **既存ファイル対応**: 既存の LICENSE がある場合は上書き確認を行う
+
+## ワークフロー
+
+```
+1. specflow-analyze でプロジェクト解析
+2. 既存 LICENSE がある場合（`specflow-analyze.license` が非 null）は上書き確認。キャンセル時はコマンド終了
+3. 各ライセンスの説明テーブルを表示
+4. おすすめライセンスを理由とともに提示
+5. AskUserQuestion でライセンス選択（ボタン形式、7種類）
+6. 著者名・年を取得（git config 不在時はユーザー入力）
+7. GitHub Licenses API からライセンス全文を取得
+8. LICENSE ファイルを生成
+9. package.json / Cargo.toml 等の license フィールドを更新
+10. 結果を報告
+```
+
+## 受け入れ基準
+
+- [ ] `global/commands/specflow.license.md` が存在する
+- [ ] `specflow-analyze` を使用してプロジェクトを解析する
+- [ ] 各ライセンスの説明がコンソールに表示される
+- [ ] おすすめライセンスが理由とともに提示される
+- [ ] `AskUserQuestion` でボタン形式のライセンス選択ができる（7種類固定）
+- [ ] GitHub Licenses API からライセンス全文を取得し `LICENSE` ファイルに書き込まれる
+- [ ] 年と著者名がライセンステキストに正しく埋め込まれる（git config 不在時はユーザー入力）
+- [ ] 既存の LICENSE ファイルがある場合は上書き確認が行われる
+- [ ] `package.json`・`Cargo.toml`・`pyproject.toml` の license フィールドが SPDX 識別子で自動更新される（ファイルが存在する場合のみ）
+
+## スコープ外
+
+- ライセンスの法的アドバイス
+- マルチライセンス（複数ライセンスの同時適用）
+- 7種類以外のカスタムライセンス対応
+- SPDX 識別子の検証
+- ライセンスヘッダーのソースファイルへの挿入

--- a/openspec/changes/add-license-generator/research.md
+++ b/openspec/changes/add-license-generator/research.md
@@ -1,0 +1,35 @@
+# Research: ライセンスコマンド実装
+
+## 既存コマンドパターン
+
+`specflow.readme.md` を参考にした既存パターン:
+- YAML frontmatter (`description` フィールド)
+- `$ARGUMENTS` でユーザー入力を受け取る
+- Prerequisites で `specflow-analyze` の存在確認
+- `specflow-analyze .` でプロジェクト解析 → JSON 出力
+- `AskUserQuestion` で UI 操作
+- Write ツールでファイル生成
+
+## GitHub Licenses API
+
+- エンドポイント: `https://api.github.com/licenses/{key}`
+- 認証不要（パブリック API）
+- レスポンス: `{ "key": "mit", "spdx_id": "MIT", "body": "MIT License\n\nCopyright (c) [year] [fullname]..." }`
+- `body` フィールドにライセンス全文が含まれる
+- プレースホルダー: MIT, BSD, ISC は `[year]`, `[fullname]` を含む。GPL, Apache, AGPL, Unlicense は含まない
+- コマンド内で `gh api /licenses/{key}` または `WebFetch` で取得可能
+
+## AskUserQuestion の制約
+
+- `options` は最大4つまで（7種類を一度に表示できない）
+- 解決策: 2回の AskUserQuestion に分割するか、カテゴリで分類
+  - 案1: 「寛容系」(MIT, Apache, BSD, ISC) と「コピーレフト系」(GPL, AGPL) と「パブリックドメイン」(Unlicense)
+  - 案2: おすすめを含む上位4つ + 「その他を表示」で2段階選択
+  - 案3: 全7種類の説明テーブルを表示し、おすすめに (Recommended) マーク付きで最初のオプションにする。残りは4つに収める工夫が必要
+- **最適解**: AskUserQuestion のオプションに「その他」が自動追加されるため、上位3-4種類をボタンで表示し、テーブルで全7種類を表示。ユーザーが「その他」で任意のライセンス名を入力できる
+
+## マニフェスト更新の実装方法
+
+- `package.json`: Read → JSON パース → `license` フィールドを Edit で更新
+- `Cargo.toml`: Read → `[package]` セクションの `license` 行を Edit で更新
+- `pyproject.toml`: Read → `[project]` セクションの `license` を確認。文字列形式のみ更新

--- a/openspec/changes/add-license-generator/review-ledger-plan.json
+++ b/openspec/changes/add-license-generator/review-ledger-plan.json
@@ -1,0 +1,67 @@
+{
+  "feature_id": "add-license-generator",
+  "phase": "plan",
+  "current_round": 2,
+  "status": "in_progress",
+  "max_finding_id": 2,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "openspec/changes/add-license-generator/plan.md",
+      "title": "License selection design does not meet the required fixed-choice UI",
+      "detail": "The plan/tasks work around AskUserQuestion's 4-option limit by showing only 3-4 buttons and sending the rest through Other free-text with partial matching.",
+      "suggested_resolution": "",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "F2",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "openspec/changes/add-license-generator/tasks.md",
+      "title": "Author fallback flow omits required prompt content and placeholder follow-up",
+      "detail": "Task 6 does not include the git config user.name example in the prompt, nor the placeholder replacement guidance when retries are exhausted.",
+      "suggested_resolution": "",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 2
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 1,
+      "open": 0,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 2,
+      "open": 0,
+      "new": 1,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 1, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-license-generator/review-ledger-plan.json.bak
+++ b/openspec/changes/add-license-generator/review-ledger-plan.json.bak
@@ -1,0 +1,37 @@
+{
+  "feature_id": "add-license-generator",
+  "phase": "plan",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 1,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "openspec/changes/add-license-generator/plan.md",
+      "title": "License selection design does not meet the required fixed-choice UI",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 1
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 1,
+      "open": 0,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-license-generator/review-ledger-spec.json
+++ b/openspec/changes/add-license-generator/review-ledger-spec.json
@@ -1,0 +1,160 @@
+{
+  "feature_id": "add-license-generator",
+  "phase": "spec",
+  "current_round": 3,
+  "status": "has_open_high",
+  "max_finding_id": 8,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Recommendation logic is not implementable from the stated analysis data",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Manifest file updates add unclear scope and side effects",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "low",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Author-name fallback flow is undefined",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "F4",
+      "severity": "medium",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Existing-license detection and overwrite flow are not aligned",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "F5",
+      "severity": "high",
+      "category": "assumption",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "TOML manifest update rules assume a universal license field shape",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 3
+    },
+    {
+      "id": "F6",
+      "severity": "medium",
+      "category": "assumption",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Manifest-only existing licenses are ignored before overwrite",
+      "detail": "A repository that already declares a license in package.json/Cargo.toml/pyproject.toml but lacks a LICENSE file would be treated as unlicensed, potentially leading to silent replacement of the existing declaration.",
+      "suggested_resolution": "",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 3,
+      "latest_round": 3
+    },
+    {
+      "id": "F7",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Supported license identifiers and template handling are underspecified",
+      "detail": "The spec conflates UI labels, SPDX identifiers, and GitHub Licenses API lookup values. Implementers cannot tell the exact API key, the exact SPDX string to write, or whether/how placeholder substitution should work.",
+      "suggested_resolution": "",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 3,
+      "latest_round": 3
+    },
+    {
+      "id": "F8",
+      "severity": "medium",
+      "category": "assumption",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "pyproject.toml rewrite assumes PEP 639-compatible build backends",
+      "detail": "The spec mandates rewriting [project].license to a string SPDX expression, but older backends expect the legacy table form.",
+      "suggested_resolution": "",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 3,
+      "latest_round": 3
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 5,
+      "open": 1,
+      "new": 2,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 1, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 1, "new": 1, "overridden": 0 },
+        "low": { "open": 1, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 0,
+      "new": 3,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 2, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 2, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 1, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-license-generator/review-ledger-spec.json.bak
+++ b/openspec/changes/add-license-generator/review-ledger-spec.json.bak
@@ -1,0 +1,102 @@
+{
+  "feature_id": "add-license-generator",
+  "phase": "spec",
+  "current_round": 2,
+  "status": "has_open_high",
+  "max_finding_id": 5,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Recommendation logic is not implementable from the stated analysis data",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Manifest file updates add unclear scope and side effects",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "low",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Author-name fallback flow is undefined",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 1,
+      "latest_round": 2
+    },
+    {
+      "id": "F4",
+      "severity": "medium",
+      "category": "ambiguity",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "Existing-license detection and overwrite flow are not aligned",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 2
+    },
+    {
+      "id": "F5",
+      "severity": "high",
+      "category": "assumption",
+      "file": "openspec/changes/add-license-generator/proposal.md",
+      "title": "TOML manifest update rules assume a universal license field shape",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "origin_round": 2,
+      "latest_round": 2
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 5,
+      "open": 1,
+      "new": 2,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 1, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 1, "new": 1, "overridden": 0 },
+        "low": { "open": 1, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/add-license-generator/tasks.md
+++ b/openspec/changes/add-license-generator/tasks.md
@@ -1,0 +1,106 @@
+# Tasks: specflow.license コマンド
+
+## Phase 1: コマンドファイル作成
+
+### Task 1: コマンドの基本構造を作成 ✅
+- **ファイル**: `global/commands/specflow.license.md`
+- **内容**: YAML frontmatter、User Input セクション、Prerequisites（specflow-analyze と gh の存在確認）
+- **優先度**: P0
+- **依存**: なし
+
+### Task 2: Step 1 — プロジェクト解析 ✅
+- **内容**: `specflow-analyze .` を Bash で実行し、JSON 出力を `ANALYZE_RESULT` に格納。エラー時は STOP。解析結果のサマリーを表示（Languages, Frameworks, License）
+- **優先度**: P0
+- **依存**: Task 1
+
+### Task 3: Step 2 — 既存ライセンスチェック ✅
+- **内容**:
+  - `ANALYZE_RESULT.license` が非 null → AskUserQuestion で上書き確認（「上書きする」/「キャンセル」）。キャンセル時はコマンド終了
+  - マニフェスト（package.json / Cargo.toml / pyproject.toml）の既存 license フィールドを Read で確認し、存在すれば参考情報として表示
+- **優先度**: P0
+- **依存**: Task 2
+
+### Task 4: Step 3 — ライセンス説明テーブル表示 ✅
+- **内容**: 7種類のライセンスを UI ラベル・説明・主な特徴のテーブルで表示
+- **優先度**: P0
+- **依存**: Task 3
+
+### Task 5: Step 4 — おすすめ提示とライセンス選択（2段階） ✅
+- **内容**:
+  - おすすめロジック（proposal.md の優先度テーブル）に基づき推奨ライセンスを理由とともに提示
+  - **Stage 1**: AskUserQuestion でカテゴリ選択（「寛容系ライセンス」/「コピーレフト系ライセンス」/「パブリックドメイン」）。推奨カテゴリに (Recommended) を付与
+  - **Stage 2**: 選択されたカテゴリ内の個別ライセンスを AskUserQuestion のボタンで表示:
+    - 寛容系: MIT / Apache 2.0 / BSD 2-Clause / ISC（4つ）
+    - コピーレフト系: GPL 3.0 / AGPL 3.0（2つ）
+    - パブリックドメイン: Unlicense（1つ、確認のみ）
+  - 推奨ライセンスに (Recommended) を付与。Rust の場合は MIT と Apache 2.0 の両方に推奨理由を表示
+- **優先度**: P0
+- **依存**: Task 4
+
+### Task 6: Step 5 — 著者名・年の取得 ✅
+- **内容**:
+  - `git config user.name` を Bash で取得
+  - 空の場合は AskUserQuestion（オプションなし、フリーテキスト）で入力を求める。質問テキストに `例: git config user.name "Your Name" で設定できます` を含める
+  - 空入力は最大3回リトライ。その後は `<AUTHOR>` プレースホルダーを使用し、`"⚠ 著者名が未設定のため <AUTHOR> プレースホルダーを使用しました。LICENSE ファイル内の <AUTHOR> を手動で置換してください"` と表示する
+  - キャンセル/dismiss 時も `<AUTHOR>` プレースホルダーを使用し同じ警告メッセージを表示する
+  - 現在の年は `date +%Y` で取得
+- **優先度**: P0
+- **依存**: Task 5
+
+### Task 7: Step 6 — ライセンス全文取得と置換 ✅
+- **内容**:
+  - `gh api /licenses/{GitHub API ID} --jq '.body'` でライセンス全文を取得
+  - API 失敗時はエラー表示 + リトライ案内
+  - `body` に `[year]` / `[fullname]` が含まれる場合のみ置換
+- **優先度**: P0
+- **依存**: Task 6
+
+### Task 8: Step 7 — LICENSE ファイル生成 ✅
+- **内容**: Write ツールで `LICENSE` ファイルを生成。生成完了を報告
+- **優先度**: P0
+- **依存**: Task 7
+
+## Phase 2: マニフェスト更新
+
+### Task 9: Step 8 — package.json 更新 ✅
+- **内容**:
+  - `package.json` を Read。存在しなければスキップ
+  - 既存 `"license"` フィールドを確認
+  - 同一 SPDX → スキップ。異なる → AskUserQuestion で確認
+  - Edit で `"license": "<SPDX-ID>"` を設定
+- **優先度**: P1
+- **依存**: Task 8
+- **並列可能**: Task 10, Task 11 と並列不可（AskUserQuestion が逐次のため）
+
+### Task 10: Step 8 — Cargo.toml 更新 ✅
+- **内容**:
+  - `Cargo.toml` を Read。存在しなければスキップ
+  - `[package]` テーブルが存在しなければスキップ
+  - 既存 `license` フィールドを確認。同一 → スキップ。異なる → AskUserQuestion で確認
+  - Edit で `[package]` 内の `license = "<SPDX-ID>"` を設定
+- **優先度**: P1
+- **依存**: Task 8
+
+### Task 11: Step 8 — pyproject.toml 更新 ✅
+- **内容**:
+  - `pyproject.toml` を Read。存在しなければスキップ
+  - `[project]` テーブルが存在しなければスキップ
+  - 既存 `license` フィールドを確認:
+    - テーブル形式（`{text = "..."}` 等）→ スキップ + 警告表示
+    - 文字列形式で同一 → スキップ
+    - 文字列形式で異なる → AskUserQuestion で確認
+  - Edit で `[project]` 内の `license = "<SPDX-ID>"` を設定
+- **優先度**: P1
+- **依存**: Task 8
+
+## Phase 3: 仕上げ
+
+### Task 12: Step 9 — 結果報告 ✅
+- **内容**: 生成した LICENSE ファイルのパス、選択されたライセンス、更新したマニフェストの一覧を報告
+- **優先度**: P1
+- **依存**: Task 9, 10, 11
+
+### Task 13: specflow-install 対応確認 ✅
+- **内容**: `bin/specflow-install` が `global/commands/specflow.license.md` を `~/.claude/commands/` にコピーする既存ロジックでカバーされることを確認（`specflow.*.md` のグロブパターン）
+- **優先度**: P2
+- **依存**: Task 1


### PR DESCRIPTION
## Summary
- `/specflow.license` スラッシュコマンドを追加。`specflow-analyze` でプロジェクトを解析し、tech stack に基づいたライセンス推奨を提示
- 7種類のライセンス（MIT, Apache 2.0, GPL 3.0, BSD 2-Clause, ISC, AGPL 3.0, Unlicense）を2段階の AskUserQuestion UI で選択
- GitHub Licenses API からライセンス全文を取得し、年/著者名の自動置換を行い LICENSE ファイルを生成
- `package.json` / `Cargo.toml` / `pyproject.toml` の license フィールドを SPDX 識別子で自動更新

## Issue
Closes https://github.com/skr19930617/specflow/issues/57

## Test plan
- [ ] `specflow-install` 後に `~/.claude/commands/specflow.license.md` がコピーされることを確認
- [ ] `/specflow.license` を実行し、ライセンス選択 → LICENSE 生成の一連フローを確認
- [ ] 既存 LICENSE があるプロジェクトで上書き確認が表示されることを確認
- [ ] pyproject.toml のレガシー形式 license でスキップ + 警告が表示されることを確認