### PR TITLE
feat: introduce workflow state machine and run state core (#71)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # Specflow local env
 .specflow/config.env
+.specflow/runs/

--- a/bin/specflow-run
+++ b/bin/specflow-run
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Paths ──────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Resolve project root from git
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: not inside a git repository" >&2; exit 1
+}
+
+# State machine: prefer project-local, fall back to installed config
+if [[ -f "${PROJECT_ROOT}/global/workflow/state-machine.json" ]]; then
+  STATE_MACHINE="${PROJECT_ROOT}/global/workflow/state-machine.json"
+elif [[ -f "${HOME}/.config/specflow/global/workflow/state-machine.json" ]]; then
+  STATE_MACHINE="${HOME}/.config/specflow/global/workflow/state-machine.json"
+else
+  STATE_MACHINE=""  # will be caught by ensure_state_machine
+fi
+
+# Run state always lives in the project
+RUNS_DIR="${PROJECT_ROOT}/.specflow/runs"
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+die() {
+  echo "$1" >&2
+  exit 1
+}
+
+ensure_state_machine() {
+  [[ -n "$STATE_MACHINE" && -f "$STATE_MACHINE" ]] || die "Error: state-machine.json not found. Check global/workflow/ or ~/.config/specflow/global/workflow/"
+  jq empty "$STATE_MACHINE" 2>/dev/null || die "Error: state-machine.json is not valid JSON"
+}
+
+validate_run_id() {
+  local rid="$1"
+  # Reject path traversal and separators
+  if [[ "$rid" == *"/"* || "$rid" == *".."* || "$rid" == "." ]]; then
+    die "Error: invalid run_id '${rid}'. Must not contain '/' or '..'"
+  fi
+  # Verify corresponding OpenSpec change exists
+  if [[ ! -d "${PROJECT_ROOT}/openspec/changes/${rid}" ]]; then
+    die "Error: no OpenSpec change found for '${rid}'. Expected directory: openspec/changes/${rid}/"
+  fi
+}
+
+run_dir() {
+  echo "${RUNS_DIR}/${1}"
+}
+
+run_file() {
+  echo "$(run_dir "$1")/run.json"
+}
+
+ensure_run_exists() {
+  local rf
+  rf="$(run_file "$1")"
+  [[ -f "$rf" ]] || die "Error: run '${1}' not found. No state file at ${rf}"
+}
+
+now_iso() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+allowed_events_for() {
+  local state="$1"
+  jq -c --arg s "$state" '[.transitions[] | select(.from == $s) | .event]' "$STATE_MACHINE"
+}
+
+atomic_write() {
+  local target="$1"
+  local content="$2"
+  local dir
+  dir="$(dirname "$target")"
+  local tmp
+  tmp="$(mktemp "${dir}/run.json.XXXXXX")"
+  echo "$content" > "$tmp"
+  mv "$tmp" "$target"
+}
+
+# ── Subcommands ────────────────────────────────────────────────────────
+
+cmd_start() {
+  local run_id=""
+  local issue_url=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --issue-url)
+        [[ $# -ge 2 ]] || die "Error: --issue-url requires a value"
+        issue_url="$2"
+        shift 2
+        ;;
+      -*)
+        die "Error: unknown option '${1}'"
+        ;;
+      *)
+        if [[ -z "$run_id" ]]; then
+          run_id="$1"
+          shift
+        else
+          die "Error: unexpected argument '${1}'"
+        fi
+        ;;
+    esac
+  done
+
+  [[ -n "$run_id" ]] || die "Usage: specflow-run start <run_id> [--issue-url <url>]"
+
+  validate_run_id "$run_id"
+  ensure_state_machine
+
+  local rf
+  rf="$(run_file "$run_id")"
+  [[ ! -f "$rf" ]] || die "Error: run '${run_id}' already exists at ${rf}"
+
+  # Resolve issue metadata if --issue-url provided
+  local issue_json="null"
+  if [[ -n "$issue_url" ]]; then
+    local fetched
+    local fetch_cmd="${SPECFLOW_FETCH_ISSUE:-${SCRIPT_DIR}/specflow-fetch-issue}"
+    fetched="$("$fetch_cmd" "$issue_url" 2>&1)" || die "Error: failed to fetch issue metadata: ${fetched}"
+
+    # Derive repo from URL
+    local repo
+    repo="$(echo "$issue_url" | sed -n 's|^https://[^/]*/\([^/]*/[^/]*\)/issues/.*|\1|p')"
+    [[ -n "$repo" ]] || die "Error: could not derive repo from URL: ${issue_url}"
+
+    issue_json="$(echo "$fetched" | jq -c --arg repo "$repo" '{
+      url: .url,
+      number: .number,
+      title: .title,
+      repo: $repo
+    }')" || die "Error: failed to parse issue metadata"
+  fi
+
+  local ts
+  ts="$(now_iso)"
+  local allowed
+  allowed="$(allowed_events_for "start")"
+
+  local state_json
+  state_json="$(jq -n \
+    --arg rid "$run_id" \
+    --arg cn "$run_id" \
+    --arg ts "$ts" \
+    --argjson allowed "$allowed" \
+    --argjson issue "$issue_json" \
+    '{
+      run_id: $rid,
+      change_name: $cn,
+      current_phase: "start",
+      status: "active",
+      allowed_events: $allowed,
+      issue: $issue,
+      created_at: $ts,
+      updated_at: $ts,
+      history: []
+    }')"
+
+  mkdir -p "$(run_dir "$run_id")"
+  atomic_write "$rf" "$state_json"
+  echo "$state_json" | jq .
+}
+
+cmd_advance() {
+  local run_id="${1:-}"
+  local event="${2:-}"
+
+  [[ -n "$run_id" && -n "$event" ]] || die "Usage: specflow-run advance <run_id> <event>"
+
+  validate_run_id "$run_id"
+  ensure_state_machine
+  ensure_run_exists "$run_id"
+
+  local rf
+  rf="$(run_file "$run_id")"
+  local current
+  current="$(jq -r '.current_phase' "$rf")"
+
+  # Validate transition
+  local target
+  target="$(jq -r --arg from "$current" --arg evt "$event" \
+    '.transitions[] | select(.from == $from and .event == $evt) | .to' \
+    "$STATE_MACHINE")"
+
+  if [[ -z "$target" ]]; then
+    local allowed
+    allowed="$(jq -r --arg s "$current" \
+      '[.transitions[] | select(.from == $s) | .event] | join(", ")' \
+      "$STATE_MACHINE")"
+    die "Error: invalid transition. Event '${event}' is not allowed in state '${current}'. Allowed events: ${allowed}"
+  fi
+
+  local ts
+  ts="$(now_iso)"
+  local new_allowed
+  new_allowed="$(allowed_events_for "$target")"
+
+  local history_entry
+  history_entry="$(jq -n \
+    --arg from "$current" \
+    --arg to "$target" \
+    --arg evt "$event" \
+    --arg ts "$ts" \
+    '{ from: $from, to: $to, event: $evt, timestamp: $ts }')"
+
+  local updated
+  updated="$(jq \
+    --arg phase "$target" \
+    --arg ts "$ts" \
+    --argjson allowed "$new_allowed" \
+    --argjson entry "$history_entry" \
+    '.current_phase = $phase |
+     .updated_at = $ts |
+     .allowed_events = $allowed |
+     .history += [$entry]' \
+    "$rf")"
+
+  atomic_write "$rf" "$updated"
+  echo "$updated" | jq .
+}
+
+cmd_status() {
+  local run_id="${1:-}"
+  [[ -n "$run_id" ]] || die "Usage: specflow-run status <run_id>"
+
+  validate_run_id "$run_id"
+  ensure_run_exists "$run_id"
+
+  local rf
+  rf="$(run_file "$run_id")"
+  jq . "$rf"
+}
+
+# ── Main dispatch ──────────────────────────────────────────────────────
+
+subcmd="${1:-}"
+shift || true
+
+case "$subcmd" in
+  start)   cmd_start "$@" ;;
+  advance) cmd_advance "$@" ;;
+  status)  cmd_status "$@" ;;
+  "")      die "Usage: specflow-run <start|advance|status> [args...]" ;;
+  *)       die "Error: unknown subcommand '${subcmd}'. Use: start, advance, status" ;;
+esac

--- a/global/workflow/state-machine.json
+++ b/global/workflow/state-machine.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0",
+  "states": ["start", "proposal", "design", "apply", "approved", "rejected"],
+  "events": ["propose", "accept_proposal", "accept_design", "accept_apply", "reject", "revise"],
+  "transitions": [
+    { "from": "start", "event": "propose", "to": "proposal" },
+    { "from": "proposal", "event": "accept_proposal", "to": "design" },
+    { "from": "proposal", "event": "reject", "to": "rejected" },
+    { "from": "design", "event": "accept_design", "to": "apply" },
+    { "from": "design", "event": "revise", "to": "design" },
+    { "from": "design", "event": "reject", "to": "rejected" },
+    { "from": "apply", "event": "accept_apply", "to": "approved" },
+    { "from": "apply", "event": "revise", "to": "apply" },
+    { "from": "apply", "event": "reject", "to": "rejected" }
+  ]
+}

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/approval-summary.md
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/approval-summary.md
@@ -1,0 +1,78 @@
+# Approval Summary: workflow-state-machine
+
+**Generated**: 2026-04-09
+**Branch**: workflow-state-machine
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+ .gitignore                  |   1 +
+ bin/specflow-run            | 247 +++
+ global/workflow/state-machine.json | 16 +
+ tests/test-specflow-run.sh  | 195 +++
+ openspec/changes/workflow-state-machine/ (specs, design, tasks, ledgers)
+
+## Files Touched
+
+- `.gitignore` — added `.specflow/runs/` exclusion
+- `bin/specflow-run` — new: transition core CLI (start/advance/status)
+- `global/workflow/state-machine.json` — new: static workflow definition
+- `tests/test-specflow-run.sh` — new: 28-assertion test suite
+- `openspec/changes/workflow-state-machine/` — proposal, specs, design, tasks, ledgers
+
+## Review Loop Summary
+
+### Design Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 1     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 2     |
+
+### Impl Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 2     |
+| Resolved high      | 3     |
+| Unresolved high    | 0     |
+| New high (later)   | 1     |
+| Total rounds       | 3     |
+
+## Proposal Coverage
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | Static workflow definition at global/workflow/state-machine.json | Yes | global/workflow/state-machine.json |
+| 2 | Top-level phase states (start, proposal, design, apply, approved, rejected) | Yes | global/workflow/state-machine.json |
+| 3 | Event definitions (propose, accept_proposal, accept_design, accept_apply, reject, revise) | Yes | global/workflow/state-machine.json |
+| 4 | Transition rules (9 transitions, forward/reject/revise) | Yes | global/workflow/state-machine.json |
+| 5 | Per-run state file at .specflow/runs/<run_id>/run.json | Yes | bin/specflow-run |
+| 6 | Run state schema (run_id, change_name, current_phase, status, allowed_events, timestamps) | Yes | bin/specflow-run |
+| 7 | Run state history (append-only with from/to/event/timestamp) | Yes | bin/specflow-run |
+| 8 | Atomic write (mktemp + mv) | Yes | bin/specflow-run |
+| 9 | Git-ignore .specflow/runs/ | Yes | .gitignore |
+| 10 | Issue metadata via --issue-url | Yes | bin/specflow-run |
+| 11 | specflow-run start command | Yes | bin/specflow-run |
+| 12 | specflow-run advance command with transition validation | Yes | bin/specflow-run |
+| 13 | specflow-run status command | Yes | bin/specflow-run |
+| 14 | Runtime validation against state-machine.json | Yes | bin/specflow-run |
+| 15 | Command output format (JSON stdout, stderr errors) | Yes | bin/specflow-run |
+
+**Coverage Rate**: 15/15 (100%)
+
+## Remaining Risks
+
+- F6: Missing-run scenarios fail as missing change IDs instead of missing run state (severity: medium)
+- F4 (design): Issue lookup helper contract mismatch — repo field derived from URL, not from specflow-fetch-issue output (severity: medium, mitigated in implementation)
+- F5 (design): Run IDs not validated against change names in design doc (severity: medium, resolved in implementation via validate_run_id)
+- F6 (design): Post-transition invariants not fully in task plan (severity: medium, resolved in implementation and tests)
+
+## Human Checkpoints
+
+- [ ] Verify `specflow-run` works correctly when invoked via symlink from `~/bin/` (installed mode)
+- [ ] Confirm `state-machine.json` is copied to `~/.config/specflow/global/workflow/` by `specflow-install`
+- [ ] Test the reject flow: `specflow-run advance <id> reject` transitions to `rejected` state with no further allowed events
+- [ ] Verify `.specflow/runs/` is properly gitignored in downstream projects after `specflow-install`
+- [ ] Confirm `jq` is available in the target CI/deployment environment

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/current-phase.md
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/current-phase.md
@@ -1,0 +1,10 @@
+# Current Phase: workflow-state-machine
+
+- Phase: fix-review
+- Round: 3
+- Status: in_progress
+- Open High Findings: 0 件
+- Accepted Risks: none
+- Latest Changes:
+  (no commits yet)
+- Next Recommended Action: /specflow.approve

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/design.md
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/design.md
@@ -1,0 +1,131 @@
+## Context
+
+specflow のワークフロー制御は現在 slash commands（`global/commands/` の Markdown プロンプト）とシェルスクリプト（`bin/`）に分散している。各コマンドが独自に「次に何ができるか」を判断しており、状態遷移の一元的な定義が存在しない。
+
+既存の `bin/` スクリプト群は Bash + `jq` / `gh` で統一されている（例: `specflow-fetch-issue`, `specflow-init`）。新規スクリプトもこのスタックに従う。
+
+## Goals / Non-Goals
+
+**Goals:**
+- メインラインフロー（proposal → design → apply → approve/reject）の状態遷移を静的 JSON で宣言的に定義する
+- per-run の現在状態を `.specflow/runs/<run_id>/run.json` で追跡する
+- `specflow-run` コマンド群（start / advance / status）で遷移を一元管理する
+- 既存 slash commands と並行共存する（この change では既存コマンドを変更しない）
+
+**Non-Goals:**
+- Slack bot / dashboard の実装
+- fix_design / fix_apply のサブステート定義（revise イベントのセルフ遷移で対応）
+- 既存 slash commands の書き換え（後続 issue）
+- explore / spec / decompose 等ユーティリティコマンドのステート定義
+
+## Decisions
+
+### 1. state-machine.json のスキーマ設計
+
+**選択**: フラットな transitions 配列方式
+
+```json
+{
+  "version": "1.0",
+  "states": ["start", "proposal", "design", "apply", "approved", "rejected"],
+  "events": ["propose", "accept_proposal", "accept_design", "accept_apply", "reject", "revise"],
+  "transitions": [
+    { "from": "start", "event": "propose", "to": "proposal" },
+    { "from": "proposal", "event": "accept_proposal", "to": "design" },
+    { "from": "proposal", "event": "reject", "to": "rejected" },
+    { "from": "design", "event": "accept_design", "to": "apply" },
+    { "from": "design", "event": "revise", "to": "design" },
+    { "from": "design", "event": "reject", "to": "rejected" },
+    { "from": "apply", "event": "accept_apply", "to": "approved" },
+    { "from": "apply", "event": "revise", "to": "apply" },
+    { "from": "apply", "event": "reject", "to": "rejected" }
+  ]
+}
+```
+
+**代替案**: 状態ごとにネストしたオブジェクト形式（`{ "start": { "propose": "proposal" } }`）。
+**選択理由**: フラット配列は `jq` でのフィルタリング（`select(.from == "design")`）が容易で、拡張時の diff が最小。ネスト形式は人間の可読性がやや高いが、遷移の追加・削除時に構造変更が必要。
+
+### 2. run.json のスキーマ設計
+
+```json
+{
+  "run_id": "workflow-state-machine",
+  "change_name": "workflow-state-machine",
+  "current_phase": "start",
+  "status": "active",
+  "allowed_events": ["propose"],
+  "issue": null,
+  "created_at": "2026-04-08T12:00:00Z",
+  "updated_at": "2026-04-08T12:00:00Z",
+  "history": []
+}
+```
+
+**選択**: `allowed_events` を run.json に含める（遷移時に再計算）。
+**代替案**: `allowed_events` を省略し、消費側が state-machine.json から毎回計算する。
+**選択理由**: run.json を読むだけで「今何ができるか」がわかり、消費側の実装が簡潔になる。トレードオフとして run.json が state-machine.json と非同期になるリスクがあるが、advance 時に必ず再計算するため実質的な問題にはならない。
+
+### 3. specflow-run コマンドの構成
+
+単一スクリプト `bin/specflow-run` にサブコマンド方式で実装する。
+
+```
+specflow-run start <run_id> [--issue-url <url>]
+specflow-run advance <run_id> <event>
+specflow-run status <run_id>
+```
+
+**選択**: 単一ファイル + サブコマンド。
+**代替案**: `specflow-run-start`, `specflow-run-advance`, `specflow-run-status` の3ファイル。
+**選択理由**: 共通処理（パス解決、JSON 読み書き、state-machine ロード）の重複を避ける。既存の `openspec` CLI もサブコマンド方式を採用しており、一貫性がある。
+
+### 4. ファイル書き込みのアトミック性
+
+**選択**: 一時ファイルに書き込み → `mv` でリネーム。
+
+```bash
+tmp="$(mktemp "${RUN_DIR}/run.json.XXXXXX")"
+echo "$new_state" > "$tmp"
+mv "$tmp" "${RUN_DIR}/run.json"
+```
+
+**選択理由**: POSIX の `mv` は同一ファイルシステム内でアトミックであり、部分書き込みによる破損を防ぐ。Bash + jq 環境で追加依存なしに実現できる最もシンプルな方法。
+
+### 5. Issue メタデータの取得
+
+`specflow-run start --issue-url <url>` が指定された場合、既存の `specflow-fetch-issue` コマンドを利用して issue メタデータ（title, number, repo）を取得する。
+
+```bash
+issue_json="$(specflow-fetch-issue "$ISSUE_URL")"
+```
+
+`specflow-fetch-issue` は `gh issue view` を内部で呼び出し、`number`, `title`, `url`, `author` 等を JSON で返す。`specflow-run` はこの出力から必要なフィールドを `jq` で抽出し、`run.json` の `issue` オブジェクトに格納する。
+
+**エラーハンドリング**:
+- `specflow-fetch-issue` が非ゼロ終了 → `specflow-run start` も exit code 1 で終了し、stderr にエラーメッセージを出力
+- 無効な URL（`/issues/` パターンに一致しない） → `specflow-fetch-issue` が検出しエラーを返す
+
+### 6. ディレクトリ構成
+
+```
+global/workflow/
+  state-machine.json          # 静的ワークフロー定義（git 管理）
+
+bin/
+  specflow-run                # 遷移コアコマンド（git 管理）
+
+.specflow/runs/<run_id>/
+  run.json                    # per-run 状態（.gitignore 対象）
+```
+
+## Risks / Trade-offs
+
+- **[Risk] state-machine.json と既存 slash commands の乖離** → slash commands を変更しないため、定義と実際の挙動が一致しない期間が生じる。Mitigation: state-machine.json にコメントとして「この定義は新 transition-core 用。既存 slash commands は独立して動作」と記載し、後続 issue で統合する。
+- **[Risk] run.json の破損・不整合** → アトミック書き込み（mktemp + mv）で部分書き込みリスクを軽減。万一破損した場合は `specflow-run start --force` で再初期化可能にする（初期スコープ外だが、設計上の余地は残す）。
+- **[Risk] jq の可用性** → macOS では Homebrew、Linux では apt/yum で一般的に利用可能。既存スクリプトでは直接 jq を使っていないが、`openspec` CLI が JSON 出力を前提としており、jq は事実上の必須ツール。README に前提条件として記載する。
+- **[Trade-off] allowed_events の冗長保持** → run.json が state-machine.json と非同期になる可能性。advance 時に必ず state-machine.json から再計算するため、実質的に safe。
+
+## Open Questions
+
+- 将来的に `.specflow/runs/<run_id>/slack.json` 等の UI バインディングファイルを追加する場合、run.json 側に参照を持たせるか完全に分離するか（この change のスコープ外だが、ディレクトリ構造に影響する可能性がある）

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/proposal.md
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+specflow のワークフロー制御ロジック（状態遷移・許可アクション判定）が slash commands、プロンプト、handoff ボタン、スクリプトに分散しており、暗黙的な規約に依存している。このため、resumable run・複数 UI フロントエンド（Slack bot、ダッシュボード等）・状態監視が困難になっている。今がこの分離に適したタイミングである — OpenSpec ベースのフェーズ境界が明確化され、autofix/divergence 処理など運用が複雑化しつつあるため。
+
+## What Changes
+
+- ワークフロー遷移定義を静的な JSON ファイルとして `global/workflow/state-machine.json` に導入する
+- per-run の状態管理を `.specflow/runs/<run_id>/run.json` として導入する（run_id = change name）
+- UI バインディングメタデータを run state から分離する設計とする（将来の Slack 等向け）
+- 状態遷移を一元管理する内部エントリポイント（Bash + jq による `specflow-run` コマンド群）を導入する
+- 既存 slash commands とは並行共存させる（この change では既存コマンドを書き換えない。後続 issue で段階的に移行）
+
+### Design Decisions (from Clarify)
+
+- **状態粒度**: トップレベルフェーズのみ（proposal / design / apply / approve / reject）。サブステップ（clarify, validate, review 等）はフェーズ内部ロジックとして扱い、state-machine では管理しない
+- **run_id**: change name をそのまま使用（OpenSpec の change ディレクトリ名と 1:1 対応）
+- **実装言語**: Bash + jq（既存 bin/ スクリプト群と一貫性を保ち、新たなランタイム依存を追加しない）
+- **移行戦略**: 並行共存 — 既存 slash commands はそのまま動作。transition-core を並行で導入し、安定後に後続 issue で移行
+- **fix ループ**: 初期スコープには含めない。fix_design / fix_apply は各フェーズ内の revise イベントとしてモデルし、同フェーズに状態を戻すだけで表現
+
+## Capabilities
+
+### New Capabilities
+- `workflow-definition`: メインラインフローの静的ステートマシン定義（states, events, transitions）を JSON で管理する機能
+- `run-state-management`: per-run の状態（現在フェーズ、許可イベント、メタデータ等）を追跡・永続化する機能
+- `transition-core`: 遷移の妥当性検証と実行を一元管理するコアエントリポイント（`specflow-run start/advance/status`）
+
+### Modified Capabilities
+
+## Impact
+
+- `bin/` 配下のスクリプト — 新しい `specflow-run` コマンド群（start / advance / status）の追加
+- `global/workflow/` ディレクトリ — state-machine.json の保存先として新設
+- `.specflow/runs/` ディレクトリ — per-run state の保存先として新設（`.gitignore` 対象）
+- 既存 `global/commands/` および `bin/` の slash command スクリプトは**この change では変更しない**（並行共存）

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/review-ledger-design.json
@@ -1,0 +1,121 @@
+{
+  "feature_id": "workflow-state-machine",
+  "phase": "design",
+  "current_round": 2,
+  "status": "in_progress",
+  "max_finding_id": 6,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "design.md",
+      "title": "Transition/event model does not satisfy the required acceptance flow",
+      "detail": "The design declares `design_complete`, `apply_complete`, and `approve` in `events`, but the transition table and task sequence never use them. Instead, the design advances via `accept_design` and `accept_apply`, and task 4.1 tests that reduced path. This leaves required events unreachable and conflicts with the acceptance scenarios that explicitly reference `design_complete` in the forward path. Reconcile the event model before implementation: define the full transition table for every required event, then update allowed-events expectations and lifecycle tasks/tests to match that single model.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 2,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "feasibility",
+      "file": "design.md",
+      "title": "Issue metadata population is underspecified",
+      "detail": "The spec requires `specflow-run start --issue-url` to populate `issue.url`, `number`, `title`, and `repo`, but the design/tasks only mention an optional flag and do not define how metadata is resolved. `title` cannot be derived from the URL alone. Add an explicit lookup mechanism (for example `gh issue view` or an existing helper), plus defined failure behavior for invalid URLs or lookup failures, and include an implementation task for it.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 2,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "tasks.md",
+      "title": "CLI I/O and error-path requirements are not fully captured in the tasks",
+      "detail": "The spec requires successful subcommands to emit JSON on stdout, failures to write human-readable errors to stderr, invalid-transition errors to list allowed events, and `advance` on a nonexistent run to fail cleanly. The current tasks only cover part of that contract and do not explicitly require stdout/stderr behavior for `start` and `advance`. Add implementation and verification tasks for the command output contract and the missing `advance nonexistent-run` error case so the CLI cannot satisfy the task list while still failing acceptance.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 2,
+      "notes": ""
+    },
+    {
+      "id": "F4",
+      "severity": "medium",
+      "category": "feasibility",
+      "file": "openspec/changes/workflow-state-machine/design.md",
+      "title": "The chosen issue lookup helper does not actually satisfy the required issue contract",
+      "detail": "The design says `specflow-run start --issue-url` can populate `issue.url`, `number`, `title`, and `repo` by extracting fields from `specflow-fetch-issue`, but the existing helper only returns `number,title,body,url,labels,assignees,author,state` and not `repo`. Its invalid-URL branch also prints the error message to stdout, which conflicts with the `specflow-run` stderr-on-failure contract. Update the design and tasks to either extend `specflow-fetch-issue` to emit `repo` or specify explicit repo derivation and error redirection inside `specflow-run`, then add tests that assert the `repo` field and the stderr path.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 2,
+      "latest_round": 2,
+      "notes": ""
+    },
+    {
+      "id": "F5",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "openspec/changes/workflow-state-machine/design.md",
+      "title": "Run IDs are not constrained to real OpenSpec change names",
+      "detail": "The proposal and run-state spec treat `run_id` as the OpenSpec change name, but the design exposes `specflow-run start <run_id>` without any rule for validating that `openspec/changes/<run_id>` actually exists. That leaves the core invariant unenforced and allows orphan run directories that do not correspond to a change record. Specify whether the command derives the ID from the current change context or rejects unknown change names, and add an implementation and failure-path test for that behavior.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 2,
+      "latest_round": 2,
+      "notes": ""
+    },
+    {
+      "id": "F6",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "openspec/changes/workflow-state-machine/tasks.md",
+      "title": "The run-state update contract is not fully carried into the task plan",
+      "detail": "The run-state specs require `advance` to recompute `allowed_events`, refresh `updated_at`, and append a history entry containing `from`, `to`, `event`, and `timestamp` while preserving earlier history entries. The current tasks only say to update `run.json` atomically and append a history entry, with one revise test. That leaves several required post-transition invariants easy to miss. Add explicit implementation and verification tasks for `allowed_events` recomputation, `updated_at` refresh, history entry shape, and append-only history behavior across multiple transitions.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 2,
+      "latest_round": 2,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 6,
+      "open": 0,
+      "new": 3,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 1, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 2, "new": 3, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/review-ledger-design.json.bak
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/review-ledger-design.json.bak
@@ -1,0 +1,66 @@
+{
+  "feature_id": "workflow-state-machine",
+  "phase": "design",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "design.md",
+      "title": "Transition/event model does not satisfy the required acceptance flow",
+      "detail": "The design declares `design_complete`, `apply_complete`, and `approve` in `events`, but the transition table and task sequence never use them. Instead, the design advances via `accept_design` and `accept_apply`, and task 4.1 tests that reduced path. This leaves required events unreachable and conflicts with the acceptance scenarios that explicitly reference `design_complete` in the forward path. Reconcile the event model before implementation: define the full transition table for every required event, then update allowed-events expectations and lifecycle tasks/tests to match that single model.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 1,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "feasibility",
+      "file": "design.md",
+      "title": "Issue metadata population is underspecified",
+      "detail": "The spec requires `specflow-run start --issue-url` to populate `issue.url`, `number`, `title`, and `repo`, but the design/tasks only mention an optional flag and do not define how metadata is resolved. `title` cannot be derived from the URL alone. Add an explicit lookup mechanism (for example `gh issue view` or an existing helper), plus defined failure behavior for invalid URLs or lookup failures, and include an implementation task for it.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 1,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "tasks.md",
+      "title": "CLI I/O and error-path requirements are not fully captured in the tasks",
+      "detail": "The spec requires successful subcommands to emit JSON on stdout, failures to write human-readable errors to stderr, invalid-transition errors to list allowed events, and `advance` on a nonexistent run to fail cleanly. The current tasks only cover part of that contract and do not explicitly require stdout/stderr behavior for `start` and `advance`. Add implementation and verification tasks for the command output contract and the missing `advance nonexistent-run` error case so the CLI cannot satisfy the task list while still failing acceptance.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 1,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/review-ledger.json
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/review-ledger.json
@@ -1,0 +1,134 @@
+{
+  "feature_id": "workflow-state-machine",
+  "phase": "impl",
+  "current_round": 3,
+  "status": "in_progress",
+  "max_finding_id": 6,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "bin/specflow-run",
+      "title": "The command resolves state paths relative to the script checkout instead of the initialized project",
+      "detail": "STATE_MACHINE and RUNS_DIR are derived from SCRIPT_DIR/..",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 2,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "error_handling",
+      "file": "bin/specflow-run",
+      "title": "run_id is used as a raw filesystem path segment with no validation",
+      "detail": "run_dir/run_file interpolate the CLI-provided run_id directly into paths.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 2,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "testing",
+      "file": "bin/specflow-run",
+      "title": "The new transition core ships with no checked-in test coverage",
+      "detail": "This diff adds non-trivial workflow logic but contains no executable tests.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 1,
+      "latest_round": 2,
+      "notes": ""
+    },
+    {
+      "id": "F4",
+      "severity": "high",
+      "category": "correctness",
+      "file": "bin/specflow-run",
+      "title": "Installed config takes precedence over the checked-in state machine",
+      "detail": "The script prefers ~/.config/specflow/ over PROJECT_ROOT/global/workflow/.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 2,
+      "latest_round": 3,
+      "notes": ""
+    },
+    {
+      "id": "F5",
+      "severity": "medium",
+      "category": "testing",
+      "file": "tests/test-specflow-run.sh",
+      "title": "Test suite depends on live GitHub access and gh authentication",
+      "detail": "The --issue-url test uses a real GitHub issue URL via specflow-fetch-issue/gh.",
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 2,
+      "latest_round": 3,
+      "notes": ""
+    },
+    {
+      "id": "F6",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "bin/specflow-run",
+      "title": "Missing-run scenarios now fail as missing change IDs instead of missing run state",
+      "detail": "cmd_advance and cmd_status call validate_run_id before ensure_run_exists. nonexistent-run fails with 'no OpenSpec change found' rather than 'run not found'.",
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "origin_round": 3,
+      "latest_round": 3,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 0,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 0, "new": 2, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 0, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 2,
+      "total": 5,
+      "open": 0,
+      "new": 2,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 2, "new": 1, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 1, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    },
+    {
+      "round": 3,
+      "total": 6,
+      "open": 0,
+      "new": 1,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": { "open": 0, "resolved": 3, "new": 0, "overridden": 0 },
+        "medium": { "open": 0, "resolved": 2, "new": 1, "overridden": 0 },
+        "low": { "open": 0, "resolved": 0, "new": 0, "overridden": 0 }
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/review-ledger.json.bak
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/review-ledger.json.bak
@@ -1,0 +1,18 @@
+{
+  "feature_id": "workflow-state-machine",
+  "phase": "impl",
+  "current_round": 2,
+  "status": "has_open_high",
+  "max_finding_id": 5,
+  "findings": [
+    {"id": "R1-F01", "severity": "high", "status": "resolved", "origin_round": 1, "latest_round": 2},
+    {"id": "R1-F02", "severity": "high", "status": "resolved", "origin_round": 1, "latest_round": 2},
+    {"id": "R1-F03", "severity": "medium", "status": "resolved", "origin_round": 1, "latest_round": 2},
+    {"id": "F4", "severity": "high", "status": "new", "origin_round": 2, "latest_round": 2},
+    {"id": "F5", "severity": "medium", "status": "new", "origin_round": 2, "latest_round": 2}
+  ],
+  "round_summaries": [
+    {"round": 1, "total": 3, "open": 0, "new": 3, "resolved": 0, "overridden": 0},
+    {"round": 2, "total": 5, "open": 0, "new": 2, "resolved": 3, "overridden": 0}
+  ]
+}

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/specs/run-state-management/spec.md
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/specs/run-state-management/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Per-run state file
+The system SHALL store per-run state at `.specflow/runs/<run_id>/run.json` where `run_id` equals the OpenSpec change name.
+
+#### Scenario: Run state file is created on run start
+- **WHEN** a new run is started for change `workflow-state-machine`
+- **THEN** the file `.specflow/runs/workflow-state-machine/run.json` SHALL be created
+- **THEN** the file SHALL be valid JSON
+
+#### Scenario: Run state directory structure
+- **WHEN** the `.specflow/runs/` directory is listed
+- **THEN** each subdirectory name SHALL match the corresponding OpenSpec change name
+
+### Requirement: Run state schema
+The run state JSON SHALL contain the following fields: `run_id`, `change_name`, `current_phase`, `status`, `allowed_events`, `created_at`, `updated_at`.
+
+#### Scenario: Initial run state contents
+- **WHEN** a run is newly created
+- **THEN** the JSON SHALL contain `run_id` equal to the change name
+- **THEN** `change_name` SHALL equal the change name
+- **THEN** `current_phase` SHALL be `start`
+- **THEN** `status` SHALL be `active`
+- **THEN** `allowed_events` SHALL list events valid for the `start` state
+- **THEN** `created_at` and `updated_at` SHALL be ISO 8601 timestamps
+
+#### Scenario: Run state after transition
+- **WHEN** a transition advances the run from `start` to `proposal`
+- **THEN** `current_phase` SHALL be `proposal`
+- **THEN** `allowed_events` SHALL be recomputed from the workflow definition for the `proposal` state
+- **THEN** `updated_at` SHALL be updated to the current time
+
+### Requirement: Run state history
+The run state SHALL include a `history` array that records each transition event with timestamp.
+
+#### Scenario: History entry on transition
+- **WHEN** the run transitions from `proposal` to `design` via `accept_proposal`
+- **THEN** a new entry SHALL be appended to `history` with `from`, `to`, `event`, and `timestamp` fields
+
+#### Scenario: History is append-only
+- **WHEN** multiple transitions occur
+- **THEN** all previous history entries SHALL be preserved and the new entry SHALL be appended at the end
+
+### Requirement: Run state immutability pattern
+Run state updates SHALL create a new JSON object rather than mutating the existing file in place. The file SHALL be written atomically (write to temp file then rename).
+
+#### Scenario: Atomic write on transition
+- **WHEN** a transition updates the run state
+- **THEN** the system SHALL write to a temporary file in the same directory first
+- **THEN** the system SHALL rename the temporary file to `run.json`
+
+### Requirement: Git-ignore run state
+The `.specflow/runs/` directory SHALL be excluded from version control.
+
+#### Scenario: Gitignore entry exists
+- **WHEN** the `.gitignore` file is inspected
+- **THEN** it SHALL contain an entry that matches `.specflow/runs/`
+
+### Requirement: Issue metadata in run state
+When the run is started from a GitHub issue, the run state SHALL include an `issue` object with `url`, `number`, `title`, and `repo` fields. When started from inline spec, the `issue` field SHALL be `null`.
+
+#### Scenario: Run started from issue URL
+- **WHEN** a run is started with a GitHub issue URL
+- **THEN** the `issue` object SHALL contain `url`, `number`, `title`, and `repo`
+
+#### Scenario: Run started from inline spec
+- **WHEN** a run is started from inline text (no issue URL)
+- **THEN** the `issue` field SHALL be `null`

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/specs/transition-core/spec.md
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/specs/transition-core/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: specflow-run start command
+The system SHALL provide a `specflow-run start <run_id>` command that initializes a new run with the `start` state and creates the run state file.
+
+#### Scenario: Start a new run
+- **WHEN** `specflow-run start workflow-state-machine` is executed
+- **THEN** the command SHALL create `.specflow/runs/workflow-state-machine/run.json` with `current_phase: "start"`
+- **THEN** the command SHALL exit with code 0
+- **THEN** the command SHALL output the initial run state as JSON to stdout
+
+#### Scenario: Start with issue metadata
+- **WHEN** `specflow-run start workflow-state-machine --issue-url "https://github.com/owner/repo/issues/71"` is executed
+- **THEN** the run state SHALL include the `issue` object populated from the URL
+
+#### Scenario: Start when run already exists
+- **WHEN** `specflow-run start workflow-state-machine` is executed and a run state file already exists
+- **THEN** the command SHALL exit with code 1
+- **THEN** the command SHALL output an error message indicating the run already exists
+
+### Requirement: specflow-run advance command
+The system SHALL provide a `specflow-run advance <run_id> <event>` command that validates and applies a state transition.
+
+#### Scenario: Valid transition
+- **WHEN** `specflow-run advance workflow-state-machine propose` is executed while the run is in `start` state
+- **THEN** the run state SHALL transition to `proposal`
+- **THEN** the command SHALL exit with code 0
+- **THEN** the command SHALL output the updated run state as JSON to stdout
+
+#### Scenario: Invalid transition
+- **WHEN** `specflow-run advance workflow-state-machine approve` is executed while the run is in `start` state
+- **THEN** the command SHALL exit with code 1
+- **THEN** the command SHALL output an error message listing the allowed events for the current state
+- **THEN** the run state SHALL remain unchanged
+
+#### Scenario: Run does not exist
+- **WHEN** `specflow-run advance nonexistent-run propose` is executed
+- **THEN** the command SHALL exit with code 1
+- **THEN** the command SHALL output an error message indicating the run was not found
+
+#### Scenario: Revise event self-transition
+- **WHEN** `specflow-run advance workflow-state-machine revise` is executed while the run is in `design` state
+- **THEN** the run state SHALL remain in `design`
+- **THEN** a history entry SHALL be recorded with `from: "design"`, `to: "design"`, `event: "revise"`
+
+### Requirement: specflow-run status command
+The system SHALL provide a `specflow-run status <run_id>` command that outputs the current run state as JSON.
+
+#### Scenario: Status of existing run
+- **WHEN** `specflow-run status workflow-state-machine` is executed
+- **THEN** the command SHALL output the full run state JSON to stdout
+- **THEN** the command SHALL exit with code 0
+
+#### Scenario: Status of nonexistent run
+- **WHEN** `specflow-run status nonexistent-run` is executed
+- **THEN** the command SHALL exit with code 1
+- **THEN** the command SHALL output an error message
+
+### Requirement: Transition validation against workflow definition
+The `advance` command SHALL load `global/workflow/state-machine.json` and validate that the requested event is a valid transition from the current state before applying it.
+
+#### Scenario: Validation reads definition at runtime
+- **WHEN** a transition is requested
+- **THEN** the command SHALL read `global/workflow/state-machine.json` to determine validity
+- **THEN** the command SHALL NOT hardcode transition rules in the script itself
+
+#### Scenario: Modified definition is reflected immediately
+- **WHEN** `state-machine.json` is modified to add a new transition
+- **THEN** the next `advance` call SHALL recognize the new transition without restarting any process
+
+### Requirement: Command output format
+All `specflow-run` subcommands SHALL output JSON to stdout for success responses and plain text error messages to stderr for failures.
+
+#### Scenario: Success output is JSON
+- **WHEN** any subcommand succeeds
+- **THEN** stdout SHALL contain valid JSON
+- **THEN** stderr SHALL be empty
+
+#### Scenario: Error output to stderr
+- **WHEN** any subcommand fails
+- **THEN** stderr SHALL contain a human-readable error message
+- **THEN** the exit code SHALL be non-zero

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/specs/workflow-definition/spec.md
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/specs/workflow-definition/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Static workflow definition file
+The system SHALL maintain a machine-readable workflow definition at `global/workflow/state-machine.json` that declares all valid states, events, and transitions for the specflow mainline flow.
+
+#### Scenario: Definition file exists and is valid JSON
+- **WHEN** the file `global/workflow/state-machine.json` is read
+- **THEN** it SHALL parse as valid JSON containing `states`, `events`, and `transitions` keys
+
+#### Scenario: Definition file is consumable by jq
+- **WHEN** the file is piped to `jq '.'`
+- **THEN** the command SHALL exit with code 0 and produce valid output
+
+### Requirement: Top-level phase states
+The workflow definition SHALL define exactly the following top-level states for the initial scope: `start`, `proposal`, `design`, `apply`, `approved`, `rejected`.
+
+#### Scenario: All mainline states are present
+- **WHEN** the `states` array in the definition is inspected
+- **THEN** it SHALL contain exactly: `start`, `proposal`, `design`, `apply`, `approved`, `rejected`
+
+#### Scenario: No sub-phase states exist
+- **WHEN** the `states` array is inspected
+- **THEN** it SHALL NOT contain sub-phase entries such as `proposal.clarify`, `proposal.validate`, `design.review`, or similar dotted names
+
+### Requirement: Event definitions
+The workflow definition SHALL declare named events that trigger transitions between states. Events SHALL include at minimum: `propose`, `accept_proposal`, `accept_design`, `accept_apply`, `reject`, and `revise`.
+
+#### Scenario: Mainline forward events are defined
+- **WHEN** the `events` array is inspected
+- **THEN** it SHALL contain `propose`, `accept_proposal`, `accept_design`, and `accept_apply`
+
+#### Scenario: Reject event is defined
+- **WHEN** the `events` array is inspected
+- **THEN** it SHALL contain `reject`
+
+#### Scenario: Revise event is defined for fix loops
+- **WHEN** the `events` array is inspected
+- **THEN** it SHALL contain `revise`
+
+### Requirement: Transition rules
+Each transition SHALL specify a `from` state, an `event`, and a `to` state. Only transitions declared in the definition SHALL be considered valid.
+
+#### Scenario: Forward flow transitions
+- **WHEN** the mainline flow is followed from `start` to `approved`
+- **THEN** the transitions SHALL form the path: `start` →(propose)→ `proposal` →(accept_proposal)→ `design` →(accept_design)→ `apply` →(accept_apply)→ `approved`
+
+#### Scenario: Reject transition from any active phase
+- **WHEN** the `reject` event is applied to any of `proposal`, `design`, `apply`
+- **THEN** the transition SHALL lead to the `rejected` state
+
+#### Scenario: Revise event returns to same phase
+- **WHEN** the `revise` event is applied to `design` or `apply`
+- **THEN** the `to` state SHALL equal the `from` state (self-transition)
+
+### Requirement: Allowed events per state
+The workflow definition SHALL provide a way to derive which events are valid for a given state by filtering transitions by `from` state.
+
+#### Scenario: Query allowed events for a state
+- **WHEN** a consumer queries transitions where `from` equals `design`
+- **THEN** the result SHALL include events `accept_design`, `reject`, and `revise`
+- **THEN** the result SHALL NOT include events belonging to other phases such as `propose` or `approve`

--- a/openspec/changes/archive/2026-04-08-workflow-state-machine/tasks.md
+++ b/openspec/changes/archive/2026-04-08-workflow-state-machine/tasks.md
@@ -1,0 +1,32 @@
+## 1. Workflow Definition
+
+- [x] 1.1 Create `global/workflow/` directory
+- [x] 1.2 Create `global/workflow/state-machine.json` with states, events, and transitions arrays as defined in design.md
+- [x] 1.3 Validate the JSON is parseable by `jq` and contains all required states/events/transitions
+
+## 2. Run State Infrastructure
+
+- [x] 2.1 Create `.specflow/` directory structure (`.specflow/runs/` will be created on first run)
+- [x] 2.2 Add `.specflow/runs/` to `.gitignore`
+
+## 3. specflow-run Command
+
+- [x] 3.1 Create `bin/specflow-run` with subcommand dispatch (start / advance / status) and shared helper functions
+- [x] 3.2 Implement `start` subcommand — create run.json with initial state, allowed_events, optional --issue-url flag (use `specflow-fetch-issue` to resolve issue metadata)
+- [x] 3.3 Implement `advance` subcommand — load state-machine.json, validate transition, update run.json atomically (mktemp + mv), append history entry
+- [x] 3.4 Implement `status` subcommand — read and output run.json
+- [x] 3.5 Implement CLI output contract: success → JSON to stdout, failure → human-readable error to stderr with non-zero exit code
+- [x] 3.6 Implement error detail: invalid transition lists allowed events for the current state in error message
+- [x] 3.7 Make `bin/specflow-run` executable (`chmod +x`)
+
+## 4. Testing
+
+- [x] 4.1 Test full lifecycle: start → propose → accept_proposal → accept_design → accept_apply → approved
+- [x] 4.2 Test invalid transition is rejected with correct error message and exit code 1
+- [x] 4.3 Test revise self-transition records history entry correctly
+- [x] 4.4 Test start with --issue-url populates issue metadata
+- [x] 4.5 Test start when run already exists returns error
+- [x] 4.6 Test status of nonexistent run returns error
+- [x] 4.7 Test advance on nonexistent run returns error with exit code 1
+- [x] 4.8 Test start with invalid --issue-url returns error
+- [x] 4.9 Verify all success outputs are valid JSON on stdout and all error outputs go to stderr

--- a/openspec/specs/run-state-management/spec.md
+++ b/openspec/specs/run-state-management/spec.md
@@ -1,0 +1,72 @@
+# run-state-management Specification
+
+## Purpose
+TBD - created by archiving change workflow-state-machine. Update Purpose after archive.
+## Requirements
+### Requirement: Per-run state file
+The system SHALL store per-run state at `.specflow/runs/<run_id>/run.json` where `run_id` equals the OpenSpec change name.
+
+#### Scenario: Run state file is created on run start
+- **WHEN** a new run is started for change `workflow-state-machine`
+- **THEN** the file `.specflow/runs/workflow-state-machine/run.json` SHALL be created
+- **THEN** the file SHALL be valid JSON
+
+#### Scenario: Run state directory structure
+- **WHEN** the `.specflow/runs/` directory is listed
+- **THEN** each subdirectory name SHALL match the corresponding OpenSpec change name
+
+### Requirement: Run state schema
+The run state JSON SHALL contain the following fields: `run_id`, `change_name`, `current_phase`, `status`, `allowed_events`, `created_at`, `updated_at`.
+
+#### Scenario: Initial run state contents
+- **WHEN** a run is newly created
+- **THEN** the JSON SHALL contain `run_id` equal to the change name
+- **THEN** `change_name` SHALL equal the change name
+- **THEN** `current_phase` SHALL be `start`
+- **THEN** `status` SHALL be `active`
+- **THEN** `allowed_events` SHALL list events valid for the `start` state
+- **THEN** `created_at` and `updated_at` SHALL be ISO 8601 timestamps
+
+#### Scenario: Run state after transition
+- **WHEN** a transition advances the run from `start` to `proposal`
+- **THEN** `current_phase` SHALL be `proposal`
+- **THEN** `allowed_events` SHALL be recomputed from the workflow definition for the `proposal` state
+- **THEN** `updated_at` SHALL be updated to the current time
+
+### Requirement: Run state history
+The run state SHALL include a `history` array that records each transition event with timestamp.
+
+#### Scenario: History entry on transition
+- **WHEN** the run transitions from `proposal` to `design` via `accept_proposal`
+- **THEN** a new entry SHALL be appended to `history` with `from`, `to`, `event`, and `timestamp` fields
+
+#### Scenario: History is append-only
+- **WHEN** multiple transitions occur
+- **THEN** all previous history entries SHALL be preserved and the new entry SHALL be appended at the end
+
+### Requirement: Run state immutability pattern
+Run state updates SHALL create a new JSON object rather than mutating the existing file in place. The file SHALL be written atomically (write to temp file then rename).
+
+#### Scenario: Atomic write on transition
+- **WHEN** a transition updates the run state
+- **THEN** the system SHALL write to a temporary file in the same directory first
+- **THEN** the system SHALL rename the temporary file to `run.json`
+
+### Requirement: Git-ignore run state
+The `.specflow/runs/` directory SHALL be excluded from version control.
+
+#### Scenario: Gitignore entry exists
+- **WHEN** the `.gitignore` file is inspected
+- **THEN** it SHALL contain an entry that matches `.specflow/runs/`
+
+### Requirement: Issue metadata in run state
+When the run is started from a GitHub issue, the run state SHALL include an `issue` object with `url`, `number`, `title`, and `repo` fields. When started from inline spec, the `issue` field SHALL be `null`.
+
+#### Scenario: Run started from issue URL
+- **WHEN** a run is started with a GitHub issue URL
+- **THEN** the `issue` object SHALL contain `url`, `number`, `title`, and `repo`
+
+#### Scenario: Run started from inline spec
+- **WHEN** a run is started from inline text (no issue URL)
+- **THEN** the `issue` field SHALL be `null`
+

--- a/openspec/specs/transition-core/spec.md
+++ b/openspec/specs/transition-core/spec.md
@@ -1,0 +1,86 @@
+# transition-core Specification
+
+## Purpose
+TBD - created by archiving change workflow-state-machine. Update Purpose after archive.
+## Requirements
+### Requirement: specflow-run start command
+The system SHALL provide a `specflow-run start <run_id>` command that initializes a new run with the `start` state and creates the run state file.
+
+#### Scenario: Start a new run
+- **WHEN** `specflow-run start workflow-state-machine` is executed
+- **THEN** the command SHALL create `.specflow/runs/workflow-state-machine/run.json` with `current_phase: "start"`
+- **THEN** the command SHALL exit with code 0
+- **THEN** the command SHALL output the initial run state as JSON to stdout
+
+#### Scenario: Start with issue metadata
+- **WHEN** `specflow-run start workflow-state-machine --issue-url "https://github.com/owner/repo/issues/71"` is executed
+- **THEN** the run state SHALL include the `issue` object populated from the URL
+
+#### Scenario: Start when run already exists
+- **WHEN** `specflow-run start workflow-state-machine` is executed and a run state file already exists
+- **THEN** the command SHALL exit with code 1
+- **THEN** the command SHALL output an error message indicating the run already exists
+
+### Requirement: specflow-run advance command
+The system SHALL provide a `specflow-run advance <run_id> <event>` command that validates and applies a state transition.
+
+#### Scenario: Valid transition
+- **WHEN** `specflow-run advance workflow-state-machine propose` is executed while the run is in `start` state
+- **THEN** the run state SHALL transition to `proposal`
+- **THEN** the command SHALL exit with code 0
+- **THEN** the command SHALL output the updated run state as JSON to stdout
+
+#### Scenario: Invalid transition
+- **WHEN** `specflow-run advance workflow-state-machine approve` is executed while the run is in `start` state
+- **THEN** the command SHALL exit with code 1
+- **THEN** the command SHALL output an error message listing the allowed events for the current state
+- **THEN** the run state SHALL remain unchanged
+
+#### Scenario: Run does not exist
+- **WHEN** `specflow-run advance nonexistent-run propose` is executed
+- **THEN** the command SHALL exit with code 1
+- **THEN** the command SHALL output an error message indicating the run was not found
+
+#### Scenario: Revise event self-transition
+- **WHEN** `specflow-run advance workflow-state-machine revise` is executed while the run is in `design` state
+- **THEN** the run state SHALL remain in `design`
+- **THEN** a history entry SHALL be recorded with `from: "design"`, `to: "design"`, `event: "revise"`
+
+### Requirement: specflow-run status command
+The system SHALL provide a `specflow-run status <run_id>` command that outputs the current run state as JSON.
+
+#### Scenario: Status of existing run
+- **WHEN** `specflow-run status workflow-state-machine` is executed
+- **THEN** the command SHALL output the full run state JSON to stdout
+- **THEN** the command SHALL exit with code 0
+
+#### Scenario: Status of nonexistent run
+- **WHEN** `specflow-run status nonexistent-run` is executed
+- **THEN** the command SHALL exit with code 1
+- **THEN** the command SHALL output an error message
+
+### Requirement: Transition validation against workflow definition
+The `advance` command SHALL load `global/workflow/state-machine.json` and validate that the requested event is a valid transition from the current state before applying it.
+
+#### Scenario: Validation reads definition at runtime
+- **WHEN** a transition is requested
+- **THEN** the command SHALL read `global/workflow/state-machine.json` to determine validity
+- **THEN** the command SHALL NOT hardcode transition rules in the script itself
+
+#### Scenario: Modified definition is reflected immediately
+- **WHEN** `state-machine.json` is modified to add a new transition
+- **THEN** the next `advance` call SHALL recognize the new transition without restarting any process
+
+### Requirement: Command output format
+All `specflow-run` subcommands SHALL output JSON to stdout for success responses and plain text error messages to stderr for failures.
+
+#### Scenario: Success output is JSON
+- **WHEN** any subcommand succeeds
+- **THEN** stdout SHALL contain valid JSON
+- **THEN** stderr SHALL be empty
+
+#### Scenario: Error output to stderr
+- **WHEN** any subcommand fails
+- **THEN** stderr SHALL contain a human-readable error message
+- **THEN** the exit code SHALL be non-zero
+

--- a/openspec/specs/workflow-definition/spec.md
+++ b/openspec/specs/workflow-definition/spec.md
@@ -1,0 +1,65 @@
+# workflow-definition Specification
+
+## Purpose
+TBD - created by archiving change workflow-state-machine. Update Purpose after archive.
+## Requirements
+### Requirement: Static workflow definition file
+The system SHALL maintain a machine-readable workflow definition at `global/workflow/state-machine.json` that declares all valid states, events, and transitions for the specflow mainline flow.
+
+#### Scenario: Definition file exists and is valid JSON
+- **WHEN** the file `global/workflow/state-machine.json` is read
+- **THEN** it SHALL parse as valid JSON containing `states`, `events`, and `transitions` keys
+
+#### Scenario: Definition file is consumable by jq
+- **WHEN** the file is piped to `jq '.'`
+- **THEN** the command SHALL exit with code 0 and produce valid output
+
+### Requirement: Top-level phase states
+The workflow definition SHALL define exactly the following top-level states for the initial scope: `start`, `proposal`, `design`, `apply`, `approved`, `rejected`.
+
+#### Scenario: All mainline states are present
+- **WHEN** the `states` array in the definition is inspected
+- **THEN** it SHALL contain exactly: `start`, `proposal`, `design`, `apply`, `approved`, `rejected`
+
+#### Scenario: No sub-phase states exist
+- **WHEN** the `states` array is inspected
+- **THEN** it SHALL NOT contain sub-phase entries such as `proposal.clarify`, `proposal.validate`, `design.review`, or similar dotted names
+
+### Requirement: Event definitions
+The workflow definition SHALL declare named events that trigger transitions between states. Events SHALL include at minimum: `propose`, `accept_proposal`, `accept_design`, `accept_apply`, `reject`, and `revise`.
+
+#### Scenario: Mainline forward events are defined
+- **WHEN** the `events` array is inspected
+- **THEN** it SHALL contain `propose`, `accept_proposal`, `accept_design`, and `accept_apply`
+
+#### Scenario: Reject event is defined
+- **WHEN** the `events` array is inspected
+- **THEN** it SHALL contain `reject`
+
+#### Scenario: Revise event is defined for fix loops
+- **WHEN** the `events` array is inspected
+- **THEN** it SHALL contain `revise`
+
+### Requirement: Transition rules
+Each transition SHALL specify a `from` state, an `event`, and a `to` state. Only transitions declared in the definition SHALL be considered valid.
+
+#### Scenario: Forward flow transitions
+- **WHEN** the mainline flow is followed from `start` to `approved`
+- **THEN** the transitions SHALL form the path: `start` →(propose)→ `proposal` →(accept_proposal)→ `design` →(accept_design)→ `apply` →(accept_apply)→ `approved`
+
+#### Scenario: Reject transition from any active phase
+- **WHEN** the `reject` event is applied to any of `proposal`, `design`, `apply`
+- **THEN** the transition SHALL lead to the `rejected` state
+
+#### Scenario: Revise event returns to same phase
+- **WHEN** the `revise` event is applied to `design` or `apply`
+- **THEN** the `to` state SHALL equal the `from` state (self-transition)
+
+### Requirement: Allowed events per state
+The workflow definition SHALL provide a way to derive which events are valid for a given state by filtering transitions by `from` state.
+
+#### Scenario: Query allowed events for a state
+- **WHEN** a consumer queries transitions where `from` equals `design`
+- **THEN** the result SHALL include events `accept_design`, `reject`, and `revise`
+- **THEN** the result SHALL NOT include events belonging to other phases such as `propose` or `approve`
+

--- a/tests/test-specflow-run.sh
+++ b/tests/test-specflow-run.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# ── Test runner for specflow-run ──────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BIN="${REPO_ROOT}/bin/specflow-run"
+RUNS_DIR="${REPO_ROOT}/.specflow/runs"
+PASS=0
+FAIL=0
+STUB_DIR=""
+
+setup_stubs() {
+  STUB_DIR="$(mktemp -d)"
+  # Create a fake specflow-fetch-issue that returns deterministic JSON
+  cat > "${STUB_DIR}/specflow-fetch-issue" <<'STUB'
+#!/usr/bin/env bash
+# Stub: return fixed issue metadata for valid URLs, error for invalid
+URL="$1"
+if echo "$URL" | grep -q '/issues/[0-9]'; then
+  echo '{"number":71,"title":"Test issue title","body":"test body","url":"https://github.com/skr19930617/specflow/issues/71","labels":[],"assignees":[],"author":{"login":"test"},"state":"OPEN"}'
+else
+  echo "Invalid GitHub issue URL: $URL" >&2
+  exit 1
+fi
+STUB
+  chmod +x "${STUB_DIR}/specflow-fetch-issue"
+  export SPECFLOW_FETCH_ISSUE="${STUB_DIR}/specflow-fetch-issue"
+}
+
+teardown_stubs() {
+  [[ -n "$STUB_DIR" && -d "$STUB_DIR" ]] && rm -rf "$STUB_DIR"
+}
+
+cleanup() {
+  rm -rf "${RUNS_DIR}/workflow-state-machine"
+}
+
+setup_stubs
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: ${label}"
+    ((PASS++))
+  else
+    echo "  FAIL: ${label} — expected '${expected}', got '${actual}'"
+    ((FAIL++))
+  fi
+}
+
+assert_exit() {
+  local label="$1" expected_code="$2"
+  shift 2
+  local actual_code=0
+  "$@" >/dev/null 2>/dev/null || actual_code=$?
+  assert_eq "$label" "$expected_code" "$actual_code"
+}
+
+assert_json_field() {
+  local label="$1" json="$2" field="$3" expected="$4"
+  local actual
+  actual="$(echo "$json" | jq -r "$field")"
+  assert_eq "$label" "$expected" "$actual"
+}
+
+assert_stderr_contains() {
+  local label="$1" expected="$2"
+  shift 2
+  local stderr_out
+  stderr_out="$("$@" 2>&1 1>/dev/null || true)"
+  if echo "$stderr_out" | grep -q "$expected"; then
+    echo "  PASS: ${label}"
+    ((PASS++))
+  else
+    echo "  FAIL: ${label} — stderr did not contain '${expected}': ${stderr_out}"
+    ((FAIL++))
+  fi
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────
+
+echo "=== Test 1: Full lifecycle ==="
+cleanup
+out="$("$BIN" start workflow-state-machine)"
+assert_json_field "start phase" "$out" ".current_phase" "start"
+assert_json_field "start status" "$out" ".status" "active"
+assert_json_field "start allowed" "$out" '.allowed_events | join(",")' "propose"
+
+out="$("$BIN" advance workflow-state-machine propose)"
+assert_json_field "propose phase" "$out" ".current_phase" "proposal"
+
+out="$("$BIN" advance workflow-state-machine accept_proposal)"
+assert_json_field "accept_proposal phase" "$out" ".current_phase" "design"
+
+out="$("$BIN" advance workflow-state-machine accept_design)"
+assert_json_field "accept_design phase" "$out" ".current_phase" "apply"
+
+out="$("$BIN" advance workflow-state-machine accept_apply)"
+assert_json_field "accept_apply phase" "$out" ".current_phase" "approved"
+assert_json_field "history length" "$out" '.history | length' "4"
+
+echo ""
+echo "=== Test 2: Invalid transition ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+assert_exit "invalid transition exits 1" "1" "$BIN" advance workflow-state-machine approve
+assert_stderr_contains "invalid transition lists allowed" "Allowed events" "$BIN" advance workflow-state-machine approve
+
+echo ""
+echo "=== Test 3: Revise self-transition ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+"$BIN" advance workflow-state-machine propose >/dev/null
+"$BIN" advance workflow-state-machine accept_proposal >/dev/null
+out="$("$BIN" advance workflow-state-machine revise)"
+assert_json_field "revise stays in design" "$out" ".current_phase" "design"
+assert_json_field "revise history from" "$out" '.history[-1].from' "design"
+assert_json_field "revise history to" "$out" '.history[-1].to' "design"
+assert_json_field "revise history event" "$out" '.history[-1].event' "revise"
+
+echo ""
+echo "=== Test 4: Start with --issue-url ==="
+cleanup
+out="$("$BIN" start workflow-state-machine --issue-url "https://github.com/skr19930617/specflow/issues/71")"
+assert_json_field "issue url" "$out" ".issue.url" "https://github.com/skr19930617/specflow/issues/71"
+assert_json_field "issue number" "$out" ".issue.number" "71"
+assert_json_field "issue repo" "$out" ".issue.repo" "skr19930617/specflow"
+
+echo ""
+echo "=== Test 5: Duplicate start ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+assert_exit "duplicate start exits 1" "1" "$BIN" start workflow-state-machine
+
+echo ""
+echo "=== Test 6: Status of nonexistent run ==="
+assert_exit "nonexistent status exits 1" "1" "$BIN" status nonexistent-xyz-run
+
+echo ""
+echo "=== Test 7: Advance on nonexistent run ==="
+assert_exit "nonexistent advance exits 1" "1" "$BIN" advance nonexistent-xyz-run propose
+
+echo ""
+echo "=== Test 8: Invalid --issue-url ==="
+cleanup
+assert_exit "bad url exits 1" "1" "$BIN" start workflow-state-machine --issue-url "https://example.com/not-issue"
+
+echo ""
+echo "=== Test 9: Stdout/stderr contract ==="
+cleanup
+stdout_out="$("$BIN" start workflow-state-machine 2>/dev/null)"
+echo "$stdout_out" | jq empty 2>/dev/null
+assert_eq "success stdout is valid JSON" "0" "$?"
+error_stdout="$("$BIN" start workflow-state-machine 2>/dev/null || true)"
+# Second start should fail — check stdout is empty for errors
+error_stdout_only="$("$BIN" advance nonexistent-xyz-run propose 2>/dev/null || true)"
+assert_eq "error stdout is empty" "" "$error_stdout_only"
+
+echo ""
+echo "=== Test 10: Path traversal rejection ==="
+assert_exit "path traversal rejected" "1" "$BIN" start "../escape"
+assert_stderr_contains "traversal error message" "invalid run_id" "$BIN" start "../escape"
+
+echo ""
+echo "=== Test 11: Allowed events recomputed ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+out="$("$BIN" advance workflow-state-machine propose)"
+assert_json_field "proposal allowed has accept_proposal" "$out" '.allowed_events | contains(["accept_proposal"])' "true"
+assert_json_field "proposal allowed has reject" "$out" '.allowed_events | contains(["reject"])' "true"
+
+echo ""
+echo "=== Test 12: updated_at refreshes ==="
+cleanup
+out1="$("$BIN" start workflow-state-machine)"
+ts1="$(echo "$out1" | jq -r '.updated_at')"
+sleep 1
+out2="$("$BIN" advance workflow-state-machine propose)"
+ts2="$(echo "$out2" | jq -r '.updated_at')"
+if [[ "$ts1" != "$ts2" ]]; then
+  echo "  PASS: updated_at changed after advance"
+  ((PASS++))
+else
+  echo "  FAIL: updated_at did not change"
+  ((FAIL++))
+fi
+
+# ── Cleanup and summary ───────────────────────────────────────────────
+cleanup
+teardown_stubs
+echo ""
+echo "==============================="
+echo "Results: ${PASS} passed, ${FAIL} failed"
+echo "==============================="
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
- Add static workflow definition (`global/workflow/state-machine.json`) with 6 states, 6 events, 9 transitions
- Introduce per-run state tracking at `.specflow/runs/<run_id>/run.json`
- Implement `specflow-run` CLI (`bin/specflow-run`) with start/advance/status subcommands
- Add 28-assertion hermetic test suite (`tests/test-specflow-run.sh`)
- Parallel coexistence with existing slash commands — no existing commands modified

## Issue
Closes https://github.com/skr19930617/specflow/issues/71