### PR TITLE
feat: extend workflow state machine to v2.0 with enriched run metadata (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,56 @@ Codex CLI がインストール済みであれば追加設定は不要（Codex t
 | プロジェクト設定 | プロジェクトルートの `CLAUDE.md` | `/specflow.setup` でインタラクティブに設定 |
 | 外部テンプレート | 環境変数 `SPECFLOW_TEMPLATE_REPO` | 任意 — デフォルトはローカルテンプレート |
 
+## ワークフローコア
+
+specflow のワークフローは以下の 3 つのコアコンポーネントで管理される。詳細は [docs/architecture.md](docs/architecture.md) を参照。
+
+| コンポーネント | ファイル | 役割 |
+|---------------|---------|------|
+| State Machine | `global/workflow/state-machine.json` | 状態・イベント・遷移の宣言的定義 (v2.0) |
+| Run CLI | `bin/specflow-run` | 状態遷移の実行・検証・per-run メタデータ管理 |
+| Run State | `.specflow/runs/<run_id>/run.json` | per-run の状態・メタデータ・履歴 |
+
+### 状態遷移図
+
+```
+                        ┌─ explore_start ──→ [explore] ──→ explore_complete ─┐
+                        │                                                    │
+[start] ←──────────────┼────────────────────────────────────────────────────┘
+   │                    │
+   │                    └─ spec_bootstrap_start ──→ [spec_bootstrap] ──→ spec_bootstrap_complete ─→ [start]
+   │
+   └── propose ──→ [proposal] ──→ accept_proposal ──→ [design] ──→ accept_design ──→ [apply] ──→ accept_apply ──→ [approved]
+                       │                              │    ↺                        │    ↺                 
+                       │                              │ revise_design               │ revise_apply
+                       └── reject ──→ [rejected] ←────┘                            │
+                                           ↑───────────────────────────────────────┘
+```
+
+**v2.0 破壊的変更**: `revise` イベントは `revise_design` / `revise_apply` に分割されました。
+
+**ブランチパス**: `explore` と `spec_bootstrap` は state machine と specflow-run CLI で完全にサポートされていますが、現在のスラッシュコマンド（`/specflow.explore`, `/specflow.spec`）はこれらのイベントをまだ emit しません（非 change スコープのため run_id の戦略が未定）。
+
+### run.json メタデータ
+
+v2.0 の `run.json` は以下のフィールドを必須とします（`specflow-run start` 時に自動検出）:
+
+| フィールド | ソース |
+|-----------|--------|
+| `project_id` | `git remote get-url origin` → `owner/repo` |
+| `repo_name` | `project_id` と同値 |
+| `repo_path` | `git rev-parse --show-toplevel` |
+| `branch_name` | `git rev-parse --abbrev-ref HEAD` |
+| `worktree_path` | `git rev-parse --show-toplevel` |
+| `agents` | `{ main: "claude", review: "codex" }` (デフォルト) |
+| `last_summary_path` | `null` (approve 時に更新) |
+
+**マイグレーション不要**: 既存の run.json は `.specflow/runs/` に gitignore されており、ローカルのみ。旧スキーマの run は破棄して `specflow-run start` で再作成。
+
+### UI バインディングメタデータ分離
+
+配信固有のメタデータ（Slack チャンネル等）は `run.json` に含めず、`.specflow/runs/<run_id>/<ui>.json`（例: `slack.json`）に分離する命名規約。
+
 ## リポジトリアーキテクチャ
 
 このリポジトリには 2 種類のコンテンツが含まれる:
@@ -272,7 +322,10 @@ specflow/                        # このリポジトリ（ツール）
     specflow-filter-diff         #   diff フィルタリング
     specflow-init                #   プロジェクト初期化 / コマンド更新
     specflow-install             #   グローバルインストール（PATH, コマンド, 権限, テンプレート）
+    specflow-run                 #   ワークフロー状態遷移 CLI (start/advance/status/update-field)
   global/                        # グローバル設定・スラッシュコマンド
+    workflow/                    #   ワークフロー定義
+      state-machine.json         #     状態遷移定義 (v2.0)
     commands/                    #   スラッシュコマンド定義
     prompts/                     #   レビュー・ワークフロープロンプト
     claude-settings.json         #   ~/.claude/settings.json 用権限テンプレート

--- a/bin/specflow-run
+++ b/bin/specflow-run
@@ -68,6 +68,38 @@ allowed_events_for() {
   jq -c --arg s "$state" '[.transitions[] | select(.from == $s) | .event]' "$STATE_MACHINE"
 }
 
+detect_project_id() {
+  local remote_url
+  remote_url="$(git remote get-url origin 2>/dev/null)" || die "Error: could not detect git remote origin"
+  # Strip protocol, host, .git suffix → owner/repo
+  echo "$remote_url" | sed -E 's|\.git$||' | sed -E 's|^.*[:/]([^/]+/[^/]+)$|\1|'
+}
+
+detect_repo_path() {
+  git rev-parse --show-toplevel 2>/dev/null || die "Error: could not detect repository root"
+}
+
+detect_branch_name() {
+  git rev-parse --abbrev-ref HEAD 2>/dev/null || die "Error: could not detect current branch"
+}
+
+detect_worktree_path() {
+  git rev-parse --show-toplevel 2>/dev/null || die "Error: could not detect worktree path"
+}
+
+validate_run_schema() {
+  local rf="$1"
+  local missing=()
+  for field in project_id repo_name repo_path branch_name worktree_path agents last_summary_path; do
+    if ! jq -e "has(\"$field\")" "$rf" >/dev/null 2>&1; then
+      missing+=("$field")
+    fi
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    die "Error: run state is missing required fields: ${missing[*]}. This run was created with an older schema. Please delete it and re-create with 'specflow-run start'."
+  fi
+}
+
 atomic_write() {
   local target="$1"
   local content="$2"
@@ -84,12 +116,24 @@ atomic_write() {
 cmd_start() {
   local run_id=""
   local issue_url=""
+  local agent_main="claude"
+  local agent_review="codex"
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --issue-url)
         [[ $# -ge 2 ]] || die "Error: --issue-url requires a value"
         issue_url="$2"
+        shift 2
+        ;;
+      --agent-main)
+        [[ $# -ge 2 ]] || die "Error: --agent-main requires a value"
+        agent_main="$2"
+        shift 2
+        ;;
+      --agent-review)
+        [[ $# -ge 2 ]] || die "Error: --agent-review requires a value"
+        agent_review="$2"
         shift 2
         ;;
       -*)
@@ -106,7 +150,7 @@ cmd_start() {
     esac
   done
 
-  [[ -n "$run_id" ]] || die "Usage: specflow-run start <run_id> [--issue-url <url>]"
+  [[ -n "$run_id" ]] || die "Usage: specflow-run start <run_id> [--issue-url <url>] [--agent-main <name>] [--agent-review <name>]"
 
   validate_run_id "$run_id"
   ensure_state_machine
@@ -135,6 +179,14 @@ cmd_start() {
     }')" || die "Error: failed to parse issue metadata"
   fi
 
+  # Auto-detect metadata
+  local project_id repo_name repo_path branch_name worktree_path
+  project_id="$(detect_project_id)"
+  repo_name="$project_id"
+  repo_path="$(detect_repo_path)"
+  branch_name="$(detect_branch_name)"
+  worktree_path="$(detect_worktree_path)"
+
   local ts
   ts="$(now_iso)"
   local allowed
@@ -147,6 +199,13 @@ cmd_start() {
     --arg ts "$ts" \
     --argjson allowed "$allowed" \
     --argjson issue "$issue_json" \
+    --arg pid "$project_id" \
+    --arg rname "$repo_name" \
+    --arg rpath "$repo_path" \
+    --arg bname "$branch_name" \
+    --arg wpath "$worktree_path" \
+    --arg amain "$agent_main" \
+    --arg areview "$agent_review" \
     '{
       run_id: $rid,
       change_name: $cn,
@@ -154,6 +213,13 @@ cmd_start() {
       status: "active",
       allowed_events: $allowed,
       issue: $issue,
+      project_id: $pid,
+      repo_name: $rname,
+      repo_path: $rpath,
+      branch_name: $bname,
+      worktree_path: $wpath,
+      agents: { main: $amain, review: $areview },
+      last_summary_path: null,
       created_at: $ts,
       updated_at: $ts,
       history: []
@@ -176,6 +242,7 @@ cmd_advance() {
 
   local rf
   rf="$(run_file "$run_id")"
+  validate_run_schema "$rf"
   local current
   current="$(jq -r '.current_phase' "$rf")"
 
@@ -231,7 +298,48 @@ cmd_status() {
 
   local rf
   rf="$(run_file "$run_id")"
+  validate_run_schema "$rf"
   jq . "$rf"
+}
+
+cmd_update_field() {
+  local run_id="${1:-}"
+  local field="${2:-}"
+  local value="${3:-}"
+
+  [[ -n "$run_id" && -n "$field" && -n "$value" ]] || die "Usage: specflow-run update-field <run_id> <field> <value>"
+
+  # Whitelist of mutable fields
+  local allowed_fields="last_summary_path"
+  local found=false
+  for af in $allowed_fields; do
+    if [[ "$field" == "$af" ]]; then
+      found=true
+      break
+    fi
+  done
+  [[ "$found" == "true" ]] || die "Error: field '${field}' is not updatable. Allowed fields: ${allowed_fields}"
+
+  validate_run_id "$run_id"
+  ensure_run_exists "$run_id"
+
+  local rf
+  rf="$(run_file "$run_id")"
+  validate_run_schema "$rf"
+
+  local ts
+  ts="$(now_iso)"
+
+  local updated
+  updated="$(jq \
+    --arg field "$field" \
+    --arg value "$value" \
+    --arg ts "$ts" \
+    '.[$field] = $value | .updated_at = $ts' \
+    "$rf")"
+
+  atomic_write "$rf" "$updated"
+  echo "$updated" | jq .
 }
 
 # ── Main dispatch ──────────────────────────────────────────────────────
@@ -240,9 +348,10 @@ subcmd="${1:-}"
 shift || true
 
 case "$subcmd" in
-  start)   cmd_start "$@" ;;
-  advance) cmd_advance "$@" ;;
-  status)  cmd_status "$@" ;;
-  "")      die "Usage: specflow-run <start|advance|status> [args...]" ;;
-  *)       die "Error: unknown subcommand '${subcmd}'. Use: start, advance, status" ;;
+  start)        cmd_start "$@" ;;
+  advance)      cmd_advance "$@" ;;
+  status)       cmd_status "$@" ;;
+  update-field) cmd_update_field "$@" ;;
+  "")           die "Usage: specflow-run <start|advance|status|update-field> [args...]" ;;
+  *)            die "Error: unknown subcommand '${subcmd}'. Use: start, advance, status, update-field" ;;
 esac

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,110 @@
+# Workflow Core Architecture
+
+## Overview
+
+specflow のワークフローは 3 つのコアコンポーネントで構成される:
+
+1. **State Machine** (`global/workflow/state-machine.json`) — 宣言的な状態遷移定義
+2. **Run CLI** (`bin/specflow-run`) — 状態遷移の実行・検証エンジン
+3. **Run State** (`.specflow/runs/<run_id>/run.json`) — per-run の永続化状態
+
+## State Machine (v2.0)
+
+### States
+
+| State | Type | Description |
+|-------|------|-------------|
+| `start` | Mainline | 初期状態 |
+| `proposal` | Mainline | Proposal 作成・Clarify・Validate |
+| `design` | Mainline | Design artifacts 生成・レビュー |
+| `apply` | Mainline | 実装・レビュー |
+| `approved` | Terminal | 承認済み |
+| `rejected` | Terminal | 拒否済み |
+| `explore` | Branch | アイデア探索（state-machine-only、run state 非参加） |
+| `spec_bootstrap` | Branch | ベースライン spec 生成（state-machine-only、run state 非参加） |
+
+### Events
+
+| Event | From | To | Description |
+|-------|------|----|-------------|
+| `propose` | start | proposal | Proposal 作成開始 |
+| `accept_proposal` | proposal | design | Proposal 承認 → Design フェーズへ |
+| `accept_design` | design | apply | Design 承認 → Apply フェーズへ |
+| `accept_apply` | apply | approved | 実装承認 |
+| `reject` | proposal/design/apply | rejected | 拒否 |
+| `revise_design` | design | design | Design 修正ループ（自己遷移） |
+| `revise_apply` | apply | apply | Apply 修正ループ（自己遷移） |
+| `explore_start` | start | explore | Explore 開始 |
+| `explore_complete` | explore | start | Explore 完了 → start に復帰 |
+| `spec_bootstrap_start` | start | spec_bootstrap | Spec bootstrap 開始 |
+| `spec_bootstrap_complete` | spec_bootstrap | start | Spec bootstrap 完了 → start に復帰 |
+
+### v2.0 Breaking Changes
+
+- `revise` イベントは削除され、`revise_design` と `revise_apply` に分割
+- `explore` と `spec_bootstrap` 状態が追加（ブランチパス）
+- version フィールドが `"1.0"` → `"2.0"` に変更
+
+### Branch Paths (D6)
+
+`explore` と `spec_bootstrap` は state-machine.json と specflow-run CLI で完全にサポートされている（`specflow-run advance ... explore_start` は有効な遷移）。ただし、現在のスラッシュコマンド（`/specflow.explore`, `/specflow.spec`）はこれらのイベントをまだ emit しない。理由: これらは change スコープではなく、自然な `run_id` が存在しない。将来的に synthetic run ID（例: `_explore_<timestamp>`）を導入する可能性がある。
+
+## Run State Schema (v2.0)
+
+### Required Fields
+
+| Field | Type | Source | Description |
+|-------|------|--------|-------------|
+| `run_id` | string | 引数 | OpenSpec change 名 |
+| `change_name` | string | 引数 | run_id と同値 |
+| `current_phase` | string | 状態遷移 | 現在の状態 |
+| `status` | string | 固定 | `"active"` |
+| `allowed_events` | string[] | state-machine.json | 現在の状態で有効なイベント |
+| `issue` | object/null | `--issue-url` | GitHub issue メタデータ |
+| `project_id` | string | `git remote get-url origin` | `owner/repo` 形式 |
+| `repo_name` | string | `project_id` と同値 | 将来の multi-project 拡張用に予約 |
+| `repo_path` | string | `git rev-parse --show-toplevel` | リポジトリルートの絶対パス |
+| `branch_name` | string | `git rev-parse --abbrev-ref HEAD` | 現在のブランチ名 |
+| `worktree_path` | string | `git rev-parse --show-toplevel` | ワークツリーの絶対パス |
+| `agents` | object | デフォルト or フラグ | `{ main: "claude", review: "codex" }` |
+| `last_summary_path` | string/null | `update-field` | 最新サマリーファイルのパス |
+| `created_at` | string | 自動 | ISO 8601 タイムスタンプ |
+| `updated_at` | string | 自動 | ISO 8601 タイムスタンプ |
+| `history` | array | 自動 | 遷移履歴 |
+
+### Schema Validation
+
+`specflow-run advance`, `status`, `update-field` は読み込み時に required fields の存在を検証する。v2.0 以前の `run.json`（required fields が欠落）は明確なエラーメッセージで拒否される。
+
+### Migration Policy
+
+既存の `run.json` のマイグレーションは行わない。`.specflow/runs/` は gitignore されておりローカルのみの状態。旧スキーマの run は `specflow-run start` で再作成する。
+
+## UI Binding Metadata Separation
+
+配信固有のメタデータ（Slack チャンネル、スレッド ID、メッセージルーティング等）は `run.json` に含めない。
+
+命名規約: `.specflow/runs/<run_id>/<ui>.json`
+
+例: `.specflow/runs/my-change/slack.json`
+
+これにより:
+- ワークフロー状態がポータブルに保たれる
+- UI 統合が交換可能になる
+- DM / チャンネル / スレッドサポートがワークフローコアを汚染しない
+
+## specflow-run CLI
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `specflow-run start <run_id> [--issue-url <url>] [--agent-main <name>] [--agent-review <name>]` | 新規 run を初期化 |
+| `specflow-run advance <run_id> <event>` | 状態遷移を実行 |
+| `specflow-run status <run_id>` | 現在の run 状態を表示 |
+| `specflow-run update-field <run_id> <field> <value>` | 許可されたフィールドを更新（現在: `last_summary_path` のみ） |
+
+### Output Contract
+
+- 成功時: stdout に JSON、stderr は空
+- 失敗時: stderr にエラーメッセージ、exit code 非ゼロ

--- a/global/commands/specflow.approve.md
+++ b/global/commands/specflow.approve.md
@@ -231,6 +231,14 @@ Each checkpoint must be specific to this feature, not generic boilerplate.
 
 Write the assembled content (header + all 6 sections) to `FEATURE_DIR/approval-summary.md` via Write tool.
 
+After writing the summary file, update the run state if a specflow run exists for this change:
+```bash
+if specflow-run status "<CHANGE_ID>" >/dev/null 2>&1; then
+  specflow-run update-field "<CHANGE_ID>" last_summary_path "<FEATURE_DIR>/approval-summary.md"
+fi
+```
+(Only attempts the update if the run exists; real errors are surfaced.)
+
 ### 4. Terminal Summary and User Confirmation
 
 Display a concise terminal summary:

--- a/global/workflow/state-machine.json
+++ b/global/workflow/state-machine.json
@@ -1,16 +1,20 @@
 {
-  "version": "1.0",
-  "states": ["start", "proposal", "design", "apply", "approved", "rejected"],
-  "events": ["propose", "accept_proposal", "accept_design", "accept_apply", "reject", "revise"],
+  "version": "2.0",
+  "states": ["start", "proposal", "design", "apply", "approved", "rejected", "explore", "spec_bootstrap"],
+  "events": ["propose", "accept_proposal", "accept_design", "accept_apply", "reject", "revise_design", "revise_apply", "explore_start", "explore_complete", "spec_bootstrap_start", "spec_bootstrap_complete"],
   "transitions": [
     { "from": "start", "event": "propose", "to": "proposal" },
     { "from": "proposal", "event": "accept_proposal", "to": "design" },
     { "from": "proposal", "event": "reject", "to": "rejected" },
     { "from": "design", "event": "accept_design", "to": "apply" },
-    { "from": "design", "event": "revise", "to": "design" },
+    { "from": "design", "event": "revise_design", "to": "design" },
     { "from": "design", "event": "reject", "to": "rejected" },
     { "from": "apply", "event": "accept_apply", "to": "approved" },
-    { "from": "apply", "event": "revise", "to": "apply" },
-    { "from": "apply", "event": "reject", "to": "rejected" }
+    { "from": "apply", "event": "revise_apply", "to": "apply" },
+    { "from": "apply", "event": "reject", "to": "rejected" },
+    { "from": "start", "event": "explore_start", "to": "explore" },
+    { "from": "explore", "event": "explore_complete", "to": "start" },
+    { "from": "start", "event": "spec_bootstrap_start", "to": "spec_bootstrap" },
+    { "from": "spec_bootstrap", "event": "spec_bootstrap_complete", "to": "start" }
   ]
 }

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/approval-summary.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/approval-summary.md
@@ -1,0 +1,66 @@
+# Approval Summary: extend-workflow-state-machine
+
+**Generated**: 2026-04-09T04:04:23Z
+**Branch**: extend-workflow-state-machine
+**Status**: ⚠️ 1 unresolved high (design review — F10: slash commands don't call specflow-run)
+
+## What Changed
+
+```
+ bin/specflow-run                    | 248 ++++++++++++++++++++
+ global/commands/specflow.approve.md |  38 ++--
+ global/workflow/state-machine.json  |  16 ++
+ tests/test-specflow-run.sh          | 196 ++++++++++++++++
+ README.md                           |  52 +++++
+ docs/architecture.md                | new
+```
+
+## Files Touched
+
+- bin/specflow-run
+- global/commands/specflow.approve.md
+- global/workflow/state-machine.json
+- tests/test-specflow-run.sh
+- README.md
+- docs/architecture.md
+
+## Review Loop Summary
+
+### Design Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 4     |
+| Unresolved high    | 1     |
+| New high (later)   | 4     |
+| Total rounds       | 5     |
+
+### Impl Review
+⚠️ No impl review data available (impl review was not run separately — implementation was done after design review)
+
+## Proposal Coverage
+
+| # | Criterion | Covered? | Mapped Files |
+|---|-----------|----------|--------------|
+| 1 | state-machine.json models mainline and key revision/branch paths | Yes | global/workflow/state-machine.json |
+| 2 | run.json has enough metadata for multi-project and resumable execution | Yes | bin/specflow-run |
+| 3 | Workflow state and UI binding metadata clearly separated | Yes | docs/architecture.md, README.md |
+| 4 | Command surface and workflow core closer to 1:1 conceptually | Partial | global/workflow/state-machine.json (branch paths modeled but not wired to slash commands) |
+| 5 | README mentions the workflow core explicitly | Yes | README.md |
+
+**Coverage Rate**: 4/5 (80%)
+
+## Remaining Risks
+
+- F10: Slash commands don't call specflow-run start/advance yet (severity: high) — normal flow won't create run.json
+- F9: project_id and repo_name are identical (severity: medium) — both reserved for future divergence
+- F11: update-field has field whitelist (severity: medium) — **resolved in implementation** (whitelist enforced)
+- ⚠️ Uncovered criterion: Command surface and workflow core not fully 1:1 (branch paths not wired to slash commands per D6)
+
+## Human Checkpoints
+
+- [ ] Verify `specflow-run start` correctly auto-detects project_id from git remote in both HTTPS and SSH URL formats
+- [ ] Confirm that the `revise` → `revise_design`/`revise_apply` rename doesn't break any external consumers beyond the listed callers
+- [ ] Test that pre-2.0 run.json files produce a clear, actionable error message when accessed
+- [ ] Verify docs/architecture.md accurately reflects the implemented behavior (especially branch-path wording)
+- [ ] Decide whether F10 (slash command wiring to specflow-run) should be tracked as a follow-up issue

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/current-phase.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/current-phase.md
@@ -1,0 +1,14 @@
+# Current Phase: extend-workflow-state-machine
+
+- Phase: design-fix-review
+- Round: 5
+- Status: has_open_high
+- Open High Findings: 1 件 — "Slash commands don't call specflow-run start/advance yet"
+- Accepted Risks: none
+- Latest Changes:
+  - 7915d8d feat: introduce workflow state machine and run state core (#71)
+  - 0b14779 chore: archive fix-autofix-early-stop change
+  - 2887d9b fix: prevent autofix loop from stopping early on temporary divergence (#67)
+  - 049ca6e feat: add specflow.spec command for baseline spec bootstrap (#66)
+  - 56f1584 fix: reorder approve flow to archive before commit (#65)
+- Next Recommended Action: /specflow.fix_design

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/design.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/design.md
@@ -1,0 +1,111 @@
+## Context
+
+The specflow workflow core currently consists of three pieces:
+- `global/workflow/state-machine.json` — a static workflow definition with 6 states (start, proposal, design, apply, approved, rejected) and 6 events
+- `bin/specflow-run` — a bash CLI that reads the state machine, validates transitions, and manages per-run state
+- `.specflow/runs/<run_id>/run.json` — per-run state tracking current phase, history, and issue metadata
+
+The current machine covers the mainline flow but omits explore, spec bootstrap, and does not distinguish design vs apply revision loops. The run state lacks project/environment metadata needed for multi-project usage and future UI integrations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expand state-machine.json to model explore, spec_bootstrap as independent branch paths returning to start
+- Replace single `revise` event with `revise_design` and `revise_apply` for explicit fix loop modeling
+- Add all new metadata fields to run.json as required fields auto-detected at initialization
+- Document UI binding metadata separation convention
+- Keep the state machine as a pure data file (no code in JSON)
+- Update specflow-run CLI to handle new states, events, and enriched metadata
+
+**Non-Goals:**
+- Implementing Slack integration or creating stub delivery files
+- Migrating existing run.json files (old runs are disposable)
+- Modeling utility commands (dashboard, license, readme, decompose) in the state machine
+- Introducing a public API or external integration layer
+- Wiring `/specflow.explore` or `/specflow.spec` to emit `specflow-run` events — these are non-change-scoped commands with no natural run_id (see D6)
+
+## Decisions
+
+### D1: Independent branch paths for explore and spec_bootstrap
+
+**Decision**: Model explore and spec_bootstrap as independent loops that fork from and return to `start`, rather than feeding into the mainline.
+
+**Rationale**: These commands operate independently of any specific change — explore creates issues, spec_bootstrap generates baseline specs. They don't produce artifacts that feed into proposal → design → apply. Modeling them as `start → explore → start` preserves the mainline's semantic integrity.
+
+**Alternative considered**: Making explore/spec_bootstrap pre-stages to proposal. Rejected because they don't always lead to a proposal — explore may produce zero issues, and spec_bootstrap is a one-time setup operation.
+
+### D2: Split revise into revise_design and revise_apply (BREAKING)
+
+**Decision**: Remove the generic `revise` event. Add `revise_design` (self-transition on `design`) and `revise_apply` (self-transition on `apply`).
+
+**Rationale**: The current single `revise` event obscures which fix loop is executing. Distinct events enable per-phase history tracking and allow future UIs to show "design revision #3" vs "apply revision #2" clearly.
+
+**Alternative considered**: Keep `revise` and add `revise_design`/`revise_apply` alongside it. Rejected because keeping the old event creates ambiguity — callers must choose between generic and specific, and the generic one provides no value.
+
+**Migration**: Update all callers of the `revise` event:
+1. `tests/test-specflow-run.sh` — replace `revise` references with `revise_design`/`revise_apply`
+2. `global/commands/specflow.review_design.md` — update any `specflow-run advance ... revise` calls to use `revise_design`
+3. `global/commands/specflow.review_apply.md` (and `specflow.fix_apply.md`) — update to use `revise_apply`
+4. `global/commands/specflow.fix_design.md` — update to use `revise_design`
+
+### D3: All new run metadata fields required
+
+**Decision**: All new fields (`project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`) are required and auto-detected at `specflow-run start`.
+
+**Rationale**: User chose all-required to ensure consistent, complete metadata from the start. Auto-detection at init time means callers don't need to supply them manually.
+
+**Auto-detection strategy** (source of truth: `project_id` is authoritative, parsed first):
+- `project_id`: parsed from `git remote get-url origin` → extract `owner/repo` (strip .git suffix, host prefix)
+- `repo_name`: set equal to `project_id` in this scope (same `owner/repo` format). Note: these fields are intentionally equal for single-repo usage. `project_id` is reserved for future multi-project scenarios where a project may span multiple repos or a monorepo may host multiple projects — at that point `project_id` would diverge from `repo_name`. Both fields are included now to establish the schema contract without requiring a migration later.
+- `repo_path`: `git rev-parse --show-toplevel`
+- `branch_name`: `git rev-parse --abbrev-ref HEAD`
+- `worktree_path`: `git rev-parse --show-toplevel` (same as repo_path for non-worktree usage)
+- `agents.main`: defaults to `"claude"`, overridable via `--agent-main`
+- `agents.review`: defaults to `"codex"`, overridable via `--agent-review`
+- `last_summary_path`: defaults to `null` at init, updated by commands that produce summaries
+
+**Exception**: `last_summary_path` starts as `null` and is updated post-init. This is acceptable because it's a pointer that only becomes meaningful after a summary is generated.
+
+**`last_summary_path` lifecycle**: The following change-scoped command produces a summary artifact and SHALL update `last_summary_path` in `run.json` after writing the summary file:
+- `specflow.approve` — writes `approval-summary.md` to the change directory
+
+Note: `specflow.dashboard` is excluded because its output is repository-wide (not tied to a single run), so it cannot update a per-run `last_summary_path`.
+
+The update mechanism is a new `specflow-run update-field <run_id> last_summary_path <path>` subcommand that atomically updates a single field in `run.json`. This keeps the write path simple and avoids callers needing to read-modify-write the full JSON. In this scope, we add the subcommand AND wire the call into `specflow.approve`.
+
+### D4: UI binding metadata convention (docs only)
+
+**Decision**: Document that delivery-specific metadata lives at `.specflow/runs/<run_id>/<ui>.json` (e.g., `slack.json`). No code or stub files in this scope.
+
+**Rationale**: The convention establishes the separation principle early. Creating stubs would add dead code with no consumers.
+
+### D6: Branch-path run lifecycle (state machine only, no run state)
+
+**Decision**: The `explore` and `spec_bootstrap` states are modeled in `state-machine.json` for conceptual completeness and documentation, but they do NOT participate in persisted run state (`specflow-run start/advance`) in this scope.
+
+**Rationale**: `specflow-run` is change-scoped — `run_id` equals the OpenSpec change name, and `run.json` lives under `.specflow/runs/<change_name>/`. The `/specflow.explore` and `/specflow.spec` commands are not tied to any change: explore creates issues, spec_bootstrap generates baseline specs. There is no natural `run_id` for these flows.
+
+**What this means**:
+- The state machine documents the full conceptual flow including branch paths
+- `specflow-run advance ... explore_start` is a valid transition if a run happens to be in `start` state, but no existing command calls it
+- Wiring explore/spec_bootstrap to emit `explore_start`/`explore_complete`/`spec_bootstrap_start`/`spec_bootstrap_complete` via `specflow-run` is a future enhancement that requires deciding on a run-id strategy for non-change flows (e.g., synthetic IDs like `_explore_<timestamp>`)
+
+**Alternative considered**: Creating synthetic run IDs for non-change flows. Deferred because it adds complexity with no current consumer — the branch states serve as documentation of the flow.
+
+### D5: Version bump in state-machine.json
+
+**Decision**: Bump version from `"1.0"` to `"2.0"` since this is a breaking change (revise event removal).
+
+**Rationale**: The version field exists for exactly this purpose. Consumers can check the version to handle schema differences.
+
+## Risks / Trade-offs
+
+**[BREAKING: revise event removal]** → Mitigated by limited callers (specflow-run tests and internal slash commands). All callers are updated in this change.
+
+**[Auto-detection may fail in CI/non-standard environments]** → Mitigated by clear error messages when git commands fail. specflow-run already requires a git repo context.
+
+**[All-required fields increase init complexity]** → Accepted trade-off for data consistency. Auto-detection handles most fields; only `agents` has defaults.
+
+**[Branch paths add states but no run uses them yet]** → Acceptable — this models the existing command surface. explore and spec_bootstrap commands exist today but weren't tracked in the state machine.
+
+**[Pre-2.0 run.json files lack required fields]** → `specflow-run advance`, `status`, and `update-field` SHALL validate that required metadata fields exist when reading `run.json`. If any required field is missing, the command exits with code 1 and a clear error message directing the user to re-create the run. This enforces the "all fields required" contract at runtime without needing migration.

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/proposal.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The workflow state machine (`global/workflow/state-machine.json`) currently models only the mainline flow (start → proposal → design → apply → approved/rejected) with a single `revise` self-transition for fix loops. It does not cover important existing paths such as `/specflow.explore`, `/specflow.spec`, or the distinct design/apply revision loops. The per-run state (`run.json`) also lacks metadata needed for multi-project usage, resumable execution, and future non-Claude UI integrations (e.g., Slack). As the product surface grows, the machine must become the authoritative source of truth for the flow — otherwise commands, docs, and workflow state will drift apart.
+
+## What Changes
+
+- **Expand states**: Add `explore` and `spec_bootstrap` as independent branch paths parallel to the mainline (start → explore → start, start → spec_bootstrap → start). These do not feed into the mainline but return to `start` upon completion.
+- **Split revision events** (**BREAKING**): Remove the single `revise` event and replace with `revise_design` (self-transition on `design`) and `revise_apply` (self-transition on `apply`). This makes each fix loop explicit in the machine definition.
+- **Add branch-path events**: Add `explore_start`, `explore_complete`, `spec_bootstrap_start`, `spec_bootstrap_complete` events for the independent branch paths
+- **Enrich run metadata (all fields required)**: Extend `run.json` schema with required fields: `project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents` (`{ main, review }`), and `last_summary_path`. All fields are required and auto-detected at run initialization.
+- **Separate UI binding metadata (convention only)**: Document the convention that delivery-specific metadata (e.g., Slack routing) lives in `.specflow/runs/<run_id>/<ui>.json` (e.g., `slack.json`), separate from `run.json`. No stub files are created in this scope — only the naming convention is documented.
+- **No migration for existing runs**: Existing `.specflow/runs/` data is gitignored and local-only. Old runs are considered disposable; new runs use the new schema exclusively.
+- **Update specflow-run CLI**: Extend `specflow-run` to handle the new states, events, and enriched metadata
+- **Update docs**: Align README and architecture docs with the expanded workflow core
+
+## Capabilities
+
+### New Capabilities
+- `extended-workflow-states`: Expanded state machine covering explore, spec bootstrap, and distinct revision loops for design and apply phases
+- `enriched-run-metadata`: Per-run state enriched with project, branch, agent, and artifact pointer fields for multi-project and resumable execution
+- `ui-binding-separation`: Convention for separating delivery/UI metadata from workflow state to keep the core portable
+
+### Modified Capabilities
+- `workflow-definition`: States and events expanded to cover explore, spec bootstrap, and split revision events
+- `run-state-management`: Run state schema extended with project/branch/agent metadata fields
+- `transition-core`: specflow-run CLI updated to handle new states, events, and enriched metadata initialization
+
+## Impact
+
+- `global/workflow/state-machine.json` — expanded states, events, transitions
+- `bin/specflow-run` — updated to support new states/events, enriched run init
+- `.specflow/runs/<run_id>/run.json` — schema extended with new metadata fields
+- Existing runs are not migrated — old run.json files are disposable (gitignored, local-only)
+- README and architecture docs updated to reflect the workflow core

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/review-ledger-design.json
@@ -1,0 +1,27 @@
+{
+  "feature_id": "extend-workflow-state-machine",
+  "phase": "design",
+  "current_round": 5,
+  "status": "has_open_high",
+  "max_finding_id": 11,
+  "findings": [
+    {"id":"R1-F01","severity":"high","category":"completeness","file":"design.md","title":"last_summary_path is only initialized, not wired","detail":"...","origin_round":1,"latest_round":3,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"R1-F02","severity":"medium","category":"consistency","file":"design.md","title":"Project metadata rules ambiguous","detail":"...","origin_round":1,"latest_round":2,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"R1-F03","severity":"medium","category":"completeness","file":"tasks.md","title":"Changed advance semantics not covered","detail":"...","origin_round":1,"latest_round":2,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F4","severity":"high","category":"consistency","file":"tasks.md","title":"Caller updates missing","detail":"...","origin_round":2,"latest_round":4,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F5","severity":"medium","category":"completeness","file":"tasks.md","title":"Documentation tasks incomplete","detail":"...","origin_round":2,"latest_round":4,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F6","severity":"high","category":"feasibility","file":"design.md","title":"Branch-path run lifecycle undefined","detail":"...","origin_round":3,"latest_round":5,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F7","severity":"medium","category":"consistency","file":"design.md","title":"dashboard not valid per-run updater","detail":"...","origin_round":3,"latest_round":4,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F8","severity":"medium","category":"completeness","file":"tasks.md","title":"No old-run validation","detail":"...","origin_round":4,"latest_round":5,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F9","severity":"medium","category":"correctness","file":"design.md","title":"project_id == repo_name","detail":"D3 derives project_id from the git remote owner/repo and then sets repo_name equal to project_id. The proposal introduced both fields for multi-project usage, so making them identical leaves no distinction.","origin_round":4,"latest_round":5,"status":"open","relation":"new","supersedes":null,"notes":""},
+    {"id":"F10","severity":"high","category":"correctness","file":"tasks.md","title":"Slash commands don't call specflow-run start/advance yet","detail":"Task 2.6 adds specflow-run update-field to specflow.approve, but the plan never adds tasks to call specflow-run start from /specflow or specflow-run advance from /specflow.design, /specflow.apply, etc. The normal flow will not create run.json.","origin_round":5,"latest_round":5,"status":"new","relation":"new","supersedes":null,"notes":""},
+    {"id":"F11","severity":"medium","category":"correctness","file":"tasks.md","title":"update-field has no field whitelist","detail":"Task 2.5 defines a generic mutator without rejecting unsupported field names. Callers could overwrite transition-controlled fields.","origin_round":5,"latest_round":5,"status":"new","relation":"new","supersedes":null,"notes":""}
+  ],
+  "round_summaries": [
+    {"round":1,"total":3,"open":0,"new":3,"resolved":0,"overridden":0,"by_severity":{"high":{"open":0,"resolved":0,"new":1,"overridden":0},"medium":{"open":0,"resolved":0,"new":2,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":2,"total":5,"open":1,"new":2,"resolved":2,"overridden":0,"by_severity":{"high":{"open":1,"resolved":0,"new":1,"overridden":0},"medium":{"open":0,"resolved":2,"new":1,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":3,"total":7,"open":2,"new":2,"resolved":3,"overridden":0,"by_severity":{"high":{"open":1,"resolved":1,"new":1,"overridden":0},"medium":{"open":1,"resolved":2,"new":1,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":4,"total":9,"open":1,"new":2,"resolved":6,"overridden":0,"by_severity":{"high":{"open":1,"resolved":2,"new":0,"overridden":0},"medium":{"open":0,"resolved":4,"new":2,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":5,"total":11,"open":1,"new":2,"resolved":8,"overridden":0,"by_severity":{"high":{"open":0,"resolved":4,"new":1,"overridden":0},"medium":{"open":1,"resolved":4,"new":1,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}}
+  ]
+}

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/review-ledger-design.json.bak
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/review-ledger-design.json.bak
@@ -1,0 +1,24 @@
+{
+  "feature_id": "extend-workflow-state-machine",
+  "phase": "design",
+  "current_round": 4,
+  "status": "has_open_high",
+  "max_finding_id": 9,
+  "findings": [
+    {"id":"R1-F01","severity":"high","category":"completeness","file":"design.md","title":"last_summary_path is only initialized, not wired","detail":"...","origin_round":1,"latest_round":3,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"R1-F02","severity":"medium","category":"consistency","file":"design.md","title":"Project metadata rules ambiguous","detail":"...","origin_round":1,"latest_round":2,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"R1-F03","severity":"medium","category":"completeness","file":"tasks.md","title":"Changed advance semantics not covered","detail":"...","origin_round":1,"latest_round":2,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F4","severity":"high","category":"consistency","file":"tasks.md","title":"Caller updates missing","detail":"...","origin_round":2,"latest_round":4,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F5","severity":"medium","category":"completeness","file":"tasks.md","title":"Documentation tasks incomplete","detail":"...","origin_round":2,"latest_round":4,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F6","severity":"high","category":"feasibility","file":"design.md","title":"Branch-path run lifecycle undefined","detail":"...","origin_round":3,"latest_round":4,"status":"open","relation":"new","supersedes":null,"notes":""},
+    {"id":"F7","severity":"medium","category":"consistency","file":"design.md","title":"dashboard not valid per-run updater","detail":"...","origin_round":3,"latest_round":4,"status":"resolved","relation":"new","supersedes":null,"notes":""},
+    {"id":"F8","severity":"medium","category":"completeness","file":"tasks.md","title":"No old-run validation","detail":"...","origin_round":4,"latest_round":4,"status":"new","relation":"new","supersedes":null,"notes":""},
+    {"id":"F9","severity":"medium","category":"correctness","file":"design.md","title":"project_id == repo_name","detail":"...","origin_round":4,"latest_round":4,"status":"new","relation":"new","supersedes":null,"notes":""}
+  ],
+  "round_summaries": [
+    {"round":1,"total":3,"open":0,"new":3,"resolved":0,"overridden":0,"by_severity":{"high":{"open":0,"resolved":0,"new":1,"overridden":0},"medium":{"open":0,"resolved":0,"new":2,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":2,"total":5,"open":1,"new":2,"resolved":2,"overridden":0,"by_severity":{"high":{"open":1,"resolved":0,"new":1,"overridden":0},"medium":{"open":0,"resolved":2,"new":1,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":3,"total":7,"open":2,"new":2,"resolved":3,"overridden":0,"by_severity":{"high":{"open":1,"resolved":1,"new":1,"overridden":0},"medium":{"open":1,"resolved":2,"new":1,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}},
+    {"round":4,"total":9,"open":1,"new":2,"resolved":6,"overridden":0,"by_severity":{"high":{"open":1,"resolved":2,"new":0,"overridden":0},"medium":{"open":0,"resolved":4,"new":2,"overridden":0},"low":{"open":0,"resolved":0,"new":0,"overridden":0}}}
+  ]
+}

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/enriched-run-metadata/spec.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/enriched-run-metadata/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Project identification fields in run state
+The run state JSON SHALL include `project_id` and `repo_name` fields. `project_id` SHALL be derived from the repository's remote origin in `owner/repo` format. `repo_name` SHALL equal the `project_id` value.
+
+#### Scenario: project_id is auto-detected from git remote
+- **WHEN** a run is started in a repository with remote origin `https://github.com/skr19930617/specflow.git`
+- **THEN** `project_id` SHALL be `"skr19930617/specflow"`
+
+#### Scenario: repo_name equals project_id
+- **WHEN** a run is newly created
+- **THEN** `repo_name` SHALL equal the value of `project_id`
+
+### Requirement: Repository path fields in run state
+The run state JSON SHALL include `repo_path` and `worktree_path` fields. Both SHALL be absolute filesystem paths auto-detected from git at run initialization.
+
+#### Scenario: repo_path is the git repository root
+- **WHEN** a run is started
+- **THEN** `repo_path` SHALL equal the output of `git rev-parse --show-toplevel`
+
+#### Scenario: worktree_path is the git working tree root
+- **WHEN** a run is started
+- **THEN** `worktree_path` SHALL equal the output of `git rev-parse --show-toplevel`
+
+### Requirement: Branch name field in run state
+The run state JSON SHALL include a `branch_name` field auto-detected from the current git branch at run initialization.
+
+#### Scenario: branch_name is auto-detected
+- **WHEN** a run is started on branch `extend-workflow-state-machine`
+- **THEN** `branch_name` SHALL be `"extend-workflow-state-machine"`
+
+### Requirement: Agent configuration fields in run state
+The run state JSON SHALL include an `agents` object with `main` and `review` string fields identifying the agents used for the run.
+
+#### Scenario: Default agent values
+- **WHEN** a run is started without explicit agent flags
+- **THEN** `agents.main` SHALL be `"claude"`
+- **THEN** `agents.review` SHALL be `"codex"`
+
+#### Scenario: Custom agent values via flags
+- **WHEN** a run is started with `--agent-main "custom-agent" --agent-review "custom-reviewer"`
+- **THEN** `agents.main` SHALL be `"custom-agent"`
+- **THEN** `agents.review` SHALL be `"custom-reviewer"`
+
+### Requirement: Summary artifact pointer in run state
+The run state JSON SHALL include a `last_summary_path` field that points to the most recent summary artifact produced by the run.
+
+#### Scenario: Initial value is null
+- **WHEN** a run is newly created
+- **THEN** `last_summary_path` SHALL be `null`
+
+#### Scenario: Updated after summary generation
+- **WHEN** a command produces a summary artifact at a given path
+- **THEN** `last_summary_path` SHALL be updated to that path
+
+### Requirement: All new metadata fields are required
+The run state JSON SHALL always include `project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, and `last_summary_path`. None of these fields SHALL be omitted from the run state.
+
+#### Scenario: Complete run state after initialization
+- **WHEN** a run is newly created
+- **THEN** the JSON SHALL contain all of: `project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`
+- **THEN** no field SHALL be absent from the JSON output

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/extended-workflow-states/spec.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/extended-workflow-states/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Explore branch path states and transitions
+The workflow definition SHALL include an `explore` state as an independent branch path. The state machine SHALL define transitions `start` →(explore_start)→ `explore` →(explore_complete)→ `start` that form a loop independent of the mainline flow.
+
+#### Scenario: Explore state exists in the definition
+- **WHEN** the `states` array in `state-machine.json` is inspected
+- **THEN** it SHALL contain `explore`
+
+#### Scenario: Explore transitions form an independent loop
+- **WHEN** the transitions are filtered for explore-related events
+- **THEN** there SHALL be a transition `{ from: "start", event: "explore_start", to: "explore" }`
+- **THEN** there SHALL be a transition `{ from: "explore", event: "explore_complete", to: "start" }`
+
+#### Scenario: Explore does not connect to mainline phases
+- **WHEN** the transitions are filtered where `from` equals `explore`
+- **THEN** no transition SHALL have a `to` value of `proposal`, `design`, `apply`, `approved`, or `rejected`
+
+### Requirement: Spec bootstrap branch path states and transitions
+The workflow definition SHALL include a `spec_bootstrap` state as an independent branch path. The state machine SHALL define transitions `start` →(spec_bootstrap_start)→ `spec_bootstrap` →(spec_bootstrap_complete)→ `start` that form a loop independent of the mainline flow.
+
+#### Scenario: Spec bootstrap state exists in the definition
+- **WHEN** the `states` array in `state-machine.json` is inspected
+- **THEN** it SHALL contain `spec_bootstrap`
+
+#### Scenario: Spec bootstrap transitions form an independent loop
+- **WHEN** the transitions are filtered for spec_bootstrap-related events
+- **THEN** there SHALL be a transition `{ from: "start", event: "spec_bootstrap_start", to: "spec_bootstrap" }`
+- **THEN** there SHALL be a transition `{ from: "spec_bootstrap", event: "spec_bootstrap_complete", to: "start" }`
+
+#### Scenario: Spec bootstrap does not connect to mainline phases
+- **WHEN** the transitions are filtered where `from` equals `spec_bootstrap`
+- **THEN** no transition SHALL have a `to` value of `proposal`, `design`, `apply`, `approved`, or `rejected`
+
+### Requirement: Distinct revision events for design and apply
+The workflow definition SHALL define `revise_design` and `revise_apply` as separate events replacing the former generic `revise` event. Each SHALL be a self-transition on its respective phase.
+
+#### Scenario: revise_design is a self-transition on design
+- **WHEN** the transitions are filtered for `revise_design`
+- **THEN** there SHALL be exactly one transition: `{ from: "design", event: "revise_design", to: "design" }`
+
+#### Scenario: revise_apply is a self-transition on apply
+- **WHEN** the transitions are filtered for `revise_apply`
+- **THEN** there SHALL be exactly one transition: `{ from: "apply", event: "revise_apply", to: "apply" }`
+
+#### Scenario: Generic revise event does not exist
+- **WHEN** the `events` array is inspected
+- **THEN** it SHALL NOT contain `revise`
+
+### Requirement: Branch path events are defined
+The workflow definition SHALL declare events: `explore_start`, `explore_complete`, `spec_bootstrap_start`, `spec_bootstrap_complete`.
+
+#### Scenario: All branch path events exist
+- **WHEN** the `events` array in `state-machine.json` is inspected
+- **THEN** it SHALL contain `explore_start`, `explore_complete`, `spec_bootstrap_start`, `spec_bootstrap_complete`

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/run-state-management/spec.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/run-state-management/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Run state schema
+The run state JSON SHALL contain the following fields: `run_id`, `change_name`, `current_phase`, `status`, `allowed_events`, `created_at`, `updated_at`, `project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`.
+
+#### Scenario: Initial run state contents
+- **WHEN** a run is newly created
+- **THEN** the JSON SHALL contain `run_id` equal to the change name
+- **THEN** `change_name` SHALL equal the change name
+- **THEN** `current_phase` SHALL be `start`
+- **THEN** `status` SHALL be `active`
+- **THEN** `allowed_events` SHALL list events valid for the `start` state
+- **THEN** `created_at` and `updated_at` SHALL be ISO 8601 timestamps
+- **THEN** `project_id` SHALL be auto-detected from git remote origin
+- **THEN** `repo_name` SHALL equal `project_id`
+- **THEN** `repo_path` SHALL be the git repository root absolute path
+- **THEN** `branch_name` SHALL be the current git branch name
+- **THEN** `worktree_path` SHALL be the git working tree root absolute path
+- **THEN** `agents` SHALL be an object with `main` and `review` string fields
+- **THEN** `last_summary_path` SHALL be `null`
+
+#### Scenario: Run state after transition
+- **WHEN** a transition advances the run from `start` to `proposal`
+- **THEN** `current_phase` SHALL be `proposal`
+- **THEN** `allowed_events` SHALL be recomputed from the workflow definition for the `proposal` state
+- **THEN** `updated_at` SHALL be updated to the current time
+- **THEN** all metadata fields (`project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`) SHALL be preserved unchanged

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/transition-core/spec.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/transition-core/spec.md
@@ -1,8 +1,5 @@
-# transition-core Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change workflow-state-machine. Update Purpose after archive.
-## Requirements
 ### Requirement: specflow-run start command
 The system SHALL provide a `specflow-run start <run_id>` command that initializes a new run with the `start` state, auto-detects project metadata, and creates the run state file.
 
@@ -60,42 +57,3 @@ The system SHALL provide a `specflow-run advance <run_id> <event>` command that 
 #### Scenario: Metadata preserved across transitions
 - **WHEN** any transition is applied
 - **THEN** all enriched metadata fields SHALL be preserved in the updated run state
-
-### Requirement: specflow-run status command
-The system SHALL provide a `specflow-run status <run_id>` command that outputs the current run state as JSON.
-
-#### Scenario: Status of existing run
-- **WHEN** `specflow-run status workflow-state-machine` is executed
-- **THEN** the command SHALL output the full run state JSON to stdout
-- **THEN** the command SHALL exit with code 0
-
-#### Scenario: Status of nonexistent run
-- **WHEN** `specflow-run status nonexistent-run` is executed
-- **THEN** the command SHALL exit with code 1
-- **THEN** the command SHALL output an error message
-
-### Requirement: Transition validation against workflow definition
-The `advance` command SHALL load `global/workflow/state-machine.json` and validate that the requested event is a valid transition from the current state before applying it.
-
-#### Scenario: Validation reads definition at runtime
-- **WHEN** a transition is requested
-- **THEN** the command SHALL read `global/workflow/state-machine.json` to determine validity
-- **THEN** the command SHALL NOT hardcode transition rules in the script itself
-
-#### Scenario: Modified definition is reflected immediately
-- **WHEN** `state-machine.json` is modified to add a new transition
-- **THEN** the next `advance` call SHALL recognize the new transition without restarting any process
-
-### Requirement: Command output format
-All `specflow-run` subcommands SHALL output JSON to stdout for success responses and plain text error messages to stderr for failures.
-
-#### Scenario: Success output is JSON
-- **WHEN** any subcommand succeeds
-- **THEN** stdout SHALL contain valid JSON
-- **THEN** stderr SHALL be empty
-
-#### Scenario: Error output to stderr
-- **WHEN** any subcommand fails
-- **THEN** stderr SHALL contain a human-readable error message
-- **THEN** the exit code SHALL be non-zero
-

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/ui-binding-separation/spec.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/ui-binding-separation/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: UI binding metadata lives outside run.json
+Delivery-specific metadata (e.g., Slack channel, thread ID, message routing) SHALL NOT be stored in `run.json`. Such metadata SHALL be stored in separate files within the run directory following the naming convention `.specflow/runs/<run_id>/<ui>.json`.
+
+#### Scenario: run.json does not contain UI-specific fields
+- **WHEN** the `run.json` schema is inspected
+- **THEN** it SHALL NOT contain fields named `slack_channel`, `slack_thread`, `slack_message_ts`, or any delivery-routing metadata
+
+#### Scenario: UI metadata file naming convention
+- **WHEN** a future UI integration stores metadata for a run
+- **THEN** the file SHALL be named `.specflow/runs/<run_id>/<ui>.json` where `<ui>` identifies the delivery platform (e.g., `slack.json`)
+
+### Requirement: UI metadata files are gitignored
+UI binding metadata files SHALL be excluded from version control alongside the run state.
+
+#### Scenario: Gitignore covers UI metadata files
+- **WHEN** `.specflow/runs/` is matched by `.gitignore`
+- **THEN** all files within run directories including `<ui>.json` files SHALL be excluded from version control

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/workflow-definition/spec.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/specs/workflow-definition/spec.md
@@ -1,18 +1,4 @@
-# workflow-definition Specification
-
-## Purpose
-TBD - created by archiving change workflow-state-machine. Update Purpose after archive.
-## Requirements
-### Requirement: Static workflow definition file
-The system SHALL maintain a machine-readable workflow definition at `global/workflow/state-machine.json` that declares all valid states, events, and transitions for the specflow mainline flow.
-
-#### Scenario: Definition file exists and is valid JSON
-- **WHEN** the file `global/workflow/state-machine.json` is read
-- **THEN** it SHALL parse as valid JSON containing `states`, `events`, and `transitions` keys
-
-#### Scenario: Definition file is consumable by jq
-- **WHEN** the file is piped to `jq '.'`
-- **THEN** the command SHALL exit with code 0 and produce valid output
+## MODIFIED Requirements
 
 ### Requirement: Top-level phase states
 The workflow definition SHALL define the following top-level states: `start`, `proposal`, `design`, `apply`, `approved`, `rejected`, `explore`, `spec_bootstrap`.
@@ -74,13 +60,7 @@ Each transition SHALL specify a `from` state, an `event`, and a `to` state. Only
 - **WHEN** the `spec_bootstrap_complete` event is applied to `spec_bootstrap`
 - **THEN** the `to` state SHALL be `start`
 
-### Requirement: Allowed events per state
-The workflow definition SHALL provide a way to derive which events are valid for a given state by filtering transitions by `from` state.
-
-#### Scenario: Query allowed events for a state
-- **WHEN** a consumer queries transitions where `from` equals `design`
-- **THEN** the result SHALL include events `accept_design`, `reject`, and `revise`
-- **THEN** the result SHALL NOT include events belonging to other phases such as `propose` or `approve`
+## ADDED Requirements
 
 ### Requirement: Workflow definition version
 The workflow definition SHALL include a `version` field. The version SHALL be `"2.0"` to reflect the breaking change of removing the `revise` event.
@@ -88,4 +68,3 @@ The workflow definition SHALL include a `version` field. The version SHALL be `"
 #### Scenario: Version is 2.0
 - **WHEN** the `version` field in `state-machine.json` is inspected
 - **THEN** it SHALL be `"2.0"`
-

--- a/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/tasks.md
+++ b/openspec/changes/archive/2026-04-09-extend-workflow-state-machine/tasks.md
@@ -1,0 +1,44 @@
+## 1. Expand State Machine Definition
+
+- [x] 1.1 Update `global/workflow/state-machine.json`: bump version to `"2.0"`, add `explore` and `spec_bootstrap` to `states` array
+- [x] 1.2 Replace `revise` event with `revise_design` and `revise_apply` in `events` array
+- [x] 1.3 Add `explore_start`, `explore_complete`, `spec_bootstrap_start`, `spec_bootstrap_complete` to `events` array
+- [x] 1.4 Update `transitions`: remove `revise` self-transitions, add `revise_design` on design and `revise_apply` on apply
+- [x] 1.5 Add transitions for explore branch path (`start` → `explore` → `start`) and spec_bootstrap branch path (`start` → `spec_bootstrap` → `start`)
+
+## 2. Enrich Run Metadata in specflow-run
+
+- [x] 2.1 Add auto-detection functions in `bin/specflow-run`: `detect_project_id` (from git remote), `detect_repo_path`, `detect_branch_name`, `detect_worktree_path`
+- [x] 2.2 Add `--agent-main` and `--agent-review` flags to `cmd_start` with defaults `"claude"` / `"codex"`
+- [x] 2.3 Update `cmd_start` to include all new required fields (`project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`) in the initial run state JSON
+- [x] 2.4 Update `cmd_advance` to preserve all metadata fields across transitions
+- [x] 2.5 Add `specflow-run update-field <run_id> <field> <value>` subcommand for atomic single-field updates (used by `last_summary_path` lifecycle)
+- [x] 2.9 Add `validate_run_schema` helper in `bin/specflow-run` that checks for required metadata fields (`project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`) when reading `run.json`; call it from `cmd_advance`, `cmd_status`, and `cmd_update_field`; exit 1 with clear error if any field is missing
+- [x] 2.6 Wire `specflow-run update-field` into `specflow.approve` template: call after writing `approval-summary.md`
+- [x] 2.7 Update `global/commands/specflow.review_design.md` and `specflow.fix_design.md`: replace `revise` event with `revise_design` in any `specflow-run advance` calls
+- [x] 2.8 Update `global/commands/specflow.review_apply.md` and `specflow.fix_apply.md`: replace `revise` event with `revise_apply` in any `specflow-run advance` calls
+
+## 3. Update Tests
+
+- [x] 3.1 Update `tests/test-specflow-run.sh`: replace `revise` event references with `revise_design` / `revise_apply`
+- [x] 3.2 Add test cases for explore branch path transitions (start → explore → start)
+- [x] 3.3 Add test cases for spec_bootstrap branch path transitions (start → spec_bootstrap → start)
+- [x] 3.4 Add test cases verifying enriched metadata fields are present in initial run state
+- [x] 3.5 Add test cases verifying metadata is preserved across transitions
+- [x] 3.6 Add test cases for `--agent-main` / `--agent-review` flag handling
+- [x] 3.7 Add test case verifying `revise_design` self-transition records correct history entry (`from: "design"`, `to: "design"`, `event: "revise_design"`)
+- [x] 3.8 Add test case verifying `revise_apply` self-transition records correct history entry
+- [x] 3.9 Add test case verifying branch-path transitions recompute `allowed_events` correctly (e.g., `explore` state only allows `explore_complete`)
+- [x] 3.10 Add test case verifying removed `revise` event returns error with allowed events list
+- [x] 3.11 Add test case verifying `project_id` equals parsed `owner/repo` from git remote and `repo_name` equals `project_id`
+- [x] 3.12 Add test case for `specflow-run update-field` subcommand (update `last_summary_path`)
+- [x] 3.13 Add test case verifying `specflow-run advance` fails with error on pre-2.0 `run.json` missing required metadata fields
+
+## 4. Documentation
+
+- [x] 4.1 Document UI binding metadata convention (`.specflow/runs/<run_id>/<ui>.json` naming) in README and architecture docs
+- [x] 4.2 Update README to mention workflow core components (state-machine.json, specflow-run, run.json) and link to architecture docs
+- [x] 4.3 Document expanded states (`explore`, `spec_bootstrap`) and new events in README workflow section; note that branch paths are state-machine-only (no run state persistence yet, per D6)
+- [x] 4.4 Document the `revise` → `revise_design`/`revise_apply` breaking change and version bump to 2.0 in README and architecture docs
+- [x] 4.5 Document the enriched `run.json` metadata schema (all required fields, auto-detection strategy) in architecture docs
+- [x] 4.6 Document no-migration policy for existing runs (old runs disposable, gitignored) in architecture docs

--- a/openspec/specs/enriched-run-metadata/spec.md
+++ b/openspec/specs/enriched-run-metadata/spec.md
@@ -1,0 +1,66 @@
+# enriched-run-metadata Specification
+
+## Purpose
+TBD - created by archiving change extend-workflow-state-machine. Update Purpose after archive.
+## Requirements
+### Requirement: Project identification fields in run state
+The run state JSON SHALL include `project_id` and `repo_name` fields. `project_id` SHALL be derived from the repository's remote origin in `owner/repo` format. `repo_name` SHALL equal the `project_id` value.
+
+#### Scenario: project_id is auto-detected from git remote
+- **WHEN** a run is started in a repository with remote origin `https://github.com/skr19930617/specflow.git`
+- **THEN** `project_id` SHALL be `"skr19930617/specflow"`
+
+#### Scenario: repo_name equals project_id
+- **WHEN** a run is newly created
+- **THEN** `repo_name` SHALL equal the value of `project_id`
+
+### Requirement: Repository path fields in run state
+The run state JSON SHALL include `repo_path` and `worktree_path` fields. Both SHALL be absolute filesystem paths auto-detected from git at run initialization.
+
+#### Scenario: repo_path is the git repository root
+- **WHEN** a run is started
+- **THEN** `repo_path` SHALL equal the output of `git rev-parse --show-toplevel`
+
+#### Scenario: worktree_path is the git working tree root
+- **WHEN** a run is started
+- **THEN** `worktree_path` SHALL equal the output of `git rev-parse --show-toplevel`
+
+### Requirement: Branch name field in run state
+The run state JSON SHALL include a `branch_name` field auto-detected from the current git branch at run initialization.
+
+#### Scenario: branch_name is auto-detected
+- **WHEN** a run is started on branch `extend-workflow-state-machine`
+- **THEN** `branch_name` SHALL be `"extend-workflow-state-machine"`
+
+### Requirement: Agent configuration fields in run state
+The run state JSON SHALL include an `agents` object with `main` and `review` string fields identifying the agents used for the run.
+
+#### Scenario: Default agent values
+- **WHEN** a run is started without explicit agent flags
+- **THEN** `agents.main` SHALL be `"claude"`
+- **THEN** `agents.review` SHALL be `"codex"`
+
+#### Scenario: Custom agent values via flags
+- **WHEN** a run is started with `--agent-main "custom-agent" --agent-review "custom-reviewer"`
+- **THEN** `agents.main` SHALL be `"custom-agent"`
+- **THEN** `agents.review` SHALL be `"custom-reviewer"`
+
+### Requirement: Summary artifact pointer in run state
+The run state JSON SHALL include a `last_summary_path` field that points to the most recent summary artifact produced by the run.
+
+#### Scenario: Initial value is null
+- **WHEN** a run is newly created
+- **THEN** `last_summary_path` SHALL be `null`
+
+#### Scenario: Updated after summary generation
+- **WHEN** a command produces a summary artifact at a given path
+- **THEN** `last_summary_path` SHALL be updated to that path
+
+### Requirement: All new metadata fields are required
+The run state JSON SHALL always include `project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, and `last_summary_path`. None of these fields SHALL be omitted from the run state.
+
+#### Scenario: Complete run state after initialization
+- **WHEN** a run is newly created
+- **THEN** the JSON SHALL contain all of: `project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`
+- **THEN** no field SHALL be absent from the JSON output
+

--- a/openspec/specs/extended-workflow-states/spec.md
+++ b/openspec/specs/extended-workflow-states/spec.md
@@ -1,0 +1,59 @@
+# extended-workflow-states Specification
+
+## Purpose
+TBD - created by archiving change extend-workflow-state-machine. Update Purpose after archive.
+## Requirements
+### Requirement: Explore branch path states and transitions
+The workflow definition SHALL include an `explore` state as an independent branch path. The state machine SHALL define transitions `start` →(explore_start)→ `explore` →(explore_complete)→ `start` that form a loop independent of the mainline flow.
+
+#### Scenario: Explore state exists in the definition
+- **WHEN** the `states` array in `state-machine.json` is inspected
+- **THEN** it SHALL contain `explore`
+
+#### Scenario: Explore transitions form an independent loop
+- **WHEN** the transitions are filtered for explore-related events
+- **THEN** there SHALL be a transition `{ from: "start", event: "explore_start", to: "explore" }`
+- **THEN** there SHALL be a transition `{ from: "explore", event: "explore_complete", to: "start" }`
+
+#### Scenario: Explore does not connect to mainline phases
+- **WHEN** the transitions are filtered where `from` equals `explore`
+- **THEN** no transition SHALL have a `to` value of `proposal`, `design`, `apply`, `approved`, or `rejected`
+
+### Requirement: Spec bootstrap branch path states and transitions
+The workflow definition SHALL include a `spec_bootstrap` state as an independent branch path. The state machine SHALL define transitions `start` →(spec_bootstrap_start)→ `spec_bootstrap` →(spec_bootstrap_complete)→ `start` that form a loop independent of the mainline flow.
+
+#### Scenario: Spec bootstrap state exists in the definition
+- **WHEN** the `states` array in `state-machine.json` is inspected
+- **THEN** it SHALL contain `spec_bootstrap`
+
+#### Scenario: Spec bootstrap transitions form an independent loop
+- **WHEN** the transitions are filtered for spec_bootstrap-related events
+- **THEN** there SHALL be a transition `{ from: "start", event: "spec_bootstrap_start", to: "spec_bootstrap" }`
+- **THEN** there SHALL be a transition `{ from: "spec_bootstrap", event: "spec_bootstrap_complete", to: "start" }`
+
+#### Scenario: Spec bootstrap does not connect to mainline phases
+- **WHEN** the transitions are filtered where `from` equals `spec_bootstrap`
+- **THEN** no transition SHALL have a `to` value of `proposal`, `design`, `apply`, `approved`, or `rejected`
+
+### Requirement: Distinct revision events for design and apply
+The workflow definition SHALL define `revise_design` and `revise_apply` as separate events replacing the former generic `revise` event. Each SHALL be a self-transition on its respective phase.
+
+#### Scenario: revise_design is a self-transition on design
+- **WHEN** the transitions are filtered for `revise_design`
+- **THEN** there SHALL be exactly one transition: `{ from: "design", event: "revise_design", to: "design" }`
+
+#### Scenario: revise_apply is a self-transition on apply
+- **WHEN** the transitions are filtered for `revise_apply`
+- **THEN** there SHALL be exactly one transition: `{ from: "apply", event: "revise_apply", to: "apply" }`
+
+#### Scenario: Generic revise event does not exist
+- **WHEN** the `events` array is inspected
+- **THEN** it SHALL NOT contain `revise`
+
+### Requirement: Branch path events are defined
+The workflow definition SHALL declare events: `explore_start`, `explore_complete`, `spec_bootstrap_start`, `spec_bootstrap_complete`.
+
+#### Scenario: All branch path events exist
+- **WHEN** the `events` array in `state-machine.json` is inspected
+- **THEN** it SHALL contain `explore_start`, `explore_complete`, `spec_bootstrap_start`, `spec_bootstrap_complete`
+

--- a/openspec/specs/run-state-management/spec.md
+++ b/openspec/specs/run-state-management/spec.md
@@ -16,7 +16,7 @@ The system SHALL store per-run state at `.specflow/runs/<run_id>/run.json` where
 - **THEN** each subdirectory name SHALL match the corresponding OpenSpec change name
 
 ### Requirement: Run state schema
-The run state JSON SHALL contain the following fields: `run_id`, `change_name`, `current_phase`, `status`, `allowed_events`, `created_at`, `updated_at`.
+The run state JSON SHALL contain the following fields: `run_id`, `change_name`, `current_phase`, `status`, `allowed_events`, `created_at`, `updated_at`, `project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`.
 
 #### Scenario: Initial run state contents
 - **WHEN** a run is newly created
@@ -26,12 +26,20 @@ The run state JSON SHALL contain the following fields: `run_id`, `change_name`, 
 - **THEN** `status` SHALL be `active`
 - **THEN** `allowed_events` SHALL list events valid for the `start` state
 - **THEN** `created_at` and `updated_at` SHALL be ISO 8601 timestamps
+- **THEN** `project_id` SHALL be auto-detected from git remote origin
+- **THEN** `repo_name` SHALL equal `project_id`
+- **THEN** `repo_path` SHALL be the git repository root absolute path
+- **THEN** `branch_name` SHALL be the current git branch name
+- **THEN** `worktree_path` SHALL be the git working tree root absolute path
+- **THEN** `agents` SHALL be an object with `main` and `review` string fields
+- **THEN** `last_summary_path` SHALL be `null`
 
 #### Scenario: Run state after transition
 - **WHEN** a transition advances the run from `start` to `proposal`
 - **THEN** `current_phase` SHALL be `proposal`
 - **THEN** `allowed_events` SHALL be recomputed from the workflow definition for the `proposal` state
 - **THEN** `updated_at` SHALL be updated to the current time
+- **THEN** all metadata fields (`project_id`, `repo_name`, `repo_path`, `branch_name`, `worktree_path`, `agents`, `last_summary_path`) SHALL be preserved unchanged
 
 ### Requirement: Run state history
 The run state SHALL include a `history` array that records each transition event with timestamp.

--- a/openspec/specs/ui-binding-separation/spec.md
+++ b/openspec/specs/ui-binding-separation/spec.md
@@ -1,0 +1,23 @@
+# ui-binding-separation Specification
+
+## Purpose
+TBD - created by archiving change extend-workflow-state-machine. Update Purpose after archive.
+## Requirements
+### Requirement: UI binding metadata lives outside run.json
+Delivery-specific metadata (e.g., Slack channel, thread ID, message routing) SHALL NOT be stored in `run.json`. Such metadata SHALL be stored in separate files within the run directory following the naming convention `.specflow/runs/<run_id>/<ui>.json`.
+
+#### Scenario: run.json does not contain UI-specific fields
+- **WHEN** the `run.json` schema is inspected
+- **THEN** it SHALL NOT contain fields named `slack_channel`, `slack_thread`, `slack_message_ts`, or any delivery-routing metadata
+
+#### Scenario: UI metadata file naming convention
+- **WHEN** a future UI integration stores metadata for a run
+- **THEN** the file SHALL be named `.specflow/runs/<run_id>/<ui>.json` where `<ui>` identifies the delivery platform (e.g., `slack.json`)
+
+### Requirement: UI metadata files are gitignored
+UI binding metadata files SHALL be excluded from version control alongside the run state.
+
+#### Scenario: Gitignore covers UI metadata files
+- **WHEN** `.specflow/runs/` is matched by `.gitignore`
+- **THEN** all files within run directories including `<ui>.json` files SHALL be excluded from version control
+

--- a/tests/test-specflow-run.sh
+++ b/tests/test-specflow-run.sh
@@ -36,7 +36,17 @@ cleanup() {
   rm -rf "${RUNS_DIR}/workflow-state-machine"
 }
 
+ensure_test_change() {
+  # Create a dummy openspec change directory so validate_run_id passes
+  mkdir -p "${REPO_ROOT}/openspec/changes/workflow-state-machine"
+}
+
+teardown_test_change() {
+  rm -rf "${REPO_ROOT}/openspec/changes/workflow-state-machine"
+}
+
 setup_stubs
+ensure_test_change
 
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
@@ -85,7 +95,7 @@ cleanup
 out="$("$BIN" start workflow-state-machine)"
 assert_json_field "start phase" "$out" ".current_phase" "start"
 assert_json_field "start status" "$out" ".status" "active"
-assert_json_field "start allowed" "$out" '.allowed_events | join(",")' "propose"
+assert_json_field "start has propose" "$out" '.allowed_events | contains(["propose"])' "true"
 
 out="$("$BIN" advance workflow-state-machine propose)"
 assert_json_field "propose phase" "$out" ".current_phase" "proposal"
@@ -108,16 +118,16 @@ assert_exit "invalid transition exits 1" "1" "$BIN" advance workflow-state-machi
 assert_stderr_contains "invalid transition lists allowed" "Allowed events" "$BIN" advance workflow-state-machine approve
 
 echo ""
-echo "=== Test 3: Revise self-transition ==="
+echo "=== Test 3: revise_design self-transition ==="
 cleanup
 "$BIN" start workflow-state-machine >/dev/null
 "$BIN" advance workflow-state-machine propose >/dev/null
 "$BIN" advance workflow-state-machine accept_proposal >/dev/null
-out="$("$BIN" advance workflow-state-machine revise)"
-assert_json_field "revise stays in design" "$out" ".current_phase" "design"
-assert_json_field "revise history from" "$out" '.history[-1].from' "design"
-assert_json_field "revise history to" "$out" '.history[-1].to' "design"
-assert_json_field "revise history event" "$out" '.history[-1].event' "revise"
+out="$("$BIN" advance workflow-state-machine revise_design)"
+assert_json_field "revise_design stays in design" "$out" ".current_phase" "design"
+assert_json_field "revise_design history from" "$out" '.history[-1].from' "design"
+assert_json_field "revise_design history to" "$out" '.history[-1].to' "design"
+assert_json_field "revise_design history event" "$out" '.history[-1].event' "revise_design"
 
 echo ""
 echo "=== Test 4: Start with --issue-url ==="
@@ -186,8 +196,110 @@ else
   ((FAIL++))
 fi
 
+echo ""
+echo "=== Test 13: Explore branch path ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+out="$("$BIN" advance workflow-state-machine explore_start)"
+assert_json_field "explore_start phase" "$out" ".current_phase" "explore"
+out="$("$BIN" advance workflow-state-machine explore_complete)"
+assert_json_field "explore_complete returns to start" "$out" ".current_phase" "start"
+
+echo ""
+echo "=== Test 14: Spec bootstrap branch path ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+out="$("$BIN" advance workflow-state-machine spec_bootstrap_start)"
+assert_json_field "spec_bootstrap_start phase" "$out" ".current_phase" "spec_bootstrap"
+out="$("$BIN" advance workflow-state-machine spec_bootstrap_complete)"
+assert_json_field "spec_bootstrap_complete returns to start" "$out" ".current_phase" "start"
+
+echo ""
+echo "=== Test 15: Enriched metadata in initial run state ==="
+cleanup
+expected_repo_path="$(git rev-parse --show-toplevel)"
+expected_branch="$(git rev-parse --abbrev-ref HEAD)"
+expected_project_id="$(git remote get-url origin | sed -E 's|\.git$||' | sed -E 's|^.*[:/]([^/]+/[^/]+)$|\1|')"
+out="$("$BIN" start workflow-state-machine)"
+assert_json_field "project_id matches git" "$out" '.project_id' "$expected_project_id"
+assert_json_field "repo_name equals project_id" "$out" '(.repo_name == .project_id)' "true"
+assert_json_field "repo_path matches git" "$out" '.repo_path' "$expected_repo_path"
+assert_json_field "branch_name matches git" "$out" '.branch_name' "$expected_branch"
+assert_json_field "worktree_path matches git" "$out" '.worktree_path' "$expected_repo_path"
+assert_json_field "has agents.main" "$out" '.agents.main' "claude"
+assert_json_field "has agents.review" "$out" '.agents.review' "codex"
+assert_json_field "last_summary_path is null" "$out" '.last_summary_path' "null"
+
+echo ""
+echo "=== Test 16: Metadata preserved across transitions ==="
+cleanup
+out1="$("$BIN" start workflow-state-machine)"
+pid1="$(echo "$out1" | jq -r '.project_id')"
+out2="$("$BIN" advance workflow-state-machine propose)"
+pid2="$(echo "$out2" | jq -r '.project_id')"
+assert_eq "project_id preserved" "$pid1" "$pid2"
+assert_json_field "agents preserved" "$out2" '.agents.main' "claude"
+assert_json_field "repo_path preserved" "$out2" ".repo_path" "$(echo "$out1" | jq -r '.repo_path')"
+
+echo ""
+echo "=== Test 17: --agent-main / --agent-review flags ==="
+cleanup
+out="$("$BIN" start workflow-state-machine --agent-main custom-agent --agent-review custom-rev)"
+assert_json_field "custom agent main" "$out" '.agents.main' "custom-agent"
+assert_json_field "custom agent review" "$out" '.agents.review' "custom-rev"
+
+echo ""
+echo "=== Test 18: revise_apply self-transition ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+"$BIN" advance workflow-state-machine propose >/dev/null
+"$BIN" advance workflow-state-machine accept_proposal >/dev/null
+"$BIN" advance workflow-state-machine accept_design >/dev/null
+out="$("$BIN" advance workflow-state-machine revise_apply)"
+assert_json_field "revise_apply stays in apply" "$out" ".current_phase" "apply"
+assert_json_field "revise_apply history event" "$out" '.history[-1].event' "revise_apply"
+
+echo ""
+echo "=== Test 19: Branch path allowed_events ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+out="$("$BIN" advance workflow-state-machine explore_start)"
+assert_json_field "explore only allows explore_complete" "$out" '.allowed_events | join(",")' "explore_complete"
+
+echo ""
+echo "=== Test 20: Removed revise event returns error ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+"$BIN" advance workflow-state-machine propose >/dev/null
+"$BIN" advance workflow-state-machine accept_proposal >/dev/null
+assert_exit "revise event rejected" "1" "$BIN" advance workflow-state-machine revise
+assert_stderr_contains "revise error lists allowed" "Allowed events" "$BIN" advance workflow-state-machine revise
+
+echo ""
+echo "=== Test 21: update-field subcommand ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+out="$("$BIN" update-field workflow-state-machine last_summary_path "/path/to/summary.md")"
+assert_json_field "updated last_summary_path" "$out" '.last_summary_path' "/path/to/summary.md"
+
+echo ""
+echo "=== Test 22: update-field rejects disallowed fields ==="
+cleanup
+"$BIN" start workflow-state-machine >/dev/null
+assert_exit "reject disallowed field" "1" "$BIN" update-field workflow-state-machine current_phase hacked
+assert_stderr_contains "rejects disallowed field" "not updatable" "$BIN" update-field workflow-state-machine current_phase hacked
+
+echo ""
+echo "=== Test 23: Pre-2.0 run.json fails validation ==="
+cleanup
+mkdir -p "${RUNS_DIR}/workflow-state-machine"
+echo '{"run_id":"workflow-state-machine","change_name":"workflow-state-machine","current_phase":"start","status":"active","allowed_events":["propose"],"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z","history":[],"issue":null}' > "${RUNS_DIR}/workflow-state-machine/run.json"
+assert_exit "old schema fails advance" "1" "$BIN" advance workflow-state-machine propose
+assert_stderr_contains "old schema error message" "missing required fields" "$BIN" status workflow-state-machine
+
 # ── Cleanup and summary ───────────────────────────────────────────────
 cleanup
+teardown_test_change
 teardown_stubs
 echo ""
 echo "==============================="


### PR DESCRIPTION
## Summary
- Expand `state-machine.json` to v2.0: 8 states, 11 events, 13 transitions (add explore, spec_bootstrap, split revise into revise_design/revise_apply)
- Enrich `run.json` with project_id, repo_name, repo_path, branch_name, worktree_path, agents, last_summary_path — all required and auto-detected
- Add `specflow-run update-field` subcommand with field whitelist for atomic metadata updates
- Add `validate_run_schema` for fail-fast on pre-2.0 run.json files
- Document UI binding metadata separation convention (`.specflow/runs/<id>/<ui>.json`)
- Add `docs/architecture.md` and README workflow core section

## Test plan
- [x] 55/55 test assertions passing (23 test groups)
- [x] Explore/spec_bootstrap branch path transitions verified
- [x] Enriched metadata auto-detection and preservation across transitions verified
- [x] revise_design/revise_apply self-transitions with history recording verified
- [x] Removed `revise` event returns proper error
- [x] update-field whitelist enforcement verified
- [x] Pre-2.0 run.json schema validation verified

## Issue
Closes https://github.com/skr19930617/specflow/issues/73