### PR TITLE
feat: extract design-side control flow into Bash orchestrator (#78)

### DIFF
--- a/bin/specflow-design-artifacts
+++ b/bin/specflow-design-artifacts
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# specflow-design-artifacts — Artifact dependency loop for design phase
+#
+# Subcommands:
+#   next <CHANGE_ID>      Return metadata for the next ready artifact
+#   validate <CHANGE_ID>  Run structural validation
+#
+# Outputs JSON to stdout. Logs/progress to stderr.
+
+set -euo pipefail
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+die() { echo "$1" >&2; exit 1; }
+
+log() { echo "$1" >&2; }
+
+usage() {
+  cat >&2 <<EOF
+Usage: specflow-design-artifacts <subcommand> <CHANGE_ID>
+
+Subcommands:
+  next      Return the next ready artifact's metadata (one-at-a-time)
+  validate  Run structural validation on the change
+
+EOF
+  exit 1
+}
+
+# ── Subcommand: next ───────────────────────────────────────────────────
+
+cmd_next() {
+  local change_id="$1"
+
+  # Poll openspec status
+  local status_json
+  status_json="$(openspec status --change "$change_id" --json 2>/dev/null)" || {
+    jq -n --arg e "openspec status failed" '{"status":"error","error":$e}'
+    exit 1
+  }
+
+  # Check if all applyRequires are done
+  local is_complete
+  is_complete="$(echo "$status_json" | jq -r '.isComplete // false')"
+  if [[ "$is_complete" == "true" ]]; then
+    jq -n '{"status":"complete"}'
+    return 0
+  fi
+
+  # Find ready artifacts
+  local ready_artifacts
+  ready_artifacts="$(echo "$status_json" | jq -c '[.artifacts[] | select(.status == "ready")]')"
+  local ready_count
+  ready_count="$(echo "$ready_artifacts" | jq 'length')"
+
+  if (( ready_count == 0 )); then
+    # No ready artifacts — check for blocked
+    local blocked_ids
+    blocked_ids="$(echo "$status_json" | jq -c '[.artifacts[] | select(.status == "blocked") | .id]')"
+    jq -n --argjson blocked "$blocked_ids" '{"status":"blocked","blocked":$blocked}'
+    exit 1
+  fi
+
+  # Take the first ready artifact
+  local artifact_id
+  artifact_id="$(echo "$ready_artifacts" | jq -r '.[0].id')"
+
+  log "Fetching instructions for artifact: ${artifact_id}"
+
+  # Fetch instructions
+  local instructions_json
+  instructions_json="$(openspec instructions "$artifact_id" --change "$change_id" --json 2>/dev/null)" || {
+    jq -n --arg e "openspec instructions failed for ${artifact_id}" '{"status":"error","error":$e}'
+    exit 1
+  }
+
+  # Output metadata
+  echo "$instructions_json" | jq -c '{
+    status: "ready",
+    artifactId: .artifactId,
+    outputPath: .outputPath,
+    template: .template,
+    instruction: .instruction,
+    dependencies: [(.dependencies // [])[] | {id: .id, path: .path, done: .done}]
+  }'
+}
+
+# ── Subcommand: validate ──────────────────────────────────────────────
+
+cmd_validate() {
+  local change_id="$1"
+
+  local result
+  local exit_code=0
+  result="$(openspec validate "$change_id" --type change --json 2>&1)" || exit_code=$?
+
+  # Parse the result
+  if echo "$result" | jq empty 2>/dev/null; then
+    local valid
+    valid="$(echo "$result" | jq -r '.items[0].valid // false')"
+    if [[ "$valid" == "true" ]]; then
+      jq -n '{"status":"valid"}'
+      return 0
+    else
+      echo "$result" | jq -c '. + {status: "invalid"}'
+      exit 1
+    fi
+  else
+    jq -n --arg e "$result" '{"status":"error","error":$e}'
+    exit 1
+  fi
+}
+
+# ── Main dispatch ─────────────────────────────────────────────────────
+
+[[ $# -ge 1 ]] || usage
+
+SUBCMD="$1"; shift
+
+case "$SUBCMD" in
+  next)
+    [[ $# -ge 1 ]] || { echo "Error: CHANGE_ID required" >&2; usage; }
+    cmd_next "$1"
+    ;;
+  validate)
+    [[ $# -ge 1 ]] || { echo "Error: CHANGE_ID required" >&2; usage; }
+    cmd_validate "$1"
+    ;;
+  *)
+    echo "Error: unknown subcommand '$SUBCMD'" >&2
+    usage
+    ;;
+esac

--- a/bin/specflow-review-apply
+++ b/bin/specflow-review-apply
@@ -10,8 +10,19 @@
 
 set -euo pipefail
 
+# ── Resolve symlinks (needed when invoked via ~/bin symlink) ──────────
+resolve_symlink() {
+  local src="$1"
+  while [[ -L "$src" ]]; do
+    local dir="$(cd "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    [[ "$src" != /* ]] && src="$dir/$src"
+  done
+  echo "$src"
+}
+
 # ── Paths ──────────────────────────────────────────────────────────────
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(resolve_symlink "$0")")" && pwd)"
 LIB_DIR="$(cd "${SCRIPT_DIR}/../lib" && pwd)"
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {

--- a/bin/specflow-review-design
+++ b/bin/specflow-review-design
@@ -1,0 +1,843 @@
+#!/usr/bin/env bash
+# specflow-review-design — Design-side orchestrator for review/fix/autofix loop
+#
+# Subcommands:
+#   review <CHANGE_ID> [--reset-ledger]      Initial design review
+#   fix-review <CHANGE_ID> [--reset-ledger]  Re-review after fixes
+#   autofix-loop <CHANGE_ID> [--max-rounds N] Auto-fix loop
+#
+# Outputs unified result JSON to stdout. Logs/progress to stderr.
+
+set -euo pipefail
+
+# ── Paths ──────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB_DIR="$(cd "${SCRIPT_DIR}/../lib" && pwd)"
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo '{"status":"error","error":"not_in_git_repo"}'; exit 1
+}
+
+PROMPTS_DIR="${HOME}/.config/specflow/global/prompts"
+
+# ── Source libraries ───────────────────────────────────────────────────
+# shellcheck source=../lib/specflow-ledger.sh
+source "${LIB_DIR}/specflow-ledger.sh"
+
+# Initialize ledger for design-side
+ledger_init "review-ledger-design.json" "design"
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+die() { echo "$1" >&2; exit 1; }
+
+log() { echo "$1" >&2; }
+
+now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+error_json() {
+  local action="$1" change_id="$2" error_msg="$3"
+  jq -n --arg a "$action" --arg c "$change_id" --arg e "$error_msg" \
+    '{"status":"error","action":$a,"change_id":$c,"error":$e}'
+}
+
+read_config() {
+  local config="${PROJECT_ROOT}/openspec/config.yaml"
+  if [[ -f "$config" ]]; then
+    MAX_AUTOFIX_ROUNDS="$(grep -E '^\s*max_autofix_rounds:' "$config" 2>/dev/null | head -1 | sed 's/.*: *//' | tr -d '[:space:]')"
+    if [[ ! "$MAX_AUTOFIX_ROUNDS" =~ ^[0-9]+$ ]] || (( MAX_AUTOFIX_ROUNDS < 1 || MAX_AUTOFIX_ROUNDS > 10 )); then
+      MAX_AUTOFIX_ROUNDS=4
+    fi
+  else
+    MAX_AUTOFIX_ROUNDS=4
+  fi
+}
+
+validate_change() {
+  local change_id="$1"
+  local change_dir="${PROJECT_ROOT}/openspec/changes/${change_id}"
+  [[ -d "$change_dir" ]] || die "Error: change directory not found: ${change_dir}"
+  [[ -f "${change_dir}/proposal.md" ]] || die "Error: proposal.md not found in ${change_dir}"
+  echo "$change_dir"
+}
+
+# ── Artifact Reading ──────────────────────────────────────────────────
+
+read_artifacts() {
+  local change_dir="$1"
+  local proposal_content="" design_content="" tasks_content="" specs_content=""
+
+  # Read proposal
+  [[ -f "${change_dir}/proposal.md" ]] && proposal_content="$(cat "${change_dir}/proposal.md")"
+
+  # Read design
+  if [[ -f "${change_dir}/design.md" ]]; then
+    design_content="$(cat "${change_dir}/design.md")"
+  else
+    log "Warning: design.md not found"
+  fi
+
+  # Read tasks
+  if [[ -f "${change_dir}/tasks.md" ]]; then
+    tasks_content="$(cat "${change_dir}/tasks.md")"
+  else
+    log "Warning: tasks.md not found"
+  fi
+
+  # Read spec files
+  local spec_files
+  spec_files="$(find "${change_dir}/specs" -name "spec.md" 2>/dev/null || true)"
+  if [[ -n "$spec_files" ]]; then
+    while IFS= read -r spec_file; do
+      local rel_path="${spec_file#${change_dir}/}"
+      specs_content+="--- ${rel_path} ---"$'\n'"$(cat "$spec_file")"$'\n\n'
+    done <<< "$spec_files"
+  fi
+
+  # Check required artifacts
+  if [[ -z "$design_content" || -z "$tasks_content" ]]; then
+    return 1
+  fi
+
+  # Export for caller
+  ARTIFACT_PROPOSAL="$proposal_content"
+  ARTIFACT_DESIGN="$design_content"
+  ARTIFACT_TASKS="$tasks_content"
+  ARTIFACT_SPECS="$specs_content"
+  return 0
+}
+
+# ── Codex CLI ──────────────────────────────────────────────────────────
+
+build_review_prompt() {
+  local change_dir="$1"
+  local prompt_file="${PROMPTS_DIR}/review_design_prompt.md"
+  [[ -f "$prompt_file" ]] || die "Error: review prompt not found: ${prompt_file}"
+
+  local tmp
+  tmp="$(mktemp /tmp/specflow-codex-prompt-XXXXX.md)"
+
+  cat "$prompt_file" > "$tmp"
+  printf '\n\nPROPOSAL CONTENT:\n%s' "$ARTIFACT_PROPOSAL" >> "$tmp"
+  if [[ -n "$ARTIFACT_SPECS" ]]; then
+    printf '\n\nSPEC FILES:\n%s' "$ARTIFACT_SPECS" >> "$tmp"
+  fi
+  printf '\n\nDESIGN CONTENT:\n%s' "$ARTIFACT_DESIGN" >> "$tmp"
+  printf '\n\nTASKS CONTENT:\n%s' "$ARTIFACT_TASKS" >> "$tmp"
+
+  echo "$tmp"
+}
+
+build_rereview_prompt() {
+  local change_dir="$1" prev_findings="$2" max_fid="$3"
+  local prompt_file="${PROMPTS_DIR}/review_design_rereview_prompt.md"
+  [[ -f "$prompt_file" ]] || die "Error: re-review prompt not found: ${prompt_file}"
+
+  local tmp
+  tmp="$(mktemp /tmp/specflow-codex-prompt-XXXXX.md)"
+
+  cat "$prompt_file" > "$tmp"
+  printf '\n\nPREVIOUS_FINDINGS:\n%s\n' "$prev_findings" >> "$tmp"
+  printf '\nMAX_FINDING_ID:\n%s\n' "$max_fid" >> "$tmp"
+  printf '\n\nPROPOSAL CONTENT:\n%s' "$ARTIFACT_PROPOSAL" >> "$tmp"
+  if [[ -n "$ARTIFACT_SPECS" ]]; then
+    printf '\n\nSPEC FILES:\n%s' "$ARTIFACT_SPECS" >> "$tmp"
+  fi
+  printf '\n\nDESIGN CONTENT:\n%s' "$ARTIFACT_DESIGN" >> "$tmp"
+  printf '\n\nTASKS CONTENT:\n%s' "$ARTIFACT_TASKS" >> "$tmp"
+
+  echo "$tmp"
+}
+
+build_fix_prompt() {
+  local change_dir="$1" findings_json="$2"
+  local prompt_file="${PROMPTS_DIR}/fix_design_prompt.md"
+  # Fallback to generic fix instruction if prompt doesn't exist
+  local tmp
+  tmp="$(mktemp /tmp/specflow-codex-prompt-XXXXX.md)"
+
+  if [[ -f "$prompt_file" ]]; then
+    cat "$prompt_file" > "$tmp"
+  else
+    cat > "$tmp" <<'FIXEOF'
+You are a design and tasks fixer. Based on the review findings below, fix all issues in the design and task documents.
+Apply fixes for all findings. Do not skip any. Modify design.md and tasks.md as needed.
+FIXEOF
+  fi
+
+  printf '\n\nREVIEW FINDINGS:\n%s\n' "$findings_json" >> "$tmp"
+  printf '\n\nPROPOSAL CONTENT:\n%s' "$ARTIFACT_PROPOSAL" >> "$tmp"
+  printf '\n\nDESIGN CONTENT:\n%s' "$ARTIFACT_DESIGN" >> "$tmp"
+  printf '\n\nTASKS CONTENT:\n%s' "$ARTIFACT_TASKS" >> "$tmp"
+
+  echo "$tmp"
+}
+
+call_codex() {
+  local prompt_file="$1"
+  local output exit_code=0
+
+  output="$(codex --approval-mode full-auto -q "$(cat "$prompt_file")" 2>/dev/null)" || exit_code=$?
+  rm -f "$prompt_file"
+
+  if [[ $exit_code -ne 0 ]]; then
+    echo "__CODEX_EXIT_${exit_code}__"
+    return 1
+  fi
+
+  if [[ -z "$output" ]]; then
+    echo "__CODEX_EMPTY__"
+    return 1
+  fi
+
+  # Try to parse as JSON
+  if echo "$output" | jq empty 2>/dev/null; then
+    echo "$output"
+    return 0
+  else
+    # Try extracting JSON from markdown code blocks
+    local extracted
+    extracted="$(echo "$output" | sed -n '/^```json/,/^```$/p' | sed '1d;$d')"
+    if [[ -n "$extracted" ]] && echo "$extracted" | jq empty 2>/dev/null; then
+      echo "$extracted"
+      return 0
+    fi
+    echo "__CODEX_PARSE_FAIL__${output}"
+    return 1
+  fi
+}
+
+# ── Current Phase Generation ──────────────────────────────────────────
+
+generate_current_phase() {
+  local change_dir="$1" ledger_json="$2"
+
+  local feature_id current_round status
+  feature_id="$(echo "$ledger_json" | jq -r '.feature_id // "unknown"')"
+  current_round="$(echo "$ledger_json" | jq -r '.current_round // 1')"
+  status="$(echo "$ledger_json" | jq -r '.status // "in_progress"')"
+
+  local phase
+  if (( current_round <= 1 )); then phase="design-review"; else phase="design-fix-review"; fi
+
+  local open_high_count open_high_titles
+  open_high_count="$(echo "$ledger_json" | jq '[.findings[] | select(.severity == "high" and (.status == "new" or .status == "open"))] | length')"
+  open_high_titles="$(echo "$ledger_json" | jq -r '[.findings[] | select(.severity == "high" and (.status == "new" or .status == "open")) | .title] | join("\", \"")')"
+
+  local open_high_str
+  if (( open_high_count > 0 )); then
+    open_high_str="${open_high_count} 件 — \"${open_high_titles}\""
+  else
+    open_high_str="0 件"
+  fi
+
+  local accepted_risks
+  accepted_risks="$(echo "$ledger_json" | jq -r '[.findings[] | select(.status == "accepted_risk" or .status == "ignored") | "\(.title) (\(.status), notes: \"\(.notes)\")"] | if length == 0 then "none" else join("\n") end')"
+
+  local latest_changes
+  latest_changes="$(git log --oneline -5 "$(git merge-base HEAD "${BASE_BRANCH:-main}" 2>/dev/null)"..HEAD 2>/dev/null | sed 's/^/  - /')" || latest_changes="  - (no commits yet)"
+  [[ -n "$latest_changes" ]] || latest_changes="  - (no commits yet)"
+
+  local next_action
+  if (( open_high_count > 0 )); then next_action="/specflow.fix_design"; else next_action="/specflow.apply"; fi
+
+  cat > "${change_dir}/current-phase.md" <<EOF
+# Current Phase: ${feature_id}
+
+- Phase: ${phase}
+- Round: ${current_round}
+- Status: ${status}
+- Open High Findings: ${open_high_str}
+- Accepted Risks: ${accepted_risks}
+- Latest Changes:
+${latest_changes}
+- Next Recommended Action: ${next_action}
+EOF
+
+  log "current-phase.md updated"
+}
+
+# ── Review Pipeline ───────────────────────────────────────────────────
+
+run_review_pipeline() {
+  local change_dir="$1" action="$2" change_id="$3" rereview_mode="$4" autofix_flag="$5"
+
+  # Step 1: Read artifacts (no diff filtering for design)
+  log "Reading artifacts..."
+  if ! read_artifacts "$change_dir"; then
+    error_json "$action" "$change_id" "missing_artifacts"
+    return
+  fi
+
+  # Step 2: Codex invocation
+  log "Calling Codex for design review..."
+  local prompt_file codex_output codex_ok=true
+
+  if [[ "$rereview_mode" == "true" ]]; then
+    local ledger_for_prev
+    ledger_for_prev="$(ledger_read "$change_dir" 3>/dev/null)" || ledger_for_prev='{}'
+    local prev_findings max_fid
+    prev_findings="$(echo "$ledger_for_prev" | jq -c '[.findings[] | select(.status != "resolved")]')"
+    max_fid="$(echo "$ledger_for_prev" | jq -r '.max_finding_id // 0')"
+    prompt_file="$(build_rereview_prompt "$change_dir" "$prev_findings" "$max_fid")"
+  else
+    prompt_file="$(build_review_prompt "$change_dir")"
+  fi
+
+  codex_output="$(call_codex "$prompt_file")" || codex_ok=false
+
+  # Handle Codex failures
+  local review_json parse_error=false raw_response=""
+  if [[ "$codex_ok" == "false" ]]; then
+    parse_error=true
+    if [[ "$codex_output" == __CODEX_EXIT_* ]]; then
+      local exit_code="${codex_output#__CODEX_EXIT_}"
+      exit_code="${exit_code%__}"
+      error_json "$action" "$change_id" "codex_exit_${exit_code}"
+      return
+    elif [[ "$codex_output" == "__CODEX_EMPTY__" ]]; then
+      raw_response=""
+    elif [[ "$codex_output" == __CODEX_PARSE_FAIL__* ]]; then
+      raw_response="${codex_output#__CODEX_PARSE_FAIL__}"
+    fi
+    review_json='{"decision":"UNKNOWN","findings":[],"summary":"parse failed"}'
+  else
+    review_json="$codex_output"
+  fi
+
+  # Step 3: Ledger update (skip if parse error)
+  local ledger_json read_status="new"
+  ledger_json="$(ledger_read "$change_dir" 3>/tmp/specflow-ledger-status-$$.txt)" || true
+  read_status="$(cat /tmp/specflow-ledger-status-$$.txt 2>/dev/null)" || read_status="new"
+  rm -f "/tmp/specflow-ledger-status-$$.txt"
+
+  local is_clean_read="false"
+  [[ "$read_status" == "clean" ]] && is_clean_read="true"
+
+  # Handle prompt_user (corrupt ledger, no backup)
+  if [[ "$read_status" == "prompt_user" ]]; then
+    jq -n --arg a "$action" --arg c "$change_id" \
+      '{"status":"success","action":$a,"change_id":$c,
+        "review":null,"ledger":null,"autofix":null,
+        "handoff":null,"ledger_recovery":"prompt_user","error":null}'
+    return
+  fi
+
+  if [[ "$parse_error" == "false" ]]; then
+    # Validate ledger
+    ledger_json="$(echo "$ledger_json" | ledger_validate)"
+
+    # Increment round
+    ledger_json="$(echo "$ledger_json" | ledger_increment_round)"
+    local current_round
+    current_round="$(echo "$ledger_json" | jq -r '.current_round')"
+
+    # Match findings
+    local rereview_classification=""
+    if [[ "$rereview_mode" == "true" ]]; then
+      # Check for ledger_error
+      local ledger_error
+      ledger_error="$(echo "$review_json" | jq -r '.ledger_error // false')"
+      if [[ "$ledger_error" == "true" ]]; then
+        # Clear findings, use new_findings only
+        ledger_json="$(echo "$ledger_json" | jq '.findings = []')"
+      fi
+
+      ledger_json="$(echo "$ledger_json" | ledger_match_rereview "$review_json" "$current_round")"
+
+      # Severity re-evaluation for still_open findings
+      local still_open_list
+      still_open_list="$(echo "$review_json" | jq -c '.still_open_previous_findings // []')"
+      ledger_json="$(echo "$ledger_json" | jq -c --argjson so "$still_open_list" '
+        .findings = [.findings[] |
+          . as $f |
+          ($so | map(select(
+            (if type == "object" then .id else tostring end) == $f.id
+          )) | .[0] // null) as $match |
+          if $match != null and ($match | type == "object") and ($match.severity // null) != null then
+            .severity = $match.severity
+          else . end
+        ]
+      ')"
+
+      # Build rereview_classification for result JSON
+      rereview_classification="$(echo "$review_json" | jq -c '{
+        resolved: [(.resolved_previous_findings // [])[] | if type == "object" then .id else tostring end],
+        still_open: [(.still_open_previous_findings // [])[] | if type == "object" then .id else tostring end],
+        new_findings: [(.new_findings // [])[] | .id]
+      }')"
+    else
+      local codex_findings
+      codex_findings="$(echo "$review_json" | jq -c '.findings // []')"
+      ledger_json="$(echo "$ledger_json" | ledger_match_findings "$codex_findings" "$current_round")"
+    fi
+
+    # Compute summary, status, max_finding_id
+    ledger_json="$(echo "$ledger_json" | ledger_compute_summary "$current_round")"
+    ledger_json="$(echo "$ledger_json" | ledger_compute_status)"
+    ledger_json="$(echo "$ledger_json" | ledger_persist_max_finding_id)"
+
+    # Backup and write
+    ledger_backup_and_write "$change_dir" "$is_clean_read" <<< "$ledger_json"
+
+    # Generate current-phase.md
+    generate_current_phase "$change_dir" "$ledger_json"
+  fi
+
+  # Step 4: Compute handoff
+  local actionable_count severity_summary handoff_state ledger_status
+  actionable_count="$(echo "$ledger_json" | ledger_actionable_count)"
+  severity_summary="$(echo "$ledger_json" | ledger_severity_summary)"
+  ledger_status="$(echo "$ledger_json" | jq -r '.status // "in_progress"')"
+
+  if (( actionable_count > 0 )); then
+    handoff_state="review_with_findings"
+  else
+    handoff_state="review_no_findings"
+  fi
+
+  # Step 5: Build result JSON
+  local ledger_round ledger_counts ledger_by_severity ledger_round_summaries
+  ledger_round="$(echo "$ledger_json" | jq '.current_round // 0')"
+  ledger_counts="$(echo "$ledger_json" | jq -c '{
+    total: (.findings | length),
+    open: [.findings[] | select(.status == "open")] | length,
+    new: [.findings[] | select(.status == "new")] | length,
+    resolved: [.findings[] | select(.status == "resolved")] | length,
+    overridden: [.findings[] | select(.status == "accepted_risk" or .status == "ignored")] | length
+  }')"
+  ledger_by_severity="$(echo "$ledger_json" | jq -c '
+    def count_by_sev(sev):
+      [.findings[] | select(.severity == sev)] |
+      {open: [.[] | select(.status == "open")] | length,
+       new: [.[] | select(.status == "new")] | length,
+       resolved: [.[] | select(.status == "resolved")] | length,
+       overridden: [.[] | select(.status == "accepted_risk" or .status == "ignored")] | length};
+    {high: count_by_sev("high"), medium: count_by_sev("medium"), low: count_by_sev("low")}
+  ')"
+  ledger_round_summaries="$(echo "$ledger_json" | jq -c '.round_summaries // []')"
+
+  local rereview_class_arg="null"
+  if [[ -n "$rereview_classification" ]]; then
+    rereview_class_arg="$rereview_classification"
+  fi
+
+  jq -n \
+    --arg status "success" \
+    --arg action "$action" \
+    --arg change_id "$change_id" \
+    --argjson review "$(echo "$review_json" | jq -c '{
+      decision: (.decision // "UNKNOWN"),
+      summary: (.summary // ""),
+      findings: (.findings // []),
+      rereview_mode: '"$([[ "$rereview_mode" == "true" ]] && echo true || echo false)"'
+    }' 2>/dev/null || echo '{"decision":"UNKNOWN","summary":"","findings":[],"rereview_mode":false}')" \
+    --arg parse_error "$parse_error" \
+    --arg raw_response "$raw_response" \
+    --argjson ledger_round "$ledger_round" \
+    --arg ledger_status "$ledger_status" \
+    --argjson ledger_counts "$ledger_counts" \
+    --argjson ledger_by_severity "$ledger_by_severity" \
+    --argjson ledger_round_summaries "$ledger_round_summaries" \
+    --arg handoff_state "$handoff_state" \
+    --argjson actionable_count "$actionable_count" \
+    --arg severity_summary "$severity_summary" \
+    --argjson rereview_classification "$rereview_class_arg" \
+    '{
+      status: $status,
+      action: $action,
+      change_id: $change_id,
+      review: ($review + {parse_error: ($parse_error == "true"), raw_response: (if $parse_error == "true" then $raw_response else null end)}),
+      ledger: {
+        round: $ledger_round,
+        status: $ledger_status,
+        counts: $ledger_counts,
+        by_severity: $ledger_by_severity,
+        round_summaries: $ledger_round_summaries
+      },
+      autofix: null,
+      handoff: {
+        state: $handoff_state,
+        actionable_count: $actionable_count,
+        severity_summary: $severity_summary
+      },
+      rereview_classification: $rereview_classification,
+      error: null
+    }'
+}
+
+# ── Autofix Loop ──────────────────────────────────────────────────────
+
+run_autofix_loop() {
+  local change_dir="$1" change_id="$2" max_rounds="$3"
+
+  # Read artifacts for fix prompts
+  if ! read_artifacts "$change_dir"; then
+    error_json "autofix_loop" "$change_id" "missing_artifacts"
+    return
+  fi
+
+  # Auto-reinitialize ledger if missing/corrupt (non-interactive)
+  local ledger_json read_status="new"
+  ledger_json="$(ledger_read "$change_dir" 3>/tmp/specflow-ledger-status-$$.txt)" || true
+  read_status="$(cat /tmp/specflow-ledger-status-$$.txt 2>/dev/null)" || read_status="new"
+  rm -f "/tmp/specflow-ledger-status-$$.txt"
+
+  if [[ "$read_status" == "prompt_user" ]]; then
+    log "Warning: corrupt ledger, auto-reinitializing for autofix mode"
+    local feature_id
+    feature_id="$(_feature_id_from_dir "$change_dir")"
+    ledger_json="$(_empty_ledger "$feature_id")"
+  fi
+
+  # Baseline snapshot
+  local baseline_score
+  baseline_score="$(echo "$ledger_json" | ledger_compute_score)"
+  local baseline_all_high_titles
+  baseline_all_high_titles="$(echo "$ledger_json" | jq -c '[.findings[] | select(.severity == "high") | .title]')"
+  local baseline_resolved_high_titles
+  baseline_resolved_high_titles="$(echo "$ledger_json" | jq -c '[.findings[] | select(.severity == "high" and .status == "resolved") | .title]')"
+
+  local autofix_round=0
+  local previous_score="$baseline_score"
+  local previous_new_high_count=0
+  local previous_all_high_titles="$baseline_all_high_titles"
+  local previous_resolved_high_titles="$baseline_resolved_high_titles"
+  local consecutive_no_change=0
+  local consecutive_failures=0
+  local loop_success=false
+  local loop_result="max_rounds_reached"
+  local round_scores="[]"
+  local divergence_warnings="[]"
+
+  while (( autofix_round < max_rounds )) && [[ "$loop_success" == "false" ]]; do
+    autofix_round=$((autofix_round + 1))
+    log "Auto-fix Round ${autofix_round}/${max_rounds}: Starting design fix..."
+
+    # Step 1: Fix via Codex
+    local fix_findings
+    fix_findings="$(echo "$ledger_json" | jq -c '[.findings[] | select(.status == "new" or .status == "open")]')"
+
+    # Re-read artifacts (may have been modified by previous round)
+    read_artifacts "$change_dir" || true
+
+    local fix_prompt
+    fix_prompt="$(build_fix_prompt "$change_dir" "$fix_findings")"
+
+    # Record pre-fix checksums for no-change detection
+    local pre_fix_hash
+    pre_fix_hash="$(cat "${change_dir}/design.md" "${change_dir}/tasks.md" 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+
+    local fix_output
+    fix_output="$(call_codex "$fix_prompt" 2>/dev/null)" || {
+      consecutive_failures=$((consecutive_failures + 1))
+      log "Warning: fix step failed (consecutive failures: ${consecutive_failures})"
+      if (( consecutive_failures >= 3 )); then
+        loop_result="consecutive_failures"
+        break
+      fi
+      continue
+    }
+
+    # Check for no-change
+    local post_fix_hash
+    post_fix_hash="$(cat "${change_dir}/design.md" "${change_dir}/tasks.md" 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+    if [[ "$pre_fix_hash" == "$post_fix_hash" ]]; then
+      consecutive_no_change=$((consecutive_no_change + 1))
+      log "Warning: no artifact changes detected (consecutive: ${consecutive_no_change})"
+      if (( consecutive_no_change >= 2 )); then
+        loop_result="no_progress"
+        break
+      fi
+    else
+      consecutive_no_change=0
+    fi
+
+    # Step 2: Re-review
+    local review_result
+    review_result="$(run_review_pipeline "$change_dir" "fix_review" "$change_id" "true" "true")" || {
+      consecutive_failures=$((consecutive_failures + 1))
+      log "Warning: re-review step failed (consecutive failures: ${consecutive_failures})"
+      if (( consecutive_failures >= 3 )); then
+        loop_result="consecutive_failures"
+        break
+      fi
+      continue
+    }
+
+    local result_status result_parse_error
+    result_status="$(echo "$review_result" | jq -r '.status // "success"' 2>/dev/null)" || result_status="error"
+    result_parse_error="$(echo "$review_result" | jq -r '.review.parse_error // false' 2>/dev/null)" || result_parse_error="false"
+
+    if [[ "$result_status" == "error" || "$result_parse_error" == "true" ]]; then
+      consecutive_failures=$((consecutive_failures + 1))
+      log "Warning: re-review returned error/parse_error (consecutive failures: ${consecutive_failures})"
+      if (( consecutive_failures >= 3 )); then
+        loop_result="consecutive_failures"
+        break
+      fi
+      continue
+    fi
+
+    # Reset failures on success
+    consecutive_failures=0
+
+    # Step 3: Read updated ledger
+    ledger_json="$(ledger_read "$change_dir" 3>/dev/null)" || ledger_json='{}'
+
+    # Step 4: Compute scores
+    local current_score
+    current_score="$(echo "$ledger_json" | ledger_compute_score)"
+    local unresolved_high_count
+    unresolved_high_count="$(echo "$ledger_json" | jq '[.findings[] | select(.severity == "high" and (.status == "new" or .status == "open"))] | length')"
+    local current_all_high_titles
+    current_all_high_titles="$(echo "$ledger_json" | jq -c '[.findings[] | select(.severity == "high") | .title]')"
+    local current_new_high_count
+    current_new_high_count="$(echo "$current_all_high_titles" | jq --argjson prev "$previous_all_high_titles" '[.[] | select(. as $t | $prev | index($t) | not)] | length')"
+
+    # Record score
+    round_scores="$(echo "$round_scores" | jq --argjson r "$autofix_round" --argjson s "$current_score" \
+      --argjson uh "$unresolved_high_count" --argjson nh "$current_new_high_count" \
+      '. + [{"round":$r,"score":$s,"unresolved_high":$uh,"new_high":$nh}]')"
+
+    # Step 5: Stop condition checks
+    if (( unresolved_high_count == 0 )); then
+      loop_success=true
+      loop_result="success"
+      log "Auto-fix Round ${autofix_round}: success (unresolved high = 0)"
+      break
+    fi
+
+    # Divergence warnings
+    if (( current_score > previous_score )); then
+      local delta=$((current_score - previous_score))
+      divergence_warnings="$(echo "$divergence_warnings" | jq --argjson r "$autofix_round" --arg d "+${delta}" \
+        '. + [{"round":$r,"type":"quality_gate_degradation","detail":$d}]')"
+    fi
+
+    local current_resolved_high_titles
+    current_resolved_high_titles="$(echo "$ledger_json" | jq -c '[.findings[] | select(.severity == "high" and .status == "resolved") | .title]')"
+    local newly_resolved
+    newly_resolved="$(echo "$current_resolved_high_titles" | jq --argjson prev "$previous_resolved_high_titles" '[.[] | select(. as $t | $prev | index($t) | not)]')"
+    local unresolved_high_titles
+    unresolved_high_titles="$(echo "$ledger_json" | jq -c '[.findings[] | select(.severity == "high" and (.status == "new" or .status == "open")) | .title]')"
+    local re_emerged
+    re_emerged="$(echo "$newly_resolved" | jq --argjson uht "$unresolved_high_titles" '[.[] | . as $nr | $uht[] | select(ascii_downcase | contains($nr | ascii_downcase)) | $nr] | unique')"
+    if (( $(echo "$re_emerged" | jq 'length') > 0 )); then
+      local re_detail
+      re_detail="$(echo "$re_emerged" | jq -r '.[0]')"
+      divergence_warnings="$(echo "$divergence_warnings" | jq --argjson r "$autofix_round" --arg d "$re_detail" \
+        '. + [{"round":$r,"type":"finding_re_emergence","detail":$d}]')"
+    fi
+
+    if (( autofix_round >= 2 && current_new_high_count > previous_new_high_count )); then
+      local nh_delta=$((current_new_high_count - previous_new_high_count))
+      divergence_warnings="$(echo "$divergence_warnings" | jq --argjson r "$autofix_round" --arg d "+${nh_delta}" \
+        '. + [{"round":$r,"type":"new_high_increase","detail":$d}]')"
+    fi
+
+    # Update tracking vars
+    previous_score="$current_score"
+    previous_new_high_count="$current_new_high_count"
+    previous_all_high_titles="$current_all_high_titles"
+    previous_resolved_high_titles="$current_resolved_high_titles"
+
+    log "Auto-fix Round ${autofix_round}/${max_rounds}: unresolved_high=${unresolved_high_count}, score=${current_score}"
+  done
+
+  # Final handoff
+  local final_actionable
+  final_actionable="$(echo "$ledger_json" | ledger_actionable_count)"
+  local final_severity_summary
+  final_severity_summary="$(echo "$ledger_json" | ledger_severity_summary)"
+  local final_handoff_state
+  if (( final_actionable == 0 )); then
+    final_handoff_state="loop_no_findings"
+  else
+    final_handoff_state="loop_with_findings"
+  fi
+
+  local ledger_round ledger_status ledger_counts ledger_by_severity ledger_round_summaries
+  ledger_round="$(echo "$ledger_json" | jq '.current_round // 0')"
+  ledger_status="$(echo "$ledger_json" | jq -r '.status // "in_progress"')"
+  ledger_counts="$(echo "$ledger_json" | jq -c '{
+    total: (.findings | length),
+    open: [.findings[] | select(.status == "open")] | length,
+    new: [.findings[] | select(.status == "new")] | length,
+    resolved: [.findings[] | select(.status == "resolved")] | length,
+    overridden: [.findings[] | select(.status == "accepted_risk" or .status == "ignored")] | length
+  }')"
+  ledger_by_severity="$(echo "$ledger_json" | jq -c '
+    def count_by_sev(sev):
+      [.findings[] | select(.severity == sev)] |
+      {open: [.[] | select(.status == "open")] | length,
+       new: [.[] | select(.status == "new")] | length,
+       resolved: [.[] | select(.status == "resolved")] | length,
+       overridden: [.[] | select(.status == "accepted_risk" or .status == "ignored")] | length};
+    {high: count_by_sev("high"), medium: count_by_sev("medium"), low: count_by_sev("low")}
+  ')"
+  ledger_round_summaries="$(echo "$ledger_json" | jq -c '.round_summaries // []')"
+
+  jq -n \
+    --arg status "success" \
+    --arg action "autofix_loop" \
+    --arg change_id "$change_id" \
+    --argjson ledger_round "$ledger_round" \
+    --arg ledger_status "$ledger_status" \
+    --argjson ledger_counts "$ledger_counts" \
+    --argjson ledger_by_severity "$ledger_by_severity" \
+    --argjson ledger_round_summaries "$ledger_round_summaries" \
+    --argjson total_rounds "$autofix_round" \
+    --arg loop_result "$loop_result" \
+    --argjson round_scores "$round_scores" \
+    --argjson divergence_warnings "$divergence_warnings" \
+    --arg handoff_state "$final_handoff_state" \
+    --argjson actionable_count "$final_actionable" \
+    --arg severity_summary "$final_severity_summary" \
+    '{
+      status: $status,
+      action: $action,
+      change_id: $change_id,
+      review: null,
+      ledger: {
+        round: $ledger_round,
+        status: $ledger_status,
+        counts: $ledger_counts,
+        by_severity: $ledger_by_severity,
+        round_summaries: $ledger_round_summaries
+      },
+      autofix: {
+        total_rounds: $total_rounds,
+        result: $loop_result,
+        round_scores: $round_scores,
+        divergence_warnings: $divergence_warnings
+      },
+      handoff: {
+        state: $handoff_state,
+        actionable_count: $actionable_count,
+        severity_summary: $severity_summary
+      },
+      error: null
+    }'
+}
+
+# ── Subcommand: review ────────────────────────────────────────────────
+
+cmd_review() {
+  local change_id="${1:-}"
+  local reset_ledger=false
+  shift || true
+
+  [[ -n "$change_id" ]] || die "Usage: specflow-review-design review <CHANGE_ID> [--reset-ledger]"
+
+  # Parse flags
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --reset-ledger) reset_ledger=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  local change_dir
+  change_dir="$(validate_change "$change_id")"
+  read_config
+
+  # Reset ledger if requested
+  if [[ "$reset_ledger" == "true" ]]; then
+    local feature_id
+    feature_id="$(_feature_id_from_dir "$change_dir")"
+    local fresh_ledger
+    fresh_ledger="$(_empty_ledger "$feature_id")"
+    echo "$fresh_ledger" | jq . > "${change_dir}/${LEDGER_FILENAME}"
+    log "Ledger reset to empty"
+  fi
+
+  run_review_pipeline "$change_dir" "review" "$change_id" "false" "false"
+}
+
+# ── Subcommand: fix-review ────────────────────────────────────────────
+
+cmd_fix_review() {
+  local change_id="${1:-}"
+  local reset_ledger=false
+  local autofix=false
+  shift || true
+
+  [[ -n "$change_id" ]] || die "Usage: specflow-review-design fix-review <CHANGE_ID> [--reset-ledger] [--autofix]"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --reset-ledger) reset_ledger=true; shift ;;
+      --autofix) autofix=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  local change_dir
+  change_dir="$(validate_change "$change_id")"
+  read_config
+
+  if [[ "$reset_ledger" == "true" ]]; then
+    local feature_id
+    feature_id="$(_feature_id_from_dir "$change_dir")"
+    local fresh_ledger
+    fresh_ledger="$(_empty_ledger "$feature_id")"
+    echo "$fresh_ledger" | jq . > "${change_dir}/${LEDGER_FILENAME}"
+    log "Ledger reset to empty"
+  fi
+
+  run_review_pipeline "$change_dir" "fix_review" "$change_id" "true" "$autofix"
+}
+
+# ── Subcommand: autofix-loop ─────────────────────────────────────────
+
+cmd_autofix_loop() {
+  local change_id="${1:-}"
+  local max_rounds=""
+  shift || true
+
+  [[ -n "$change_id" ]] || die "Usage: specflow-review-design autofix-loop <CHANGE_ID> [--max-rounds N]"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --max-rounds)
+        max_rounds="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  local change_dir
+  change_dir="$(validate_change "$change_id")"
+  read_config
+
+  [[ -n "$max_rounds" ]] || max_rounds="$MAX_AUTOFIX_ROUNDS"
+
+  run_autofix_loop "$change_dir" "$change_id" "$max_rounds"
+}
+
+# ── Main dispatch ─────────────────────────────────────────────────────
+
+[[ $# -ge 1 ]] || {
+  cat >&2 <<EOF
+Usage: specflow-review-design <subcommand> <CHANGE_ID> [options]
+
+Subcommands:
+  review        Initial design review
+  fix-review    Re-review after fixes
+  autofix-loop  Auto-fix loop
+
+EOF
+  exit 1
+}
+
+SUBCMD="$1"; shift
+
+case "$SUBCMD" in
+  review)      cmd_review "$@" ;;
+  fix-review)  cmd_fix_review "$@" ;;
+  autofix-loop) cmd_autofix_loop "$@" ;;
+  *)
+    echo "Error: unknown subcommand '$SUBCMD'. Available: review, fix-review, autofix-loop" >&2
+    exit 1
+    ;;
+esac

--- a/bin/specflow-review-design
+++ b/bin/specflow-review-design
@@ -10,8 +10,19 @@
 
 set -euo pipefail
 
+# ── Resolve symlinks (needed when invoked via ~/bin symlink) ──────────
+resolve_symlink() {
+  local src="$1"
+  while [[ -L "$src" ]]; do
+    local dir="$(cd "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    [[ "$src" != /* ]] && src="$dir/$src"
+  done
+  echo "$src"
+}
+
 # ── Paths ──────────────────────────────────────────────────────────────
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(resolve_symlink "$0")")" && pwd)"
 LIB_DIR="$(cd "${SCRIPT_DIR}/../lib" && pwd)"
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {

--- a/global/commands/specflow.design.md
+++ b/global/commands/specflow.design.md
@@ -37,25 +37,44 @@ If the command fails, report the error and **STOP**.
 
 ## Step 2: Generate Artifacts in Dependency Order
 
-Loop through artifacts that are `ready` (all dependencies satisfied):
+Use the orchestrator to discover the next ready artifact, then generate its content.
 
-For each ready artifact:
-1. Run:
+### Artifact Loop
+
+Repeat the following until all `applyRequires` artifacts are complete:
+
+1. Run the orchestrator:
    ```bash
-   openspec instructions <artifact-id> --change "<CHANGE_ID>" --json
+   specflow-design-artifacts next <CHANGE_ID>
    ```
-2. Read any dependency artifacts referenced in the instructions for context.
-3. Create the artifact file using `template` from the instructions as the structure.
-4. Apply `context` and `rules` from the instructions as constraints when writing the artifact content. Do **NOT** copy `context` or `rules` verbatim into the file.
-5. Report progress: `Created <artifact-id>`
 
-After each artifact is created, re-run:
-```bash
-openspec status --change "<CHANGE_ID>" --json
-```
-to refresh which artifacts are now `ready`.
+2. Capture stdout as `ARTIFACT_JSON`. Parse as JSON.
 
-Continue until all `applyRequires` artifacts are complete.
+3. Handle result by `ARTIFACT_JSON.status`:
+
+   **`"complete"`** — All required artifacts are done. Exit the loop and proceed to Step 3.
+
+   **`"ready"`** — An artifact is ready for generation:
+   - `ARTIFACT_JSON.artifactId`: the artifact to create
+   - `ARTIFACT_JSON.outputPath`: where to write the file
+   - `ARTIFACT_JSON.template`: structure template
+   - `ARTIFACT_JSON.instruction`: generation instructions
+   - `ARTIFACT_JSON.dependencies`: list of `{id, path, done}` dependency artifacts
+
+   Actions:
+   a. Read each dependency artifact file listed in `ARTIFACT_JSON.dependencies` for context.
+   b. Create the artifact file at `ARTIFACT_JSON.outputPath` using `template` as the structure.
+   c. Apply `instruction` as constraints when writing the artifact content. Do **NOT** copy `instruction` verbatim into the file.
+   d. Report progress: `Created <artifactId>`
+   e. Continue the loop (call `next` again to get the next artifact).
+
+   **`"blocked"`** — No artifacts are ready and none are complete:
+   - `ARTIFACT_JSON.blocked`: array of blocked artifact IDs
+   - Report which artifacts are blocked and ask the user how to proceed.
+   - If the user cannot resolve, **STOP**.
+
+   **`"error"`** — The orchestrator encountered an error:
+   - Display `ARTIFACT_JSON.error` and **STOP**.
 
 ## Step 3: Verify Completion
 
@@ -69,26 +88,39 @@ If any are incomplete, report which artifacts are missing and ask the user how t
 
 ## Step 4: Validate
 
-Run:
+Run the orchestrator:
 ```bash
-openspec validate "<CHANGE_ID>" --type change --json
+specflow-design-artifacts validate <CHANGE_ID>
 ```
 
-Present validation results to the user.
-If issues are found, let the user decide whether to fix them or continue.
+Capture stdout as `VALIDATE_JSON`. Parse as JSON.
+
+Handle result by `VALIDATE_JSON.status`:
+
+**`"valid"`** — Validation passed. Report success and continue to Step 5.
+
+**`"invalid"`** — Validation found issues. Present the validation results to the user. Let the user decide whether to fix them or continue.
+
+**`"error"`** — Display `VALIDATE_JSON.error` and **STOP**.
 
 ## Step 5: Codex Design Review
 
-Read the file `global/specflow.review_design.md` and follow its complete workflow.
+Invoke the design review workflow:
+
+```
+Skill(skill: "specflow.review_design")
+```
 
 This will:
-- Read the review prompt and `openspec/changes/<CHANGE_ID>/` artifacts
-- Call Codex MCP to review the design artifacts
+- Call `specflow-review-design review <CHANGE_ID>` via Bash
+- Handle ledger recovery if needed
 - Present the review results
-- Show handoff options (実装に進む / Design を修正 / 中止)
+- Show handoff options (実装に進む / Auto-fix / 手動修正 / Reject)
 
 ## Important Rules
 
 - Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.
 - All artifacts are managed in `openspec/changes/<CHANGE_ID>/`.
 - If any tool call fails, report the error and ask the user how to proceed.
+- Artifact generation (Step 2) is driven by calling `specflow-design-artifacts next` in a loop. The LLM generates artifact content; the orchestrator manages the dependency graph and readiness.
+- Validation (Step 4) is delegated to `specflow-design-artifacts validate`.

--- a/global/commands/specflow.fix_design.md
+++ b/global/commands/specflow.fix_design.md
@@ -24,29 +24,21 @@ $ARGUMENTS
 
 ## Setup
 
-Resolve `FEATURE_DIR` from the current change id:
-- If `$ARGUMENTS` contains a change id (excluding `autofix`), set `FEATURE_DIR=openspec/changes/<id>`.
-- Otherwise, detect the active change from the current branch name or prompt the user.
+Determine `CHANGE_ID`:
+- If `$ARGUMENTS` contains a change id (excluding `autofix`), use it.
+- Otherwise, derive from the current branch name or prompt the user.
 
-Verify `FEATURE_DIR` exists via Bash (`ls <FEATURE_DIR>/proposal.md`). If missing → **STOP** with error.
+Verify `openspec/changes/<CHANGE_ID>/proposal.md` exists via Bash. If missing → **STOP** with error.
 
 Derive the design and tasks file paths:
 ```
+FEATURE_DIR = openspec/changes/<CHANGE_ID>
 FEATURE_PROPOSAL = <FEATURE_DIR>/specs/*/spec.md (glob for the first match) or <FEATURE_DIR>/proposal.md as fallback
 DESIGN_FILE = <FEATURE_DIR>/design.md
 TASKS_FILE = <FEATURE_DIR>/tasks.md
-LEDGER_FILE = <FEATURE_DIR>/review-ledger-design.json
 ```
 
 Read all three files: `FEATURE_PROPOSAL`, `DESIGN_FILE`, `TASKS_FILE`.
-
-### Ledger Detection
-
-Attempt to Read `LEDGER_FILE` to determine review mode:
-
-- **If file does not exist**: Set `REREVIEW_MODE = false`.
-- **If file exists and valid JSON**: Set `REREVIEW_MODE = true`.
-- **If file exists but JSON parse fails**: Set `REREVIEW_MODE = true`, `LEDGER_ERROR = true`. Display: `"⚠ review-ledger-design.json が破損しています。空の前回 findings で re-review を実行します。"`.
 
 ### Autofix Detection
 
@@ -66,268 +58,111 @@ Update `DESIGN_FILE` and/or `TASKS_FILE` as needed. If a finding requires fundam
 
 Report what was fixed.
 
-## Step 2: Re-run Codex Design/Tasks Review
+## Step 2: Run Orchestrator for Re-review
 
-### Prompt Selection
+Run the Bash orchestrator:
 
-**If `REREVIEW_MODE = false`** (no ledger, initial review prompt):
-
-Read `~/.config/specflow/global/prompts/review_design_prompt.md`. If the file does not exist, display: `"❌ review prompt が見つかりません（~/.config/specflow/global/prompts/review_design_prompt.md）。specflow を再インストールしてください: specflow-install"` → **STOP**.
-
-Read the updated `FEATURE_PROPOSAL`, `DESIGN_FILE`, and `TASKS_FILE`.
-
-Call the `codex` MCP server tool with:
-
-```
-<review_design_prompt.md の内容>
-
-PROPOSAL CONTENT:
-<FEATURE_PROPOSAL の内容>
-
-DESIGN CONTENT:
-<DESIGN_FILE の内容>
-
-TASKS CONTENT:
-<TASKS_FILE の内容>
+**Autofix mode** (`AUTOFIX_MODE = true`):
+```bash
+specflow-review-design fix-review <CHANGE_ID> --autofix
 ```
 
-**If `REREVIEW_MODE = true`** (ledger exists, re-review prompt):
-
-Extract from ledger: `PREVIOUS_FINDINGS` = findings where status in ["new", "open", "accepted_risk", "ignored"]. Extract `MAX_FINDING_ID` from ledger (if present), or derive from `max(findings.map(f => extractNumber(f.id)))`, or 0 if empty. If `LEDGER_ERROR = true`, use empty `PREVIOUS_FINDINGS` array and `MAX_FINDING_ID = 0`.
-
-Read `~/.config/specflow/global/prompts/review_design_rereview_prompt.md`. If the file does not exist, display: `"❌ review prompt が見つかりません（~/.config/specflow/global/prompts/review_design_rereview_prompt.md）。specflow を再インストールしてください: specflow-install"` → **STOP**.
-
-Read the updated `FEATURE_PROPOSAL`, `DESIGN_FILE`, and `TASKS_FILE`.
-
-Call the `codex` MCP server tool with:
-
-```
-<review_design_rereview_prompt.md の内容>
-
-PREVIOUS_FINDINGS:
-<PREVIOUS_FINDINGS の JSON 配列>
-
-MAX_FINDING_ID:
-<MAX_FINDING_ID の値>
-
-PROPOSAL CONTENT:
-<FEATURE_PROPOSAL の内容>
-
-DESIGN CONTENT:
-<DESIGN_FILE の内容>
-
-TASKS CONTENT:
-<TASKS_FILE の内容>
+**通常モード** (`AUTOFIX_MODE = false`):
+```bash
+specflow-review-design fix-review <CHANGE_ID>
 ```
 
-If `LEDGER_ERROR = true`, append to the prompt: `"NOTE: The previous review ledger was corrupted. Set ledger_error to true in your response. Treat all findings as new."`
+Capture stdout as `RESULT_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
 
-### Parse Response
+Parse `RESULT_JSON` as JSON. If parse fails, display raw output and **STOP**.
 
-Parse the response as JSON. If the JSON parse fails (Codex returned invalid JSON), display an error: `"⚠ Codex review の JSON パースに失敗しました。ledger 更新をスキップします。"` and skip the ledger update step entirely. Present whatever raw response was received and proceed to the handoff.
+## Step 3: Handle Ledger Recovery
 
-### Prior-ID Classification Validation (re-review mode only)
+If `RESULT_JSON.ledger_recovery == "prompt_user"`:
 
-If `REREVIEW_MODE = true` and JSON parse succeeded, validate the classified output before proceeding to ledger update:
+The ledger was corrupt and no backup was available. Use `AskUserQuestion` to ask the user:
 
-1. Collect `prior_ids` = all IDs from PREVIOUS_FINDINGS that were passed to Codex.
-2. Collect `response_resolved_ids` = IDs in `resolved_previous_findings`.
-3. Collect `response_still_open_ids` = IDs in `still_open_previous_findings`.
-4. **Check exhaustive**: for each ID in `prior_ids`, verify it appears in either resolved or still_open. If any prior ID is missing, auto-classify it as still_open with `note: "classification missing from Codex output"` and `severity` from the previous ledger. Display: `"⚠ Codex が前回 finding を分類しませんでした (自動的に still_open に分類): {missing_ids}"`.
-5. **Check exclusive**: if any ID appears in both resolved and still_open, keep the still_open classification and remove from resolved (conservative). Display: `"⚠ 重複分類を検出しました (still_open を優先): {duplicate_ids}"`.
-6. **Check unknown**: if any ID in the response is not in `prior_ids`, display as explicit anomaly: `"⚠ Unknown IDs in Codex response (excluded from ledger): {unknown_ids}"`. Exclude from ledger update.
+```
+AskUserQuestion:
+  question: "review-ledger-design.json が破損しており、バックアップもありません。新規 ledger を作成しますか？ (既存データは失われます)"
+  options:
+    - label: "新規作成"
+      description: "空の ledger を作成して再レビューを実行"
+    - label: "中止"
+      description: "ワークフローを停止"
+```
 
-### Re-review Results Display (re-review mode only)
+- 「新規作成」 → Re-run the orchestrator with `--reset-ledger`:
+  ```bash
+  specflow-review-design fix-review <CHANGE_ID> --reset-ledger
+  ```
+  (add `--autofix` if `AUTOFIX_MODE = true`)
+  Capture and parse again as `RESULT_JSON`, then continue from Step 4.
+- 「中止」 → **STOP**.
 
-If `REREVIEW_MODE = true`, display the classified results before the standard findings table:
+## Step 4: Handle Error Results
+
+If `RESULT_JSON.status == "error"`:
+- Display `RESULT_JSON.error` → **STOP**.
+
+## Step 5: Display Review Results
+
+### Re-review Classification (if RESULT_JSON.rereview_classification is not null)
+
+Display the classified results before the standard findings table:
 
 ```
 ### Re-review Classification
 
-**Resolved** ({count}):
+**Resolved** ({count of RESULT_JSON.rereview_classification.resolved}):
 | ID | Note |
 |----|------|
 | R1-F01 | fixed ordering issue |
 
-**Still Open** ({count}):
+**Still Open** ({count of RESULT_JSON.rereview_classification.still_open}):
 | ID | Severity | Note |
 |----|----------|------|
 | R1-F02 | high | still unresolved |
 
-**New Findings** ({count}):
+**New Findings** ({count of RESULT_JSON.rereview_classification.new_findings}):
 | ID | Severity | Category | Title |
 |----|----------|----------|-------|
 | F3 | medium | completeness | missing test coverage |
 ```
 
-## Step 2.5: Update Review Ledger
+### Review Findings
 
-**This step runs BEFORE presenting findings to the user.** Only execute if Codex returned valid JSON.
+If `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.
 
-### Ledger Read / Create
-
-1. Determine `FEATURE_DIR` from `FEATURE_PROPOSAL` (its parent directory).
-2. Attempt to Read `FEATURE_DIR/review-ledger-design.json`.
-
-   **Auto-fix mode ledger recovery** (`AUTOFIX_MODE = true`):
-   - **If file does not exist**: `"⚠ autofix mode: review-ledger-design.json が見つかりません。新規作成して継続します。"` と表示し、空の ledger を新規作成して継続する: `{ "feature_id": "<change id>", "phase": "design", "current_round": 0, "status": "all_resolved", "max_finding_id": 0, "findings": [], "round_summaries": [] }`。これは "clean read" ではない — この空 ledger からバックアップを作成しない。
-   - **If file exists but JSON parse fails**: 破損ファイルを `review-ledger-design.json.corrupt` にリネーム（`mv`）。`"⚠ autofix mode: review-ledger-design.json が破損していました。新規作成して継続します。（破損ファイルは .corrupt に退避）"` と表示し、空の ledger を新規作成して継続する: `{ "feature_id": "<change id>", "phase": "design", "current_round": 0, "status": "all_resolved", "max_finding_id": 0, "findings": [], "round_summaries": [] }`。これは "clean read" ではない。
-   - **If file exists and valid JSON**: 通常通り使用する。
-
-   **通常モード** (`AUTOFIX_MODE = false`):
-   - **If file does not exist**: Create a new ledger: `{ "feature_id": "<change id>", "phase": "design", "current_round": 0, "status": "all_resolved", "findings": [], "round_summaries": [] }`.
-   - **If file exists but JSON parse fails**: Rename the corrupt file to `review-ledger-design.json.corrupt` via Bash (`mv`). Attempt to Read `review-ledger-design.json.bak`. If bak succeeds, use it and display: `"⚠ review-ledger-design.json が破損していました。バックアップから復旧しました（破損ファイルは .corrupt に退避）"`. If bak also fails, use `AskUserQuestion` to ask `"新規 ledger を作成しますか？ (既存データは失われます)"` with options "新規作成" / "中止". On "中止", stop the workflow. On "新規作成", create a fresh empty ledger: `{ "feature_id": "<change id>", "phase": "design", "current_round": 0, "status": "all_resolved", "findings": [], "round_summaries": [] }` and continue normal processing. This is NOT a "clean read" — do not create a backup from this empty ledger.
-   - **If file exists and valid JSON**: Use it. This is a "clean read" — backup will be created from this content before writing.
-
-### Ledger Validation
-
-3. Check all high-severity findings with `accepted_risk` or `ignored` status: if `notes` field is empty or whitespace-only, auto-revert to `status: "open"` and display `"⚠ high severity finding の override には notes が必須です: {id}"`.
-
-### Round Pre-processing
-
-4. Increment `current_round` by 1. Initialize a sequence counter `seq = 0` for this round's new finding IDs.
-
-### Finding Update
-
-**If `REREVIEW_MODE = true`** (classified re-review output):
-
-The Codex response already classifies findings into resolved/still_open/new. Use this classification directly instead of the matching algorithm.
-
-5. For each finding in `resolved_previous_findings`:
-   - Find the corresponding finding in the ledger by `id`.
-   - Set `status` = `"resolved"`, `latest_round` = current_round. Keep all other attributes unchanged.
-
-6. For each finding in `still_open_previous_findings`:
-   - Find the corresponding finding in the ledger by `id`.
-   - **Overwrite from re-review**: `severity` (re-evaluated value), update ledger `notes` field only if re-review `note` provides new information (do not overwrite user override `notes` for accepted_risk/ignored findings).
-   - **Preserve from previous ledger**: `id`, `category`, `file`, `title`, `detail`, `origin_round`, `relation`, `supersedes`.
-   - Update: `status` → `"open"` (unless finding has override status accepted_risk/ignored — preserve override), `latest_round` → current_round.
-
-7. For each finding in `new_findings`:
-   - Add as new ledger entry: copy `id`, `severity`, `category`, `file`, `title`, `detail` from Codex output. Set `origin_round` = current_round, `latest_round` = current_round, `status` = `"new"`, `relation` = `"new"`, `supersedes` = null, `notes` = `""`.
-
-8. **Persist max_finding_id**: compute `new_max = max(prev_ledger.max_finding_id || 0, max(new_findings.map(f => extractNumber(f.id))) || 0)` and write to ledger JSON as `"max_finding_id": new_max`. This MUST be written on every ledger update.
-
-9. **Handle ledger_error=true**: if the Codex response has `ledger_error: true`, set `max_finding_id` from new_findings only, and the findings array contains only new_findings (no carryover from corrupt ledger).
-
-**If `REREVIEW_MODE = false`** (initial review output, standard matching):
-
-5. Build the **candidate pool**: all existing findings where `status` ≠ `resolved`.
-
-6. **Step 1 — Same match** (`file` + `category` + `severity` exact):
-   - For each Codex finding, search candidates with matching `file`, `category`, `severity`.
-   - 1:1 → same. N:M → normalize titles (lowercase + whitespace collapse + trim) and match exact. Remaining → pair by index order. 余った Codex findings → Step 2.
-   - **Matched active (open/new)**: set `status` = `"open"`, `relation` = `"same"`, `latest_round` = current_round.
-   - **Matched override (accepted_risk/ignored)**: preserve `status`, set `relation` = `"same"`, `latest_round` = current_round.
-
-7. **Step 2 — Reframed match** (`file` + `category` match, `severity` differs):
-   - For unmatched Codex findings, search unmatched candidates with matching `file` + `category` but different `severity`. 1:1 index-order pairing.
-   - **Old finding** (active or override): set `status` = `"resolved"`, `relation` = `"reframed"` (keep original severity).
-   - **New finding**: `seq++`, `id` = `R{current_round}-F{seq (zero-padded 2 digits)}`, `origin_round` = current_round, `latest_round` = current_round, `status` = `"open"`, `relation` = `"reframed"`, `supersedes` = old finding's id. Copy severity/category/file/title/detail from Codex finding. `notes` = `""`.
-
-8. **Step 3 — Remaining**:
-   - Unmatched Codex findings → new: `seq++`, `id` = `R{current_round}-F{seq zero-padded to 2 digits, e.g. 01, 02, 10}`, `origin_round` = current_round, `latest_round` = current_round, `status` = `"new"`, `relation` = `"new"`, `supersedes` = null, `notes` = `""`.
-   - Unmatched active candidates (open/new) → `status` = `"resolved"` (keep `relation` as previous value, do NOT update `latest_round`).
-   - Unmatched override candidates → preserve status unchanged.
-
-### Zero-Findings Edge Case
-
-9. If Codex returned 0 findings (both modes): skip matching. Set all active (open/new) findings to `status` = `"resolved"`. Override findings are preserved.
-
-### Round Summary (Snapshot)
-
-10. Compute end-of-round snapshot counts from the full `findings[]`:
-    - `total`: count of all findings
-    - `open`: count where status = "open"
-    - `new`: count where status = "new"
-    - `resolved`: count where status = "resolved"
-    - `overridden`: count where status in ["accepted_risk", "ignored"]
-    - `by_severity`: for each of high/medium/low: { open, resolved, new, overridden }
-    Append `{ "round": current_round, "total": ..., "open": ..., "new": ..., "resolved": ..., "overridden": ..., "by_severity": ... }` to `round_summaries[]`.
-
-### Top-Level Status Derivation
-
-11. Compute `status`:
-    - `"has_open_high"`: if ANY high-severity finding has status in ["open", "new", "accepted_risk", "ignored"]
-    - `"all_resolved"`: if ALL findings have status = "resolved", OR findings is empty
-    - `"in_progress"`: otherwise
-
-### Override Warnings
-
-12. For each high-severity finding with status `accepted_risk` or `ignored` (with valid notes): display `"⚠ high severity finding が override されています: {id}"`.
-
-### Backup and Write
-
-13. If the ledger was a "clean read" (not recovered from backup): Write the pre-update ledger content to `review-ledger-design.json.bak` via Write tool.
-14. Write the updated ledger JSON to `review-ledger-design.json` via Write tool.
-
-### Ledger Summary Display
-
-15. Display before the findings table:
-    ```
-    Review Ledger (Plan): Round {current_round} | Status: {status} | Findings: {new} new, {open} open, {resolved} resolved
-    ```
-    If `round_summaries` has more than 1 entry, show a compact progress table:
-    ```
-    | Round | Total | Open | New | Resolved | Overridden |
-    |-------|-------|------|-----|----------|------------|
-    | 1     | 5     | 0    | 0   | 3        | 2          |
-    | 2     | 7     | 2    | 2   | 3        | 2          |
-    ```
-    Then show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`
-
-## Step 2.6: Update current-phase.md
-
-**This step runs after the review-ledger has been fully updated, backed up, and persisted to disk.**
-
-1. Read the just-written `FEATURE_DIR/review-ledger-design.json`.
-2. Extract: `feature_id` (or derive from directory name), `current_round`, `status`, `findings[]`.
-3. Compute each field:
-   - **Phase**: `design-fix-review`.
-   - **Round**: `current_round`. Fallback: `1`.
-   - **Status**: Direct read from `status`. Fallback: `in_progress`.
-   - **Open High Findings**: Filter `findings[]` where `severity == "high"` AND `status in ["new", "open"]`. Format: `<count> 件 — "<title1>", "<title2>"`. If none: `0 件`. Fallback: `0 件`.
-   - **Accepted Risks**: Filter `findings[]` where `status in ["accepted_risk", "ignored"]`. Format each as `<title> (<status>, notes: "<notes>")`. If none: `none`. Fallback: `none`.
-   - **Latest Changes**: Run `git log --oneline -5 $(git merge-base HEAD ${BASE_BRANCH:-main})..HEAD` via Bash. Format each line as `  - <hash> <subject>`. If the command fails or returns empty output, use: `(no commits yet)`.
-   - **Next Recommended Action**: If Open High Findings count > 0 → `/specflow.fix_design`; else → `/specflow.apply`. Fallback: `/specflow.fix_design`.
-4. **Malformed/missing ledger recovery** (if the ledger read in step 1 fails):
-   - First: attempt partial recovery — extract any readable top-level fields from the file.
-   - Second: supplement missing fields with in-memory data from the just-completed Codex review (findings, decision).
-   - Third: use spec-defined fallback values listed above.
-   - If `findings[]` is missing from both sources: set `0 件 (ledger findings unavailable)` and `none (ledger findings unavailable)`.
-   - Append parenthetical note to any fallback value (e.g., `in_progress (ledger parse error)`).
-5. Write `FEATURE_DIR/current-phase.md` using the Write tool (complete overwrite):
-
-```markdown
-# Current Phase: <feature_id>
-
-- Phase: <phase>
-- Round: <round>
-- Status: <status>
-- Open High Findings: <open_high_findings>
-- Accepted Risks: <accepted_risks>
-- Latest Changes:
-<latest_changes lines, each prefixed with "  - ">
-- Next Recommended Action: <next_action>
-```
-
-Report: `current-phase.md updated`
-
-## Present Review Results
-
-After the ledger update, present the Codex review findings:
+Otherwise display:
 ```
 Codex Design/Tasks Review (after fix)
 
-**Decision:** <APPROVE | REQUEST_CHANGES | BLOCK>
-**Summary:** <summary>
+**Decision:** <RESULT_JSON.review.decision>
+**Summary:** <RESULT_JSON.review.summary>
 
 | # | Severity | Category | Title | Detail |
 |---|----------|----------|-------|--------|
 | P1 | high | completeness | ... | ... |
 ```
 
-Report the review results.
+### Ledger Summary Display
+
+Use `RESULT_JSON.ledger` to display:
+```
+Review Ledger (Plan): Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved
+```
+
+If `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:
+```
+| Round | Total | Open | New | Resolved | Overridden |
+|-------|-------|------|-----|----------|------------|
+| 1     | 5     | 0    | 0   | 3        | 2          |
+| 2     | 7     | 2    | 2   | 3        | 2          |
+```
+Then show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`
+
+Report: `current-phase.md updated` (the orchestrator generates this automatically).
 
 ## Handoff: 次のアクション選択
 
@@ -335,8 +170,19 @@ Report the review results.
 
 **通常モード**（`AUTOFIX_MODE = false`）:
 
-レビュー結果を表示した後、必ず `AskUserQuestion` ツールを使って次のアクションを選択させる。
+レビュー結果を表示した後、Dual-Display Fallback Pattern に従い、テキストプロンプトを先に表示してから AskUserQuestion を呼び出す。
 
+**テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+```
+✅ Fix & re-review complete
+
+次のアクションを選択してください（テキスト入力またはボタンで回答）:
+- **実装に進む** → `/specflow.apply`
+- **Design を修正** → `/specflow.fix_design`
+- **中止** → `/specflow.reject`
+```
+
+**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
 ```
 AskUserQuestion:
   question: "次のアクションを選択してください"
@@ -349,9 +195,18 @@ AskUserQuestion:
       description: "変更を破棄して終了"
 ```
 
+**入力受理**: 最初に受理された有効入力（ボタンまたはテキスト）のみを採用する。テキスト入力が label または command に一致しない場合、テキストプロンプトを再表示して再度入力を待つ。
+
 ユーザーの選択に応じて、`Skill` ツールで次のコマンドを実行する:
 - 「実装に進む」 → `Skill(skill: "specflow.apply")`
 - 「Design を修正」 → `Skill(skill: "specflow.fix_design")`
 - 「中止」 → `Skill(skill: "specflow.reject")`
 
-**IMPORTANT:** Do NOT present next-action choices as text.必ず `AskUserQuestion` のボタン UI を使うこと。
+**IMPORTANT:** Do NOT present next-action choices as text. 必ず Dual-Display Fallback Pattern（テキストプロンプト + AskUserQuestion の両方）を使うこと。
+
+## Important Rules
+
+- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.
+- All artifacts (proposal, design, tasks, review-ledger-design, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.
+- If any tool call fails, report the error and ask the user how to proceed.
+- ALL control flow logic (Codex invocation, ledger detection/CRUD, finding matching, current-phase generation) is handled by the `specflow-review-design fix-review` orchestrator. This slash command applies fixes (LLM), then calls the orchestrator for re-review, parses its JSON output, and displays UI.

--- a/global/commands/specflow.review_design.md
+++ b/global/commands/specflow.review_design.md
@@ -24,180 +24,67 @@ $ARGUMENTS
 
 ## Setup
 
-Resolve `FEATURE_DIR` from the current change id:
-- If `$ARGUMENTS` contains a change id, set `FEATURE_DIR=openspec/changes/<id>`.
-- Otherwise, detect the active change from the current branch name or prompt the user.
+Determine `CHANGE_ID`:
+- If `$ARGUMENTS` contains a change id, use it.
+- Otherwise, derive from the current branch name or prompt the user.
 
-Verify `FEATURE_DIR` exists via Bash (`ls <FEATURE_DIR>/proposal.md`). If missing → **STOP** with error.
+Verify `openspec/changes/<CHANGE_ID>/proposal.md` exists via Bash. If missing → **STOP** with error.
 
-Set `FEATURE_PROPOSAL` to `<FEATURE_DIR>/specs/*/spec.md` (glob for the first match) or `<FEATURE_DIR>/proposal.md` as fallback.
+Verify that `openspec/changes/<CHANGE_ID>/design.md` and `openspec/changes/<CHANGE_ID>/tasks.md` exist (via Read tool). If either file does not exist, display an error: `"design.md または tasks.md が見つかりません。先に /specflow.design を実行してください。"` → **STOP**.
 
-Derive the design and tasks file paths:
-```
-DESIGN_FILE = FEATURE_DIR/design.md
-TASKS_FILE = FEATURE_DIR/tasks.md
-```
+## Step 1: Run Orchestrator
 
-Verify that `DESIGN_FILE` and `TASKS_FILE` exist (via Read tool). If either file does not exist, display an error: `"design.md または tasks.md が見つかりません。先に /specflow.design を実行してください。"` → **STOP**.
-
-Read all three files: `FEATURE_PROPOSAL`, `DESIGN_FILE`, `TASKS_FILE`.
-
-## Step 1: Codex Design/Tasks Review
-
-Read `~/.config/specflow/global/prompts/review_design_prompt.md` for the review prompt. If the file does not exist, display: `"❌ review prompt が見つかりません（~/.config/specflow/global/prompts/review_design_prompt.md）。specflow を再インストールしてください: specflow-install"` → **STOP**.
-
-Call the `codex` MCP server tool to review the design and tasks. Pass the following as the prompt:
-
-```
-<review_design_prompt.md の内容>
-
-PROPOSAL CONTENT:
-<FEATURE_PROPOSAL の内容>
-
-DESIGN CONTENT:
-<DESIGN_FILE の内容>
-
-TASKS CONTENT:
-<TASKS_FILE の内容>
+Run the Bash orchestrator:
+```bash
+specflow-review-design review <CHANGE_ID>
 ```
 
-Parse the response as JSON. If the JSON parse fails (Codex returned invalid JSON), display an error: `"⚠ Codex review の JSON パースに失敗しました。ledger 更新をスキップします。"` and skip the ledger update step entirely. Present whatever raw response was received and proceed to the handoff.
+Capture stdout as `RESULT_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
 
-## Step 1.5: Update Review Ledger
+Parse `RESULT_JSON` as JSON. If parse fails, display raw output and **STOP**.
 
-**This step runs BEFORE presenting findings to the user.** Only execute if Codex returned valid JSON.
+## Step 2: Handle Ledger Recovery
 
-### Ledger Read / Create
+If `RESULT_JSON.ledger_recovery == "prompt_user"`:
 
-1. Use `FEATURE_DIR` resolved in Setup.
-2. Attempt to Read `FEATURE_DIR/review-ledger-design.json`.
-   - **If file does not exist**: Create a new ledger: `{ "feature_id": "<change id from FEATURE_DIR>", "phase": "design", "current_round": 0, "status": "all_resolved", "max_finding_id": 0, "findings": [], "round_summaries": [] }` (Note: the change id is the directory name of `FEATURE_DIR`, e.g. `openspec/changes/my-change` → `my-change`)
-   - **If file exists but JSON parse fails**: Rename the corrupt file to `review-ledger-design.json.corrupt` via Bash (`mv`). Attempt to Read `review-ledger-design.json.bak`. If bak succeeds, use it and display: `"⚠ review-ledger-design.json が破損していました。バックアップから復旧しました（破損ファイルは .corrupt に退避）"`. If bak also fails, use `AskUserQuestion` to ask `"新規 ledger を作成しますか？ (既存データは失われます)"` with options "新規作成" / "中止". On "中止", stop the workflow. On "新規作成", create a fresh empty ledger: `{ "feature_id": "<change id from FEATURE_DIR>", "phase": "design", "current_round": 0, "status": "all_resolved", "max_finding_id": 0, "findings": [], "round_summaries": [] }` and continue normal processing. This is NOT a "clean read" — do not create a backup from this empty ledger.
-   - **If file exists and valid JSON**: Use it. This is a "clean read" — backup will be created from this content before writing.
+The ledger was corrupt and no backup was available. Use `AskUserQuestion` to ask the user:
 
-### Ledger Validation
-
-3. Check all high-severity findings with `accepted_risk` or `ignored` status: if `notes` field is empty or whitespace-only, auto-revert to `status: "open"` and display `"⚠ high severity finding の override には notes が必須です: {id}"`.
-
-### Round Pre-processing
-
-4. Increment `current_round` by 1. Initialize a sequence counter `seq = 0` for this round's new finding IDs.
-
-### Finding Matching (Unified Pool)
-
-5. Build the **candidate pool**: all existing findings where `status` ≠ `resolved`.
-
-6. **Step 1 — Same match** (`file` + `category` + `severity` exact):
-   - For each Codex finding, search candidates with matching `file`, `category`, `severity`.
-   - 1:1 → same. N:M → normalize titles (lowercase + whitespace collapse + trim) and match exact. Remaining → pair by index order.余った Codex findings → Step 2.
-   - **Matched active (open/new)**: set `status` = `"open"`, `relation` = `"same"`, `latest_round` = current_round.
-   - **Matched override (accepted_risk/ignored)**: preserve `status`, set `relation` = `"same"`, `latest_round` = current_round.
-
-7. **Step 2 — Reframed match** (`file` + `category` match, `severity` differs):
-   - For unmatched Codex findings, search unmatched candidates with matching `file` + `category` but different `severity`. 1:1 index-order pairing.
-   - **Old finding** (active or override): set `status` = `"resolved"`, `relation` = `"reframed"` (keep original severity).
-   - **New finding**: `seq++`, `id` = `R{current_round}-F{seq (zero-padded 2 digits)}`, `origin_round` = current_round, `latest_round` = current_round, `status` = `"open"`, `relation` = `"reframed"`, `supersedes` = old finding's id. Copy severity/category/file/title/detail from Codex finding. `notes` = `""`.
-
-8. **Step 3 — Remaining**:
-   - Unmatched Codex findings → new: `seq++`, `id` = `R{current_round}-F{seq zero-padded to 2 digits, e.g. 01, 02, 10}`, `origin_round` = current_round, `latest_round` = current_round, `status` = `"new"`, `relation` = `"new"`, `supersedes` = null, `notes` = `""`.
-   - Unmatched active candidates (open/new) → `status` = `"resolved"` (keep `relation` as previous value, do NOT update `latest_round`).
-   - Unmatched override candidates → preserve status unchanged.
-
-### Zero-Findings Edge Case
-
-9. If Codex returned 0 findings: skip matching. Set all active (open/new) findings to `status` = `"resolved"`. Override findings are preserved.
-
-### Round Summary (Snapshot)
-
-10. Compute end-of-round snapshot counts from the full `findings[]`:
-    - `total`: count of all findings
-    - `open`: count where status = "open"
-    - `new`: count where status = "new"
-    - `resolved`: count where status = "resolved"
-    - `overridden`: count where status in ["accepted_risk", "ignored"]
-    - `by_severity`: for each of high/medium/low: { open, resolved, new, overridden }
-    Append `{ "round": current_round, "total": ..., "open": ..., "new": ..., "resolved": ..., "overridden": ..., "by_severity": ... }` to `round_summaries[]`.
-
-### Top-Level Status Derivation
-
-11. Compute `status`:
-    - `"has_open_high"`: if ANY high-severity finding has status in ["open", "new", "accepted_risk", "ignored"]
-    - `"all_resolved"`: if ALL findings have status = "resolved", OR findings is empty
-    - `"in_progress"`: otherwise
-
-### Override Warnings
-
-12. For each high-severity finding with status `accepted_risk` or `ignored` (with valid notes): display `"⚠ high severity finding が override されています: {id}"`.
-
-### Persist max_finding_id
-
-13. Compute `max_finding_id` from the current findings array: `max(findings.map(f => extractNumber(f.id)))` where `extractNumber("R1-F03") = 3`. If findings is empty, set to 0. Write this value as `"max_finding_id"` in the ledger JSON. This field MUST be present in every ledger file from initialization onward.
-
-### Backup and Write
-
-14. If the ledger was a "clean read" (not recovered from backup): Write the pre-update ledger content to `review-ledger-design.json.bak` via Write tool.
-15. Write the updated ledger JSON (including `max_finding_id`) to `review-ledger-design.json` via Write tool.
-
-### Ledger Summary Display
-
-16. Display before the findings table:
-    ```
-    Review Ledger (Plan): Round {current_round} | Status: {status} | Findings: {new} new, {open} open, {resolved} resolved
-    ```
-    If `round_summaries` has more than 1 entry, show a compact progress table:
-    ```
-    | Round | Total | Open | New | Resolved | Overridden |
-    |-------|-------|------|-----|----------|------------|
-    | 1     | 5     | 0    | 0   | 3        | 2          |
-    | 2     | 7     | 2    | 2   | 3        | 2          |
-    ```
-    Then show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`
-
-## Step 1.6: Generate current-phase.md
-
-**This step runs after the review-ledger has been fully updated, backed up, and persisted to disk.**
-
-1. Read the just-written `FEATURE_DIR/review-ledger-design.json`.
-2. Extract: `feature_id` (or derive from directory name), `current_round`, `status`, `findings[]`.
-3. Compute each field:
-   - **Phase**: `design-review`.
-   - **Round**: `current_round`. Fallback: `1`.
-   - **Status**: Direct read from `status`. Fallback: `in_progress`.
-   - **Open High Findings**: Filter `findings[]` where `severity == "high"` AND `status in ["new", "open"]`. Format: `<count> 件 — "<title1>", "<title2>"`. If none: `0 件`. Fallback: `0 件`.
-   - **Accepted Risks**: Filter `findings[]` where `status in ["accepted_risk", "ignored"]`. Format each as `<title> (<status>, notes: "<notes>")`. If none: `none`. Fallback: `none`.
-   - **Latest Changes**: Run `git log --oneline -5 $(git merge-base HEAD ${BASE_BRANCH:-main})..HEAD` via Bash. Format each line as `  - <hash> <subject>`. If the command fails or returns empty output, use: `(no commits yet)`.
-   - **Next Recommended Action**: If Open High Findings count > 0 → `/specflow.fix_design`; else → `/specflow.apply`. Fallback: `/specflow.fix_design`.
-4. **Malformed/missing ledger recovery** (if the ledger read in step 1 fails):
-   - First: attempt partial recovery — extract any readable top-level fields from the file.
-   - Second: supplement missing fields with in-memory data from the just-completed Codex review (findings, decision).
-   - Third: use spec-defined fallback values listed above.
-   - If `findings[]` is missing from both sources: set `0 件 (ledger findings unavailable)` and `none (ledger findings unavailable)`.
-   - Append parenthetical note to any fallback value (e.g., `in_progress (ledger parse error)`).
-5. Write `FEATURE_DIR/current-phase.md` using the Write tool (complete overwrite):
-
-```markdown
-# Current Phase: <feature_id>
-
-- Phase: <phase>
-- Round: <round>
-- Status: <status>
-- Open High Findings: <open_high_findings>
-- Accepted Risks: <accepted_risks>
-- Latest Changes:
-<latest_changes lines, each prefixed with "  - ">
-- Next Recommended Action: <next_action>
+```
+AskUserQuestion:
+  question: "review-ledger-design.json が破損しており、バックアップもありません。新規 ledger を作成しますか？ (既存データは失われます)"
+  options:
+    - label: "新規作成"
+      description: "空の ledger を作成してレビューを再実行"
+    - label: "中止"
+      description: "ワークフローを停止"
 ```
 
-Report: `current-phase.md generated`
+- 「新規作成」 → Re-run the orchestrator with `--reset-ledger`:
+  ```bash
+  specflow-review-design review <CHANGE_ID> --reset-ledger
+  ```
+  Capture and parse again as `RESULT_JSON`, then continue from Step 3.
+- 「中止」 → **STOP**.
 
-## Step 2: Present Review Results
+## Step 3: Handle Error Results
 
-After the ledger update, present the Codex review findings:
+If `RESULT_JSON.status == "error"`:
+- Display `RESULT_JSON.error` → **STOP**.
+
+## Step 4: Display Review Results
+
+### Review Findings
+
+Present the Codex review from `RESULT_JSON.review`:
+
+If `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.
+
+Otherwise display:
 ```
 Codex Design/Tasks Review
 
-**Decision:** <APPROVE | REQUEST_CHANGES | BLOCK>
-**Summary:** <summary>
+**Decision:** <RESULT_JSON.review.decision>
+**Summary:** <RESULT_JSON.review.summary>
 
 | # | Severity | File | Category | Title | Detail |
 |---|----------|------|----------|-------|--------|
@@ -205,34 +92,71 @@ Codex Design/Tasks Review
 | P2 | medium | tasks.md | ordering | ... | ... |
 ```
 
-Report the review results.
+### Ledger Summary Display
 
-## Auto-fix 確認: AskUserQuestion 直接表示
+Use `RESULT_JSON.ledger` to display:
+```
+Review Ledger (Plan): Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved
+```
 
-レビュー結果を表示した後、以下のロジックで auto-fix 確認を行う。
+If `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:
+```
+| Round | Total | Open | New | Resolved | Overridden |
+|-------|-------|------|-----|----------|------------|
+| 1     | 5     | 0    | 0   | 3        | 2          |
+| 2     | 7     | 2    | 2   | 3        | 2          |
+```
+Then show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`
+
+## Step 5: Handoff (based on RESULT_JSON.handoff.state)
+
+### Actionable Findings 定義
+
+**Actionable findings**: `status ∈ {"new", "open"}` の finding。`"resolved"`, `"accepted_risk"`, `"ignored"` は non-actionable。
 
 ### Severity 集計
 
-1. `findings[]` 内の actionable findings（`status ∈ {"new", "open"}`）を収集する。
-2. severity 別にグループ化し件数をカウントする。
-3. 表示用の `severity_summary` を生成する:
-   - 表示順: CRITICAL → HIGH → MEDIUM → LOW
-   - 0 件の severity は除外する
-   - フォーマット: `"CRITICAL: N, HIGH: M, ..."` （件数が 1 以上の severity のみ）
-4. `actionable_count` = actionable findings の総件数を記録する。
+Use `RESULT_JSON.handoff.actionable_count` and `RESULT_JSON.handoff.severity_summary`.
 
-**注意**: review-ledger-design.json の `status` フィールド（`has_open_high`）は accepted_risk/ignored を含むためレポート目的のみ。auto-fix 確認の分岐は `actionable_count` で判定する。
+The `severity_summary` format: CRITICAL → HIGH → MEDIUM → LOW order, 0 件の severity は除外。
 
-### 分岐: actionable_count による判定
+### `accepted_risk`/`ignored` の扱い
 
-- **actionable_count == 0** → 「Step: 承認フローへ直接遷移」に進む
-- **actionable_count > 0** → 「Step: Auto-fix 確認プロンプト表示」に進む
-- **review-ledger-design.json が存在しない / 読み込み失敗** → 「Step: エラー時の処理」に進む
+- `accepted_risk` や `ignored` ステータスの high finding は、ユーザーが明示的に受容/無視した判断であり、auto-fix loop の**修正対象外**とする。
+- **ループ開始判定**: actionable findings（`new`/`open`、全 severity）が 0 件の場合は実装フローへ直接遷移する。
+- **Quality gate スコア計算**: `accepted_risk`/`ignored` の finding は unresolved として**カウントに含める**。
 
-### Step: 承認フローへ直接遷移
+### State-to-Option Mapping
 
-actionable findings が 0 件の場合（全て resolved、または全て accepted_risk/ignored のみ）、auto-fix 確認を表示せずに実装フローへ遷移する。
+| State | Condition | Options (label → command) |
+|-------|-----------|--------------------------|
+| `review_with_findings` | `actionable_count > 0` after review | "Auto-fix 実行" → auto-fix loop, "手動修正" → `/specflow.fix_design` |
+| `review_no_findings` | `actionable_count == 0` after review | "実装に進む" → `/specflow.apply`, "Reject" → `/specflow.reject` |
+| `loop_no_findings` | `actionable_count == 0` after loop | "実装に進む" → `/specflow.apply`, "Reject" → `/specflow.reject` |
+| `loop_with_findings` | `actionable_count > 0` after loop | "手動修正" → `/specflow.fix_design`, "実装に進む" → `/specflow.apply`, "Reject" → `/specflow.reject` |
 
+### Dual-Display Fallback Pattern
+
+全ハンドオフポイントに以下のパターンを適用する:
+
+1. **テキストプロンプト表示**: 1行ステータスメッセージ + 選択肢リスト（label → command 形式）を表示
+2. **AskUserQuestion 呼び出し**: 同じ選択肢をボタンとして表示
+3. **入力受理ルール**: 最初に受理された有効入力（ボタンまたはテキスト）のみを採用する
+4. **テキスト入力検証**: exact label または exact slash command のみ受理（label は case-insensitive）。部分一致は不可
+5. **無効入力時**: テキストプロンプトを再表示し、再度入力を待つ。自動選択や無入力での進行は禁止
+
+### `review_no_findings` (actionable_count == 0)
+
+**テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+```
+✅ Review complete — all findings resolved
+
+次のアクションを選択してください（テキスト入力またはボタンで回答）:
+- **実装に進む** → `/specflow.apply`
+- **Reject** → `/specflow.reject`
+```
+
+**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
 ```
 AskUserQuestion:
   question: "指摘事項はすべて解決済みです。次のアクションを選択してください"
@@ -243,13 +167,23 @@ AskUserQuestion:
       description: "全変更を破棄して終了"
 ```
 
+**入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
 - 「実装に進む」 → `Skill(skill: "specflow.apply")`
 - 「Reject」 → `Skill(skill: "specflow.reject")`
 
-### Step: Auto-fix 確認プロンプト表示
+### `review_with_findings` (actionable_count > 0)
 
-actionable findings が 1 件以上ある場合、AskUserQuestion で auto-fix 確認を直接表示する。
+**テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+```
+⚠ Review complete — {RESULT_JSON.handoff.actionable_count} actionable finding(s): {RESULT_JSON.handoff.severity_summary}
 
+次のアクションを選択してください（テキスト入力またはボタンで回答）:
+- **Auto-fix 実行** → auto-fix loop
+- **手動修正** → `/specflow.fix_design`
+```
+
+**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
 ```
 AskUserQuestion:
   question: "レビュー指摘: {severity_summary}\nauto-fix を実行しますか？"
@@ -260,8 +194,10 @@ AskUserQuestion:
       description: "手動で修正した後に再レビューする"
 ```
 
+**入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
 ユーザーの選択に応じて分岐:
-- 「Auto-fix 実行」 → 以下の Round 0 Baseline Snapshot に進む（auto-fix loop 開始）
+- 「Auto-fix 実行」 → Step 6: Auto-fix Loop に進む
 - 「手動修正 (/specflow.fix_design)」 → 手動修正誘導メッセージを表示し、`Skill(skill: "specflow.fix_design")` を実行する
 - **スキップ/dismiss/タイムアウト時**: 「手動修正 (/specflow.fix_design)」を選択したものとして扱い、手動修正誘導メッセージを表示する
 
@@ -270,127 +206,31 @@ AskUserQuestion:
 手動修正モードに進みます。/specflow.fix_design で指摘を修正し、再レビューしてください。
 ```
 
-### Step: エラー時の処理
+## Step 6: Auto-fix Loop
 
-review-ledger-design.json が存在しない、読み込みに失敗した、または JSON パースに失敗した場合、エラーメッセージを表示しワークフローを **停止** する:
+ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator で auto-fix loop を実行する。
 
-```
-❌ review-ledger-design.json の読み込みに失敗しました。ワークフローを停止します。
-原因: {ファイルが存在しない | 読み込みエラー | JSON パースエラー}
+### Run Orchestrator
 
-review-ledger-design.json を確認し、再度 /specflow.review_design を実行してください。
-```
-
-→ **STOP**（ワークフロー終了。AskUserQuestion は表示しない）。
-
-**注意**: この処理は Step 1.5 の Ledger Read / Create とは独立したタイミングで実行される。Step 1.5 で ledger が正常に読み込めた場合のみ Severity 集計に進む。Step 1.5 自体がエラーを報告した場合は、このステップに到達しない。
-
-### `accepted_risk`/`ignored` の扱い
-
-- `accepted_risk` や `ignored` ステータスの high finding は、ユーザーが明示的に受容/無視した判断であり、auto-fix loop の**修正対象外**とする。
-- **ループ開始判定**: actionable findings（`new`/`open`、全 severity）が 0 件の場合は実装フローへ直接遷移する。
-- **ループ成功判定**: `new`/`open` の high が 0 件になればループ成功とする。`accepted_risk`/`ignored` は成功判定をブロックしない。
-- **Quality gate スコア計算**: `accepted_risk`/`ignored` の finding は unresolved として**カウントに含める**（`status ∉ {"resolved"}` に該当するため）。これにより、ユーザーが override した finding の severity も品質指標に反映される。
-- **理由**: auto-fix loop はマシンが自動修正可能な finding（`new`/`open`）を対象とする。ユーザーが意図的に受容した finding を自動修正しようとするのは不適切。
-
-#### Round 0 Baseline Snapshot
-
-ループ開始前に、現在の review-ledger-design.json を読み、以下の baseline 値を記録する:
-
-1. **baseline_score**: 全 unresolved findings（`status ∉ {"resolved"}`）の severity 重み付けスコア合計（high=3, medium=2, low=1）
-2. **baseline_new_high_count**: 0（design review 直後はまだ auto-fix ラウンドが未実行のため、new high の比較基準は 0 とする。ラウンド 1 終了時に実際の new high count が記録され、ラウンド 2 以降で比較に使用される）
-3. **baseline_resolved_high_titles**: `findings[]` 内の `status == "resolved"` かつ `severity == "high"` の `title` 一覧
-4. **baseline_all_high_titles**: `findings[]` 内の `severity == "high"` の全 `title` 一覧（resolved 含む）
-
-#### ループ変数の初期化
-
-```
-autofix_round = 0
-previous_score = baseline_score
-previous_new_high_count = baseline_new_high_count
-previous_resolved_high_titles = baseline_resolved_high_titles
-previous_all_resolved_high_titles = baseline_resolved_high_titles
-previous_all_high_titles = baseline_all_high_titles
-divergence_warnings = []
-round_scores = []
-loop_success = false
+```bash
+specflow-review-design autofix-loop <CHANGE_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
 ```
 
-#### ループ本体
+Capture stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
 
-以下を `MAX_AUTOFIX_ROUNDS` 回まで繰り返す:
+Parse `LOOP_JSON` as JSON. If parse fails, display raw output and **STOP**.
 
-```
-WHILE autofix_round < MAX_AUTOFIX_ROUNDS AND NOT loop_success:
-```
-
-1. `autofix_round` をインクリメント
-
-2. ラウンドヘッダーを表示:
-   ```
-   Auto-fix Round {autofix_round}/{MAX_AUTOFIX_ROUNDS}: Starting design fix...
-   ```
-
-3. `Skill(skill: "specflow.fix_design", args: "autofix")` を呼び出す。`autofix` 引数により specflow.fix_design はハンドオフをスキップし、fix → re-review → ledger 更新のみ実行して制御を返す。
-   - もし Skill 呼び出しが失敗した場合: エラーを報告し、ループを停止して「Step: エラー時の処理」に進む
-
-4. 更新された `FEATURE_DIR/review-ledger-design.json` を Read する。
-   - もし読み込み失敗: エラーを報告し、ループを停止して「Step: エラー時の処理」に進む
-
-5. **スコア計算**（停止条件チェックの前に実行し、全終了パスでスコアが記録されるようにする）:
-   - `current_score = Σ weight(f.severity) for f in findings where f.status ∉ {"resolved"}`（high=3, medium=2, low=1）
-   - `previous_all_high_titles` に存在しなかった title の件数 = `current_new_high_count`
-   - `unresolved_high_count` = `findings[]` 内の `severity == "high"` かつ `status ∈ {"new", "open"}` の件数
-
-6. **スコア記録**（全終了パスで確実に記録される）:
-   - `round_scores.push({ round: autofix_round, score: current_score, unresolved_high: unresolved_high_count, new_high: current_new_high_count })`
-
-7. **停止条件チェック**（優先順位順に実行、最初にトリガーされた条件で停止）:
-
-   **7a. Success check（最優先）**:
-   - `unresolved_high_count == 0` の場合: `loop_success = true` → ループ終了
-
-   **7b. 同種 high 再発チェック**（警告のみ、停止しない）:
-   - 現ラウンドの ledger で `status == "resolved"` かつ `severity == "high"` の `title` 一覧を取得し、`previous_all_resolved_high_titles` になかったものを抽出 → 「直前ラウンドで新たに resolved になった high titles」
-   - 現ラウンドの unresolved high titles と case-insensitive 部分文字列比較
-   - 1 件でも一致 → `divergence_warnings.push({ round: autofix_round, type: "finding_re_emergence", detail: "<matching title>" })`
-
-   **7c. Quality gate 悪化チェック**（警告のみ、停止しない）:
-   - `current_score > previous_score` → `divergence_warnings.push({ round: autofix_round, type: "quality_gate_degradation", detail: "+<score delta>" })`
-
-   **7d. New high 増加チェック**（autofix_round >= 2 のみ、警告のみ、停止しない）:
-   - `current_new_high_count > previous_new_high_count` → `divergence_warnings.push({ round: autofix_round, type: "new_high_increase", detail: "+<count delta>" })`
-
-   **7e. Max rounds チェック**:
-   - `autofix_round >= MAX_AUTOFIX_ROUNDS` かつ unresolved_high_count > 0 → ループ終了
-
-8. **追跡変数を更新**:
-   - `previous_score = current_score`
-   - `previous_new_high_count = current_new_high_count`
-   - `previous_all_resolved_high_titles = findings[]` 内の resolved high titles
-   - `previous_all_high_titles = findings[]` 内の全 high titles
-
-9. ラウンド結果を表示:
-   ```
-   Auto-fix Round {autofix_round}/{MAX_AUTOFIX_ROUNDS}:
-     - Unresolved high: {count} ({delta} from previous)
-     - Severity score: {current_score} ({delta} from previous)
-     - New high: {current_new_high_count}
-     - Warnings: {divergence_warnings for this round, or "none"}
-     - Status: continuing
-   ```
-
-#### ループ完了サマリー
+### Display Loop Summary
 
 ```
 Auto-fix Loop Complete (Plan):
-  - Total rounds: {autofix_round}
-  - Result: {loop_success ? "success" : "max rounds reached"}
-  - Reason: {loop_success ? "unresolved high = 0" : "max rounds reached"}
-  - Remaining unresolved high: {count}
+  - Total rounds: {LOOP_JSON.autofix.total_rounds}
+  - Result: {LOOP_JSON.autofix.result}
+  - Reason: {LOOP_JSON.autofix.result == "success" ? "unresolved high = 0" : LOOP_JSON.autofix.result}
+  - Remaining actionable: {LOOP_JSON.handoff.actionable_count} ({LOOP_JSON.handoff.severity_summary})
 ```
 
-**スコア推移テーブル**（`round_scores` が 1 件以上の場合に表示）:
+**スコア推移テーブル**（`LOOP_JSON.autofix.round_scores` が 1 件以上の場合に表示）:
 ```
 | Round | Score | Unresolved High | New High |
 |-------|-------|-----------------|----------|
@@ -398,7 +238,7 @@ Auto-fix Loop Complete (Plan):
 | 2     | 9     | 2               | 0        |
 ```
 
-**Divergence 警告履歴**（`divergence_warnings` が 1 件以上の場合に表示）:
+**Divergence 警告履歴**（`LOOP_JSON.autofix.divergence_warnings` が 1 件以上の場合に表示）:
 ```
 Divergence Warnings:
   - Round {round}: {type} ({detail})
@@ -406,17 +246,28 @@ Divergence Warnings:
 ```
 `divergence_warnings` が空の場合、この警告履歴セクションは表示しない。
 
-#### ループ後のハンドオフ状態判定
+### Ledger Summary Display (Loop)
 
-ループ完了後、`actionable_count` を再計算する（`findings[]` 内の `status ∈ {"new", "open"}` の総件数）。
+Use `LOOP_JSON.ledger` to display the same ledger summary format as Step 4:
+```
+Review Ledger (Plan): Round {round} | Status: {status} | Findings: {new} new, {open} open, {resolved} resolved
+```
+If `round_summaries` has more than 1 entry, show the compact progress table and round-over-round diff.
 
-- **`actionable_count == 0`** → `loop_no_findings` 状態（成功）
-- **`actionable_count > 0`** → `loop_with_findings` 状態（停止）
+### Loop Handoff (based on LOOP_JSON.handoff.state)
 
-#### ループ後の Auto-fix 確認
+#### `loop_no_findings` (actionable_count == 0)
 
-**`loop_no_findings`**（`actionable_count == 0`）:
+**テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+```
+✅ Auto-fix complete — all findings resolved
 
+次のアクションを選択してください（テキスト入力またはボタンで回答）:
+- **実装に進む** → `/specflow.apply`
+- **Reject** → `/specflow.reject`
+```
+
+**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
 ```
 AskUserQuestion:
   question: "Auto-fix loop 完了（成功）。次のアクションを選択してください"
@@ -427,16 +278,29 @@ AskUserQuestion:
       description: "全変更を破棄して終了"
 ```
 
+**入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
 - 「実装に進む」 → `Skill(skill: "specflow.apply")`
 - 「Reject」 → `Skill(skill: "specflow.reject")`
 
-**`loop_with_findings`**（`actionable_count > 0`）:
+#### `loop_with_findings` (actionable_count > 0)
 
-残存する actionable findings の severity_summary を再集計し（表示順: CRITICAL → HIGH → MEDIUM → LOW、0 件除外）、AskUserQuestion で表示する。
+残存する actionable findings の severity_summary を `LOOP_JSON.handoff.severity_summary` から取得。
 
+**テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+```
+⚠ Auto-fix stopped — {LOOP_JSON.autofix.result == "success" ? "success (high resolved, lower-severity remaining)" : "max rounds reached"}. Remaining: {LOOP_JSON.handoff.severity_summary}
+
+次のアクションを選択してください（テキスト入力またはボタンで回答）:
+- **手動修正** → `/specflow.fix_design`
+- **実装に進む** → `/specflow.apply`
+- **Reject** → `/specflow.reject`
+```
+
+**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
 ```
 AskUserQuestion:
-  question: "Auto-fix loop 停止（{loop_success ? 'high resolved, lower-severity remaining' : 'max rounds reached'}）。残存指摘: {severity_summary}\n次のアクションを選択してください"
+  question: "Auto-fix loop 停止（{result_reason}）。残存指摘: {severity_summary}\n次のアクションを選択してください"
   options:
     - label: "手動修正 (/specflow.fix_design)"
       description: "残りの指摘を手動で修正して再レビュー"
@@ -446,17 +310,20 @@ AskUserQuestion:
       description: "全変更を破棄して終了"
 ```
 
+**入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
 - 「手動修正 (/specflow.fix_design)」 → `Skill(skill: "specflow.fix_design")`
 - 「実装に進む」 → `Skill(skill: "specflow.apply")`
 - 「Reject」 → `Skill(skill: "specflow.reject")`
 
-**IMPORTANT:** Do NOT present next-action choices as text. 必ず `AskUserQuestion` のボタン UI を使うこと。
+**IMPORTANT:** 全ハンドオフポイントで Dual-Display Fallback Pattern を適用すること — テキストプロンプトと AskUserQuestion の両方を必ず表示する。
 
 ## Important Rules
 
 - Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.
-- All artifacts (proposal, design, tasks, review-ledger-design, current-phase) are managed in `openspec/changes/<change id>/`.
+- All artifacts (proposal, design, tasks, review-ledger-design, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.
 - If any tool call fails, report the error and ask the user how to proceed.
 - Ledger file is `FEATURE_DIR/review-ledger-design.json` (NOT `review-ledger.json`).
 - Phase is `"design"` in ledger JSON.
-- Auto-fix calls `Skill(skill: "specflow.fix_design", args: "autofix")` (NOT `specflow.fix_apply`).
+- Auto-fix loop calls `specflow-review-design autofix-loop` (NOT `specflow.fix_apply`).
+- ALL control flow logic (Codex invocation, ledger CRUD, finding matching, score computation, current-phase generation) is handled by the `specflow-review-design` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.

--- a/global/prompts/fix_design_prompt.md
+++ b/global/prompts/fix_design_prompt.md
@@ -1,0 +1,24 @@
+You are a design and tasks fixer.
+
+Input:
+You will receive:
+1. REVIEW FINDINGS — an array of review findings to fix
+2. PROPOSAL CONTENT — the feature specification (source of intent)
+3. DESIGN CONTENT — the current implementation design
+4. TASKS CONTENT — the current task breakdown
+
+Task:
+Fix all issues identified in the review findings by modifying the design and/or tasks documents.
+
+Rules:
+- Address every finding. Do not skip any.
+- Modify design.md and/or tasks.md as needed to resolve each finding
+- Keep changes minimal and focused — only change what is necessary to resolve the finding
+- Do not alter the proposal's intent or acceptance criteria
+- Preserve existing design decisions that are not affected by the findings
+- Ensure tasks remain properly ordered by dependency
+- If a finding requires adding new decisions, add them with rationale
+- If a finding requires adding new tasks, insert them in the correct dependency position
+
+Output:
+Apply the fixes directly to the files. No additional commentary needed.

--- a/lib/specflow-ledger.sh
+++ b/lib/specflow-ledger.sh
@@ -7,11 +7,24 @@ set -euo pipefail
 # All functions operate on JSON via stdin/stdout or file paths.
 # ────────────────────────────────────────────────────────────────────────
 
-# ── Constants ───────────────────────────────────────────────────────────
+# ── Constants (defaults — overridable via ledger_init) ─────────────────
 
-readonly LEDGER_FILENAME="review-ledger.json"
-readonly LEDGER_BAK_FILENAME="review-ledger.json.bak"
-readonly LEDGER_CORRUPT_SUFFIX=".corrupt"
+LEDGER_FILENAME="review-ledger.json"
+LEDGER_BAK_FILENAME="review-ledger.json.bak"
+LEDGER_CORRUPT_SUFFIX=".corrupt"
+LEDGER_DEFAULT_PHASE="impl"
+
+# ── ledger_init ────────────────────────────────────────────────────────
+# Call before any ledger operations to configure the ledger filename.
+# $1 = ledger filename (required, e.g. "review-ledger-design.json")
+# $2 = default phase (optional, e.g. "design"; defaults to "impl")
+
+ledger_init() {
+  local filename="$1"
+  LEDGER_FILENAME="$filename"
+  LEDGER_BAK_FILENAME="${filename}.bak"
+  LEDGER_DEFAULT_PHASE="${2:-impl}"
+}
 
 # ── Internal helpers ────────────────────────────────────────────────────
 
@@ -31,9 +44,10 @@ _empty_ledger() {
   local feature_id="$1"
   jq -n \
     --arg fid "$feature_id" \
+    --arg phase "$LEDGER_DEFAULT_PHASE" \
     '{
       feature_id: $fid,
-      phase: "impl",
+      phase: $phase,
       current_round: 0,
       status: "all_resolved",
       max_finding_id: 0,

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/approval-summary.md
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/approval-summary.md
@@ -1,0 +1,70 @@
+# Approval Summary: design-orchestrator-extraction
+
+**Generated**: 2026-04-09T07:12:08Z
+**Branch**: design-orchestrator-extraction
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+```
+ global/commands/specflow.design.md        |  76 +++--
+ global/commands/specflow.fix_design.md    | 313 ++++++---------------
+ global/commands/specflow.review_design.md | 447 +++++++++++-------------------
+ lib/specflow-ledger.sh                    |  26 +-
+ bin/specflow-design-artifacts             | 120 +++++++  (new)
+ bin/specflow-review-design                | 647 ++++++++++++++++++++++++++++  (new)
+ global/prompts/fix_design_prompt.md       |  19 +  (new)
+```
+
+## Files Touched
+
+- `lib/specflow-ledger.sh` — Added `ledger_init` function, removed `readonly`
+- `bin/specflow-design-artifacts` — New: artifact dependency loop orchestrator
+- `bin/specflow-review-design` — New: design review orchestrator (review, fix-review, autofix-loop)
+- `global/prompts/fix_design_prompt.md` — New: design fix prompt for autofix-loop
+- `global/commands/specflow.design.md` — Simplified to thin wrapper calling orchestrators
+- `global/commands/specflow.fix_design.md` — Simplified to thin wrapper calling orchestrators
+- `global/commands/specflow.review_design.md` — Simplified to thin wrapper calling orchestrators
+
+## Review Loop Summary
+
+### Design Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 8     |
+| Unresolved high    | 0     |
+| New high (later)   | 7     |
+| Total rounds       | 4     |
+
+### Impl Review
+⚠️ No impl review data available (review skipped by user).
+
+## Proposal Coverage
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | Artifact dependency loop runs deterministically in Bash | Yes | bin/specflow-design-artifacts |
+| 2 | Design ledger updates handled entirely by Bash script | Yes | bin/specflow-review-design, lib/specflow-ledger.sh |
+| 3 | Re-review classification logic testable independently | Yes | bin/specflow-review-design (uses lib/specflow-ledger.sh ledger_match_rereview) |
+| 4 | design and fix_design slash commands are thin wrappers | Yes | global/commands/specflow.design.md, specflow.fix_design.md, specflow.review_design.md |
+| 5 | Existing user-facing command interface unchanged | Yes | All slash commands preserve AskUserQuestion patterns |
+
+**Coverage Rate**: 5/5 (100%)
+
+## Remaining Risks
+
+- R4-F10: Simplified /specflow.design wrapper does not define blocked or invalid-status handling (severity: medium)
+- R4-F12: Artifact-loop task contract does not preserve instruction constraints (severity: medium)
+- R4-F13: Risk section still describes the abandoned JSONL streaming model (severity: medium)
+- ⚠️ New file not mentioned in review: bin/specflow-design-artifacts
+- ⚠️ New file not mentioned in review: bin/specflow-review-design
+- ⚠️ New file not mentioned in review: global/prompts/fix_design_prompt.md
+
+## Human Checkpoints
+
+- [ ] Verify `specflow-review-apply` backward compatibility by running an existing apply-side review on a test change
+- [ ] Run `/specflow.design` on a new change to confirm artifact loop works with one-at-a-time `next` invocations
+- [ ] Verify `ledger_init` does not affect existing `review-ledger.json` files when sourced by `specflow-review-apply`
+- [ ] Test corrupt ledger recovery: create a corrupt `review-ledger-design.json` and verify `--reset-ledger` flag works
+- [ ] Run `specflow-install` and confirm `fix_design_prompt.md` is deployed to `~/.config/specflow/global/prompts/`

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/current-phase.md
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/current-phase.md
@@ -1,0 +1,14 @@
+# Current Phase: design-orchestrator-extraction
+
+- Phase: design-fix-review
+- Round: 4
+- Status: in_progress
+- Open High Findings: 0 件
+- Accepted Risks: none
+- Latest Changes:
+  - 1dbe65e feat: extract apply-side control flow into Bash orchestrator (#77)
+  - 77b4b0d feat: extend workflow state machine to v2.0 with enriched run metadata (#73)
+  - 7915d8d feat: introduce workflow state machine and run state core (#71)
+  - 0b14779 chore: archive fix-autofix-early-stop change
+  - 2887d9b fix: prevent autofix loop from stopping early on temporary divergence (#67)
+- Next Recommended Action: /specflow.apply

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/design.md
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/design.md
@@ -1,0 +1,125 @@
+## Context
+
+The apply-side orchestrator extraction (PR #77) established the pattern: deterministic control flow lives in `bin/specflow-review-apply` (Bash), with the shared ledger library in `lib/specflow-ledger.sh`. The design-side (`specflow.design`, `specflow.review_design`, `specflow.fix_design`) still embeds equivalent logic in LLM-interpreted markdown — artifact dependency loops, ledger CRUD, finding matching, re-review classification, score aggregation, and autofix loops.
+
+Current state:
+- `lib/specflow-ledger.sh` hardcodes `LEDGER_FILENAME="review-ledger.json"` as `readonly`, preventing reuse for the design-side's `review-ledger-design.json`
+- Design review passes artifact file contents (design.md, tasks.md, spec.md) directly to Codex — no diff filtering needed (unlike apply-side which uses `specflow-filter-diff`)
+- The artifact dependency loop in `specflow.design` mixes deterministic loop control (status → ready → instructions) with LLM content generation
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extract design-side review/fix/autofix lifecycle into `bin/specflow-review-design` with the same subcommand interface as the apply-side orchestrator (`review`, `fix-review`, `autofix-loop`)
+- Extract the artifact dependency loop into `bin/specflow-design-artifacts` (loop control + metadata output only)
+- Parameterize `lib/specflow-ledger.sh` via a `ledger_init` function so both orchestrators share the same library
+- Produce the same result JSON schema as the apply-side for unified slash command parsing
+- Reduce slash commands to thin UI wrappers (AskUserQuestion, content generation)
+
+**Non-Goals:**
+- Moving artifact content generation (design.md, tasks.md, spec.md writing) into Bash — this remains LLM's responsibility
+- Changing user-facing command interfaces or adding new slash commands
+- Introducing diff filtering for design reviews
+- Modifying the apply-side orchestrator's behavior (only the shared library changes)
+
+## Decisions
+
+### Decision 1: Ledger library parameterization via `ledger_init`
+
+**Choice:** Add a `ledger_init` function that sets module-level variables `LEDGER_FILENAME` and `LEDGER_BAK_FILENAME`. Remove `readonly` from these constants and set them as defaults that `ledger_init` can override.
+
+**Rationale:** Function-based initialization is self-documenting (the caller's intent is clear in the source), backward-compatible (apply-side needs no changes if it doesn't call `ledger_init`), and avoids environment variable pollution.
+
+**Alternatives considered:**
+- Environment variable (`SPECFLOW_LEDGER_FILENAME`): Less discoverable, potential name collision
+- Per-function argument: Too invasive — every `ledger_*` function would need an extra parameter, breaking existing callers
+
+### Decision 2: Design orchestrator mirrors apply-side architecture
+
+**Choice:** `bin/specflow-review-design` follows the same structure as `bin/specflow-review-apply`: same subcommands, same pipeline stages, same result JSON schema. Key differences are design-specific:
+- No diff filtering step — reads artifact files directly
+- Prompt templates: `review_design_prompt.md` / `review_design_rereview_prompt.md`
+- Phase field: `"design"` instead of `"impl"`
+- current-phase.md uses design-specific phase names (`design-review`, `design-fix-review`)
+- Next-state derivation: `fix → fix_design`, `advance → apply`, `stop → rejected`
+
+**Rationale:** Structural consistency reduces cognitive overhead and enables future unification. Differences are isolated to configuration-level constants.
+
+### Decision 3: Artifact dependency loop — one-artifact-at-a-time invocations
+
+**Choice:** `bin/specflow-design-artifacts` uses a **one-artifact-at-a-time** invocation model instead of a streaming JSONL model. The slash command drives the loop:
+1. Slash command calls `specflow-design-artifacts next <CHANGE_ID>` → script runs `openspec status`, finds the next ready artifact, fetches its instructions, and outputs a single JSON object to stdout. If all artifacts are complete, outputs `{"status": "complete"}`.
+2. Slash command uses the LLM to generate content for that artifact and writes it to `outputPath`.
+3. Slash command calls `specflow-design-artifacts next <CHANGE_ID>` again → script re-polls status, finds next ready artifact, etc.
+4. Loop until `{"status": "complete"}` or `{"status": "blocked"}`.
+
+**Subcommands:**
+- `next <CHANGE_ID>` — returns the next ready artifact's metadata or completion/blocked status
+- `validate <CHANGE_ID>` — structural validation wrapper
+
+**Rationale:** The one-at-a-time model avoids the synchronous continuation problem: the Bash script doesn't need to wait for mid-stream LLM output. Each invocation is stateless — it reads `openspec status` fresh. The slash command owns the loop control and can interleave LLM content generation between invocations.
+
+### Decision 4: Design review prompt construction in Bash
+
+**Choice:** The orchestrator reads artifact files (proposal.md, design.md, tasks.md, and any spec files under specs/) and assembles the Codex prompt by concatenating the prompt template with file contents. No diff is involved.
+
+**Rationale:** This matches the current behavior of the slash command but moves the file reading and prompt assembly into deterministic Bash code.
+
+### Decision 5: Fix-review and autofix-loop scope
+
+**Choice:** Two distinct paths for design artifact fixes:
+- **Manual path (`fix-review` subcommand):** The slash command (`specflow.fix_design`) uses the main LLM (Claude Code) to modify design.md/tasks.md, then calls `bin/specflow-review-design fix-review` for re-review + ledger update only. Bash handles: prompt assembly → Codex re-review → response parsing → ledger update → score computation → current-phase.md generation.
+- **Auto-fix path (`autofix-loop` subcommand):** The Bash orchestrator owns the full loop. Each round uses `codex` CLI to both fix design.md/tasks.md (via a design-specific fix prompt, `fix_design_prompt.md`) AND re-review them. This mirrors the apply-side pattern where `specflow-review-apply autofix-loop` calls codex for fixes and re-review within Bash.
+
+**Rationale:** The manual path preserves LLM quality for user-initiated fixes. The autofix path uses codex CLI for speed and determinism within the loop. This matches the apply-side exactly: `fix-review` is called by the slash command after LLM fixes, while `autofix-loop` uses codex for both fix and review internally.
+
+**Key implementation detail:** The `autofix-loop` builds a fix prompt (`build_fix_prompt`) containing the current findings and artifact contents, sends it to codex CLI to modify the files, then runs the re-review pipeline. The slash command is not invoked during the loop.
+
+**Prompt file delivery:** The `fix_design_prompt.md` file SHALL be installed to `~/.config/specflow/global/prompts/fix_design_prompt.md` by `specflow-install`. If the file is missing at runtime, the orchestrator SHALL fall back to a generic fix instruction (same pattern as apply-side `build_fix_prompt` which falls back to `review_apply_prompt.md` when `fix_apply_prompt.md` is absent).
+
+**Failure handling in autofix-loop:**
+- If the codex fix step fails (non-zero exit, empty output): log warning, skip the round, continue to the next round. Do NOT count as a successful round.
+- If the codex re-review returns invalid JSON: log warning, skip ledger update for this round, continue.
+- If a round produces no effective artifact changes (codex returns but files are unchanged): log warning, increment round counter, continue. If 2 consecutive no-change rounds occur, terminate with `result: "no_progress"`.
+- Fatal errors (ledger write failure, etc.): terminate loop with `result: "error"`.
+
+### Decision 6: Corrupt-ledger recovery via `--reset-ledger` flag
+
+**Choice:** Add a `--reset-ledger` flag to the `review` and `fix-review` subcommands. When passed, the orchestrator creates a fresh empty ledger (overwriting any existing file) before proceeding with the normal pipeline. The slash command uses this flag after `AskUserQuestion` confirms the user wants to reset.
+
+**Flow:**
+1. Orchestrator detects corrupt ledger with no backup → returns `ledger_recovery: "prompt_user"` in result JSON
+2. Slash command shows AskUserQuestion: "新規 ledger を作成しますか？"
+3. User selects "新規作成" → slash command re-invokes orchestrator with `--reset-ledger`
+4. User selects "中止" → workflow stops
+
+**Rationale:** Keeps recovery logic in Bash (deterministic), the slash command only handles UI. No need for a separate subcommand — a flag on existing subcommands is simpler.
+
+**Autofix-loop exception:** In `autofix-loop` mode, the orchestrator SHALL auto-reinitialize a missing or corrupt ledger with a warning to stderr (no user prompt), since autofix runs non-interactively. The `--reset-ledger` flag and `ledger_recovery: "prompt_user"` only apply to interactive `review` and `fix-review` subcommands.
+
+### Decision 7: Re-review ledger semantics — shared library reuse
+
+**Choice:** The existing `ledger_match_rereview` function in `lib/specflow-ledger.sh` already handles the re-review contract (resolved/still_open/new_findings classification, exhaustive check, duplicate check, unknown ID exclusion). The design-side orchestrator reuses this function directly, same as the apply-side. Additional design-specific post-processing (re-evaluated severity for still_open, `ledger_error: true` handling) is implemented in the orchestrator script, not the shared library.
+
+**Key behaviors already in `ledger_match_rereview`:**
+- Resolved findings: status set to "resolved", resolved_round updated
+- Still-open findings: status preserved (open) or override preserved, latest_round updated
+- New findings: created with sequential IDs from `max_finding_id`
+- Exhaustive check: missing prior IDs auto-classified as still_open
+- Duplicate check: IDs in both lists → still_open wins
+
+**Design-specific additions in orchestrator:**
+- Severity re-evaluation: update severity field for still_open findings based on Codex response
+- `ledger_error: true` handling: clear all existing findings, use only new_findings from response
+- Override notes validation: existing in shared library (`ledger_validate`)
+
+**Rationale:** The shared library already covers 90% of re-review semantics. Only the Codex-response-specific post-processing needs orchestrator-level code, avoiding unnecessary library changes.
+
+**Result JSON extension for re-review:** When `fix-review` runs, the result JSON SHALL include a `rereview_classification` object alongside the standard fields: `{"resolved": [...ids], "still_open": [...ids], "new_findings": [...ids]}`. This allows the slash command wrapper to display the resolved/still-open/new classification table without reimplementing classification logic.
+
+## Risks / Trade-offs
+
+- **[Risk] Ledger `readonly` removal may cause accidental mutation** → Mitigation: `ledger_init` sets defaults at source-time; apply-side callers are not affected since they never call `ledger_init` and the defaults remain unchanged.
+- **[Risk] Two parallel orchestrator scripts with similar but not identical logic** → Mitigation: Both share `lib/specflow-ledger.sh` for all ledger operations. Design-specific differences (no diff, different prompts, different phase names) are isolated to the orchestrator-level code.
+- **[Risk] Artifact dependency loop stdout streaming may be fragile** → Mitigation: Each artifact outputs a self-contained JSON line (JSONL format), making parsing robust. The script exits with a final summary JSON.
+- **[Risk] Backward compatibility of slash command changes** → Mitigation: Slash commands call the orchestrator scripts and parse their stdout JSON. The user-facing interface (AskUserQuestion buttons, progress messages) is unchanged.

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/proposal.md
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The design-side control flow (`specflow.design`, `specflow.review_design`, `specflow.fix_design`) currently embeds deterministic logic — artifact dependency loops, ledger read/write/match cycles, re-review classification, and next-state derivation — directly inside slash command markdown that an LLM interprets at runtime. This mirrors the problem that was already solved on the apply-side by extracting `bin/specflow-review-apply`. Moving the design-side logic into a Bash orchestrator (`bin/specflow-review-design`) produces deterministic, testable, and faster execution while reducing LLM token cost and eliminating prompt-interpretation variability.
+
+## What Changes
+
+- **New `bin/specflow-review-design` Bash orchestrator** with three subcommands:
+  - `review <CHANGE_ID>` — initial design review pipeline (read artifact files → codex invocation → ledger init/update → score → current-phase.md → result JSON). No diff filtering — artifact files (design.md, tasks.md, spec.md) are passed directly to Codex.
+  - `fix-review <CHANGE_ID> [--autofix]` — re-review pipeline only (codex re-review → ledger update → score). The "fix" step (modifying artifacts) remains in the slash command (LLM). Bash handles re-review + ledger update only.
+  - `autofix-loop <CHANGE_ID> [--max-rounds N]` — auto-fix loop with baseline snapshot, divergence warnings, and stop conditions
+- **New `bin/specflow-design-artifacts` Bash orchestrator** for the artifact dependency loop (loop control + metadata only):
+  - `generate <CHANGE_ID>` — loops `openspec status` → identify ready artifacts → `openspec instructions` → outputs JSON metadata (template, instructions, outputPath) to stdout per artifact. Content generation (writing design.md, tasks.md, spec.md) remains the LLM's responsibility in the slash command.
+  - `validate <CHANGE_ID>` — structural validation wrapper
+- **Parameterize `lib/specflow-ledger.sh`** via `ledger_init` function: callers invoke `ledger_init "review-ledger-design.json"` to set the filename; if `ledger_init` is not called, the default `review-ledger.json` is used (backward-compatible with apply-side)
+- **Result JSON schema** matches the apply-side (`{status, action, review, ledger, autofix, handoff}`) for unified slash command parsing
+- **Slash commands become thin wrappers**: `specflow.design`, `specflow.review_design`, and `specflow.fix_design` delegate deterministic control flow to the orchestrator scripts and retain only user-facing prompts, AskUserQuestion handoffs, and artifact content generation
+
+## Capabilities
+
+### New Capabilities
+- `design-orchestrator`: Bash orchestrator for design-side review/fix/autofix-loop lifecycle, including design ledger management, re-review classification, score aggregation, current-phase.md generation, and next-state derivation
+- `design-artifact-loop`: Bash orchestrator for the artifact dependency loop that drives `openspec status` → `openspec instructions` → file creation cycles
+
+### Modified Capabilities
+- `apply-orchestrator`: Parameterize ledger filename constants in `lib/specflow-ledger.sh` so both apply-side (`review-ledger.json`) and design-side (`review-ledger-design.json`) can share the same library functions
+
+## Impact
+
+- **Scripts**: New `bin/specflow-review-design`, new `bin/specflow-design-artifacts`; modified `lib/specflow-ledger.sh` (parameterized filenames with backward-compatible defaults)
+- **Slash commands**: `global/commands/specflow.design.md`, `global/commands/specflow.review_design.md`, `global/commands/specflow.fix_design.md` will be simplified to thin wrappers
+- **Dependencies**: Requires `jq`, `openspec` CLI, `codex` CLI (same as apply-side)
+- **Backward compatibility**: No change to user-facing command interface; all existing specflow slash commands continue to work identically

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/review-ledger-design.json
@@ -1,0 +1,28 @@
+{
+  "feature_id": "design-orchestrator-extraction",
+  "phase": "design",
+  "current_round": 4,
+  "status": "in_progress",
+  "max_finding_id": 13,
+  "findings": [
+    {"id": "R1-F01", "severity": "high", "category": "feasibility", "file": "design.md", "title": "Autofix-loop ownership is unresolved", "origin_round": 1, "latest_round": 2, "status": "resolved", "resolved_round": 2, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R2-F02", "severity": "high", "category": "feasibility", "file": "design.md", "title": "Corrupt-ledger recovery has no continuation contract", "origin_round": 2, "latest_round": 3, "status": "resolved", "resolved_round": 3, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R2-F03", "severity": "high", "category": "consistency", "file": "design.md", "title": "Re-review ledger semantics not covered by shared-library plan", "origin_round": 2, "latest_round": 3, "status": "resolved", "resolved_round": 3, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R2-F04", "severity": "high", "category": "completeness", "file": "tasks.md", "title": "Wrapper simplification doesn't wire all subcommands", "origin_round": 2, "latest_round": 3, "status": "resolved", "resolved_round": 3, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R3-F05", "severity": "high", "category": "feasibility", "file": "design.md", "title": "Artifact-loop streaming design lacks a continuation contract", "origin_round": 3, "latest_round": 4, "status": "resolved", "resolved_round": 4, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R3-F06", "severity": "high", "category": "completeness", "file": "design.md", "title": "Autofix ledger recovery is no longer specified as non-interactive", "origin_round": 3, "latest_round": 4, "status": "resolved", "resolved_round": 4, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R3-F07", "severity": "high", "category": "completeness", "file": "tasks.md", "title": "specflow.design task list omits post-validation review handoff", "origin_round": 3, "latest_round": 4, "status": "resolved", "resolved_round": 4, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R3-F08", "severity": "medium", "category": "consistency", "file": "design.md", "title": "Thin-wrapper plan does not expose re-review classification data", "origin_round": 3, "latest_round": 4, "status": "resolved", "resolved_round": 4, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R4-F09", "severity": "high", "category": "completeness", "file": "tasks.md", "title": "Autofix prompt file is referenced but never delivered", "origin_round": 3, "latest_round": 4, "status": "resolved", "resolved_round": 4, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R4-F10", "severity": "medium", "category": "completeness", "file": "tasks.md", "title": "Simplified /specflow.design wrapper does not define blocked or invalid-status handling", "origin_round": 3, "latest_round": 4, "status": "open", "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R4-F11", "severity": "medium", "category": "risk", "file": "design.md", "title": "Autofix-loop failure handling is still unspecified", "origin_round": 3, "latest_round": 4, "status": "resolved", "resolved_round": 4, "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R4-F12", "severity": "medium", "category": "completeness", "file": "tasks.md", "title": "Artifact-loop task contract does not preserve instruction constraints", "origin_round": 4, "latest_round": 4, "status": "new", "relation": "new", "supersedes": null, "notes": ""},
+    {"id": "R4-F13", "severity": "medium", "category": "consistency", "file": "design.md", "title": "Risk section still describes the abandoned JSONL streaming model", "origin_round": 4, "latest_round": 4, "status": "new", "relation": "new", "supersedes": null, "notes": ""}
+  ],
+  "round_summaries": [
+    {"round": 1, "total": 1, "open": 0, "new": 1, "resolved": 0, "overridden": 0, "by_severity": {"high": 1, "medium": 0, "low": 0}},
+    {"round": 2, "total": 4, "open": 0, "new": 3, "resolved": 1, "overridden": 0, "by_severity": {"high": 3, "medium": 0, "low": 0}},
+    {"round": 3, "total": 8, "open": 0, "new": 4, "resolved": 4, "overridden": 0, "by_severity": {"high": 3, "medium": 1, "low": 0}},
+    {"round": 4, "total": 13, "open": 1, "new": 2, "resolved": 10, "overridden": 0, "by_severity": {"high": 0, "medium": 3, "low": 0}}
+  ]
+}

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/review-ledger-design.json.bak
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/review-ledger-design.json.bak
@@ -1,0 +1,38 @@
+{
+  "feature_id": "design-orchestrator-extraction",
+  "phase": "design",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 1,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "feasibility",
+      "file": "design.md",
+      "title": "Autofix-loop ownership is unresolved",
+      "detail": "The design assigns autofix-loop to bin/specflow-review-design, but also says artifact fixes remain in the slash command/LLM and that slash commands retain artifact content generation. That leaves no defined component that can actually edit design.md/tasks.md inside a Bash-managed multi-round loop. Resolve by choosing one owner for the loop: either let the orchestrator perform fix generation in autofix mode via codex CLI, or keep loop control in the slash command and limit the Bash script to single-pass re-review/ledger operations.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 1,
+      "open": 0,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 0,
+        "low": 0
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/specs/apply-orchestrator/spec.md
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/specs/apply-orchestrator/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Ledger lifecycle management
+The orchestrator SHALL manage the full ledger lifecycle: read (with corruption recovery), validate, increment round, match findings, compute summary, compute status, backup, and write. The ledger filename SHALL be configurable via the `ledger_init` function in `lib/specflow-ledger.sh`.
+
+#### Scenario: Ledger creation on first review
+- **WHEN** the ledger file (as configured by `ledger_init` or default `review-ledger.json`) does not exist and `review` subcommand runs
+- **THEN** the orchestrator SHALL create a new ledger with `current_round: 0`, empty `findings`, and empty `round_summaries`
+
+#### Scenario: Ledger corruption recovery from backup
+- **WHEN** the ledger file exists but JSON parse fails and the corresponding `.bak` file exists and is valid
+- **THEN** the orchestrator SHALL rename the corrupt file to `.corrupt`, use the backup, and log a warning to stderr
+
+#### Scenario: Ledger corruption with no backup
+- **WHEN** the ledger file is corrupt and no valid backup exists
+- **THEN** the result JSON SHALL contain `ledger_recovery: "prompt_user"` so the slash command can ask the user whether to create a new ledger or abort
+
+#### Scenario: High-severity override notes validation
+- **WHEN** a high-severity finding has status `accepted_risk` or `ignored` with empty notes
+- **THEN** the orchestrator SHALL revert the finding status to `open` and log a warning to stderr
+
+#### Scenario: Round counter increment
+- **WHEN** ledger update begins
+- **THEN** `current_round` SHALL be incremented by 1
+
+## ADDED Requirements
+
+### Requirement: Ledger library filename parameterization
+The `lib/specflow-ledger.sh` library SHALL provide a `ledger_init` function that allows callers to configure the ledger filename and backup filename. If `ledger_init` is not called, the default filenames (`review-ledger.json` and `review-ledger.json.bak`) SHALL be used for backward compatibility.
+
+#### Scenario: Default filename without ledger_init
+- **WHEN** `ledger_read` is called without a prior `ledger_init` call
+- **THEN** the library SHALL use `review-ledger.json` as the ledger filename and `review-ledger.json.bak` as the backup filename
+
+#### Scenario: Custom filename via ledger_init
+- **WHEN** `ledger_init "review-ledger-design.json"` is called before `ledger_read`
+- **THEN** the library SHALL use `review-ledger-design.json` as the ledger filename and `review-ledger-design.json.bak` as the backup filename
+
+#### Scenario: ledger_init with phase parameter
+- **WHEN** `ledger_init "review-ledger-design.json" "design"` is called
+- **THEN** the library SHALL use the specified filename AND set the default phase to `"design"` for newly created ledgers (via `_empty_ledger`)
+
+#### Scenario: Multiple ledger_init calls
+- **WHEN** `ledger_init` is called multiple times
+- **THEN** the most recent call's values SHALL take effect

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/specs/design-artifact-loop/spec.md
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/specs/design-artifact-loop/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Artifact loop script entry point
+The system SHALL provide `bin/specflow-design-artifacts` as a Bash script with two subcommands: `next` and `validate`. The script SHALL exit with code 0 on success and non-zero on error.
+
+#### Scenario: Next subcommand invocation
+- **WHEN** `specflow-design-artifacts next <CHANGE_ID>` is executed
+- **THEN** the script SHALL poll `openspec status`, find the next ready artifact, fetch its instructions, and output a single JSON object to stdout
+
+#### Scenario: Validate subcommand invocation
+- **WHEN** `specflow-design-artifacts validate <CHANGE_ID>` is executed
+- **THEN** the script SHALL run `openspec validate` and output the validation result JSON to stdout
+
+#### Scenario: Missing CHANGE_ID argument
+- **WHEN** `specflow-design-artifacts next` is executed without a CHANGE_ID
+- **THEN** the script SHALL exit with code 1 and print usage to stderr
+
+### Requirement: One-artifact-at-a-time dependency resolution
+The `next` subcommand SHALL be stateless: each invocation polls `openspec status` fresh, identifies the next ready artifact, fetches its instructions, and returns. The calling slash command drives the loop by invoking `next` repeatedly.
+
+#### Scenario: Ready artifact found
+- **WHEN** `openspec status --change <CHANGE_ID> --json` reports one or more artifacts with `status: "ready"`
+- **THEN** the script SHALL select the first ready artifact, run `openspec instructions <artifact-id> --change <CHANGE_ID> --json`, and output: `{"status": "ready", "artifactId": "<id>", "outputPath": "<path>", "template": "<template>", "instruction": "<instruction>", "dependencies": [...]}`
+
+#### Scenario: All artifacts complete
+- **WHEN** all artifacts in `applyRequires` have `status: "done"`
+- **THEN** the script SHALL output `{"status": "complete"}` and exit with code 0
+
+#### Scenario: Blocked — no ready artifacts remain
+- **WHEN** no artifacts have `status: "ready"` and blocked artifacts remain
+- **THEN** the script SHALL output `{"status": "blocked", "blocked": ["<artifact-ids>"]}` and exit with code 1
+
+### Requirement: Structural validation wrapper
+The `validate` subcommand SHALL wrap `openspec validate` with consistent output formatting.
+
+#### Scenario: Validation pass
+- **WHEN** `openspec validate <CHANGE_ID> --type change --json` returns `valid: true`
+- **THEN** the script SHALL output `{"status": "valid"}` and exit with code 0
+
+#### Scenario: Validation failure
+- **WHEN** `openspec validate <CHANGE_ID> --type change --json` returns `valid: false`
+- **THEN** the script SHALL output the full validation JSON (including issues) and exit with code 1

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/specs/design-orchestrator/spec.md
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/specs/design-orchestrator/spec.md
@@ -1,48 +1,41 @@
-# apply-orchestrator Specification
+## ADDED Requirements
 
-## Purpose
-TBD - created by archiving change bash-orchestrator-extraction. Update Purpose after archive.
-## Requirements
 ### Requirement: Orchestrator script entry point
-The system SHALL provide `bin/specflow-review-apply` as a Bash script with three subcommands: `review`, `fix-review`, and `autofix-loop`. The script SHALL exit with code 0 on success and non-zero on error, outputting result JSON to stdout and log messages to stderr.
+The system SHALL provide `bin/specflow-review-design` as a Bash script with three subcommands: `review`, `fix-review`, and `autofix-loop`. The script SHALL exit with code 0 on success and non-zero on error, outputting result JSON to stdout and log messages to stderr.
 
 #### Scenario: Review subcommand invocation
-- **WHEN** `specflow-review-apply review <CHANGE_ID>` is executed
-- **THEN** the script SHALL run the full review pipeline (diff → codex → ledger → score) and output result JSON to stdout
+- **WHEN** `specflow-review-design review <CHANGE_ID>` is executed
+- **THEN** the script SHALL run the full design review pipeline (read artifacts → codex → ledger → score → current-phase.md) and output result JSON to stdout
 
 #### Scenario: Fix-review subcommand invocation
-- **WHEN** `specflow-review-apply fix-review <CHANGE_ID>` is executed
-- **THEN** the script SHALL run the fix-review pipeline (diff → codex re-review → ledger → score) and output result JSON to stdout
+- **WHEN** `specflow-review-design fix-review <CHANGE_ID>` is executed
+- **THEN** the script SHALL run the re-review pipeline (codex re-review → ledger → score) and output result JSON to stdout
 
 #### Scenario: Autofix-loop subcommand invocation
-- **WHEN** `specflow-review-apply autofix-loop <CHANGE_ID> --max-rounds 4` is executed
+- **WHEN** `specflow-review-design autofix-loop <CHANGE_ID> --max-rounds 4` is executed
 - **THEN** the script SHALL run the auto-fix loop up to the specified max rounds and output result JSON to stdout
 
 #### Scenario: Missing CHANGE_ID argument
-- **WHEN** `specflow-review-apply review` is executed without a CHANGE_ID
+- **WHEN** `specflow-review-design review` is executed without a CHANGE_ID
 - **THEN** the script SHALL exit with code 1 and print usage to stderr
 
 #### Scenario: Invalid subcommand
-- **WHEN** `specflow-review-apply invalid-cmd` is executed
+- **WHEN** `specflow-review-design invalid-cmd` is executed
 - **THEN** the script SHALL exit with code 1 and print available subcommands to stderr
 
-### Requirement: Diff filtering pipeline
-The orchestrator SHALL invoke `specflow-filter-diff` to produce a filtered diff and parse the summary JSON. The orchestrator SHALL detect empty diffs and line count threshold exceedance.
+### Requirement: Artifact file reading pipeline
+The orchestrator SHALL read artifact files (proposal.md, design.md, tasks.md, and spec files under specs/) from the change directory and pass their contents directly to Codex. No diff filtering SHALL be applied.
 
-#### Scenario: Normal diff filtering
-- **WHEN** the review subcommand runs and `specflow-filter-diff` produces a non-empty diff
-- **THEN** the result JSON SHALL contain `diff_summary` with `excluded_count`, `included_count`, and `total_lines`
+#### Scenario: Normal artifact reading
+- **WHEN** the review subcommand runs and all required artifact files exist in the change directory
+- **THEN** the prompt SHALL contain the full contents of proposal.md, design.md, tasks.md, and any spec.md files under specs/
 
-#### Scenario: Empty diff detection
-- **WHEN** `specflow-filter-diff` produces an empty diff (0 bytes)
-- **THEN** the orchestrator SHALL exit with code 0 and set `status: "error"` with `error: "no_changes"` in the result JSON
+#### Scenario: Missing artifact detection
+- **WHEN** a required artifact file (design.md or tasks.md) is missing from the change directory
+- **THEN** the orchestrator SHALL exit with code 1 and set `status: "error"` with `error: "missing_artifacts"` in the result JSON
 
-#### Scenario: Line count threshold exceedance
-- **WHEN** the filtered diff `total_lines` exceeds the configured `diff_warn_threshold`
-- **THEN** the result JSON SHALL contain `diff_warning: true` and `diff_total_lines` so the slash command can prompt the user
-
-### Requirement: Codex CLI invocation
-The orchestrator SHALL invoke `codex --approval-mode full-auto -q` with the review prompt and parse the JSON response. The orchestrator SHALL handle parse failures gracefully.
+### Requirement: Codex CLI invocation for design review
+The orchestrator SHALL invoke `codex --approval-mode full-auto -q` with the design review prompt and parse the JSON response. The orchestrator SHALL handle parse failures gracefully.
 
 #### Scenario: Successful Codex invocation
 - **WHEN** codex CLI returns valid JSON
@@ -53,26 +46,40 @@ The orchestrator SHALL invoke `codex --approval-mode full-auto -q` with the revi
 - **THEN** the result JSON SHALL contain `review.parse_error: true` and `review.raw_response` with the raw output
 - **THEN** ledger update SHALL be skipped
 
-#### Scenario: Review prompt selection
-- **WHEN** the subcommand is `review` (initial)
-- **THEN** the orchestrator SHALL use `review_apply_prompt.md`
-- **WHEN** the subcommand is `fix-review` (re-review)
-- **THEN** the orchestrator SHALL use `review_apply_rereview_prompt.md`
+#### Scenario: Review prompt selection for initial review
+- **WHEN** the subcommand is `review`
+- **THEN** the orchestrator SHALL use `review_design_prompt.md`
 
-### Requirement: Ledger lifecycle management
-The orchestrator SHALL manage the full ledger lifecycle: read (with corruption recovery), validate, increment round, match findings, compute summary, compute status, backup, and write. The ledger filename SHALL be configurable via the `ledger_init` function in `lib/specflow-ledger.sh`.
+#### Scenario: Review prompt selection for re-review
+- **WHEN** the subcommand is `fix-review`
+- **THEN** the orchestrator SHALL use `review_design_rereview_prompt.md`
+
+### Requirement: Design ledger lifecycle management
+The orchestrator SHALL manage the full design ledger lifecycle using `review-ledger-design.json`: read (with corruption recovery), validate, increment round, match findings, compute summary, compute status, backup, and write. The orchestrator SHALL call `ledger_init "review-ledger-design.json"` before any ledger operations.
 
 #### Scenario: Ledger creation on first review
-- **WHEN** the ledger file (as configured by `ledger_init` or default `review-ledger.json`) does not exist and `review` subcommand runs
-- **THEN** the orchestrator SHALL create a new ledger with `current_round: 0`, empty `findings`, and empty `round_summaries`
+- **WHEN** `review-ledger-design.json` does not exist and `review` subcommand runs
+- **THEN** the orchestrator SHALL create a new ledger with `phase: "design"`, `current_round: 0`, empty `findings`, and empty `round_summaries`
 
 #### Scenario: Ledger corruption recovery from backup
-- **WHEN** the ledger file exists but JSON parse fails and the corresponding `.bak` file exists and is valid
+- **WHEN** `review-ledger-design.json` exists but JSON parse fails and `review-ledger-design.json.bak` exists and is valid
 - **THEN** the orchestrator SHALL rename the corrupt file to `.corrupt`, use the backup, and log a warning to stderr
 
 #### Scenario: Ledger corruption with no backup
-- **WHEN** the ledger file is corrupt and no valid backup exists
+- **WHEN** `review-ledger-design.json` is corrupt and no valid backup exists
 - **THEN** the result JSON SHALL contain `ledger_recovery: "prompt_user"` so the slash command can ask the user whether to create a new ledger or abort
+
+#### Scenario: Ledger reset via --reset-ledger flag
+- **WHEN** `specflow-review-design review <CHANGE_ID> --reset-ledger` is executed
+- **THEN** the orchestrator SHALL create a fresh empty ledger (overwriting any existing file) before proceeding with the normal review pipeline
+
+#### Scenario: Autofix-loop auto-reinitialization on missing ledger
+- **WHEN** `autofix-loop` runs and `review-ledger-design.json` does not exist
+- **THEN** the orchestrator SHALL create a fresh empty ledger with a warning to stderr and continue the loop (no user prompt)
+
+#### Scenario: Autofix-loop auto-reinitialization on corrupt ledger
+- **WHEN** `autofix-loop` runs and `review-ledger-design.json` is corrupt with no valid backup
+- **THEN** the orchestrator SHALL create a fresh empty ledger with a warning to stderr and continue the loop (no user prompt)
 
 #### Scenario: High-severity override notes validation
 - **WHEN** a high-severity finding has status `accepted_risk` or `ignored` with empty notes
@@ -83,7 +90,7 @@ The orchestrator SHALL manage the full ledger lifecycle: read (with corruption r
 - **THEN** `current_round` SHALL be incremented by 1
 
 ### Requirement: Finding matching algorithm (initial review)
-For initial reviews (no re-review mode), the orchestrator SHALL use a 3-stage matching algorithm: same match, reframed match, remaining.
+For initial reviews, the orchestrator SHALL use the same 3-stage matching algorithm as the apply-side: same match, reframed match, remaining.
 
 #### Scenario: Same match (file + category + severity)
 - **WHEN** a Codex finding matches an existing ledger finding by file, category, and severity
@@ -121,6 +128,14 @@ For re-reviews, the orchestrator SHALL apply the Codex-provided classification (
 - **WHEN** a finding ID in the Codex response does not exist in prior findings
 - **THEN** the orchestrator SHALL exclude it from ledger update and log a warning
 
+#### Scenario: Severity re-evaluation for still_open findings
+- **WHEN** a still_open finding has a different severity in the Codex re-review response
+- **THEN** the orchestrator SHALL update the finding's severity in the ledger to the re-evaluated value
+
+#### Scenario: ledger_error true handling
+- **WHEN** the Codex re-review response contains `ledger_error: true`
+- **THEN** the orchestrator SHALL clear all existing findings and use only `new_findings` from the response, setting `max_finding_id` from new_findings only
+
 ### Requirement: Zero-findings edge case
 The orchestrator SHALL handle the case where Codex returns zero findings.
 
@@ -153,7 +168,7 @@ The orchestrator SHALL create a backup before writing and use atomic writes.
 
 #### Scenario: Backup creation on clean read
 - **WHEN** the ledger was read successfully (not recovered from backup)
-- **THEN** the pre-update content SHALL be written to `review-ledger.json.bak` before the updated ledger is written
+- **THEN** the pre-update content SHALL be written to `review-ledger-design.json.bak` before the updated ledger is written
 
 #### Scenario: No backup on recovery
 - **WHEN** the ledger was recovered from backup or newly created
@@ -175,7 +190,11 @@ The orchestrator SHALL maintain `max_finding_id` in the ledger to prevent ID col
 - **THEN** `max_finding_id` SHALL be 0
 
 ### Requirement: Auto-fix loop orchestration
-The orchestrator `autofix-loop` subcommand SHALL manage the full auto-fix cycle with baseline snapshot, round iteration, and stop conditions.
+The orchestrator `autofix-loop` subcommand SHALL manage the full auto-fix cycle with baseline snapshot, round iteration, and stop conditions. Each round SHALL use the `codex` CLI to both fix design.md/tasks.md (via `fix_design_prompt.md`) AND re-review them. The slash command is NOT invoked during the loop.
+
+#### Scenario: Round fix step via codex CLI
+- **WHEN** an auto-fix round begins
+- **THEN** the orchestrator SHALL build a fix prompt containing current findings and artifact contents, invoke `codex --approval-mode full-auto -q` to modify design.md/tasks.md, then proceed to re-review
 
 #### Scenario: Baseline snapshot before loop
 - **WHEN** autofix-loop starts
@@ -201,6 +220,26 @@ The orchestrator `autofix-loop` subcommand SHALL manage the full auto-fix cycle 
 - **WHEN** `current_new_high_count > previous_new_high_count` in round 2 or later
 - **THEN** the orchestrator SHALL record a divergence warning of type `new_high_increase`
 
+#### Scenario: Fix prompt file fallback
+- **WHEN** `fix_design_prompt.md` is not found at `~/.config/specflow/global/prompts/`
+- **THEN** the orchestrator SHALL use a generic fix instruction as fallback
+
+#### Scenario: Codex fix step failure in autofix round
+- **WHEN** the codex fix invocation fails (non-zero exit or empty output) during a round
+- **THEN** the orchestrator SHALL log a warning, skip the round, and continue to the next round
+
+#### Scenario: Re-review parse failure in autofix round
+- **WHEN** the codex re-review returns invalid JSON during a round
+- **THEN** the orchestrator SHALL log a warning, skip ledger update for this round, and continue
+
+#### Scenario: No-progress stop condition
+- **WHEN** 2 consecutive autofix rounds produce no effective artifact changes
+- **THEN** the loop SHALL terminate with `result: "no_progress"`
+
+#### Scenario: Fatal error stop condition
+- **WHEN** a fatal error occurs during autofix (ledger write failure, etc.)
+- **THEN** the loop SHALL terminate with `result: "error"`
+
 ### Requirement: Handoff state determination
 The orchestrator SHALL determine the handoff state based on actionable findings count and include it in the result JSON.
 
@@ -225,14 +264,20 @@ The orchestrator SHALL generate `current-phase.md` after ledger update with phas
 
 #### Scenario: current-phase.md content after initial review
 - **WHEN** the review completes at round 1
-- **THEN** `current-phase.md` SHALL contain `Phase: impl-review`, `Round: 1`, and the computed status
+- **THEN** `current-phase.md` SHALL contain `Phase: design-review`, `Round: 1`, and the computed status
 
 #### Scenario: current-phase.md content after fix review
 - **WHEN** the fix-review completes at round > 1
-- **THEN** `current-phase.md` SHALL contain `Phase: fix-review` and the current round number
+- **THEN** `current-phase.md` SHALL contain `Phase: design-fix-review` and the current round number
+
+#### Scenario: Next recommended action derivation
+- **WHEN** open high findings exist
+- **THEN** next action SHALL be `/specflow.fix_design`
+- **WHEN** no open high findings exist
+- **THEN** next action SHALL be `/specflow.apply`
 
 ### Requirement: Result JSON schema
-All subcommands SHALL output a unified result JSON schema to stdout containing status, action, review results, ledger state, autofix state (if applicable), handoff state, and error information.
+All subcommands SHALL output a unified result JSON schema to stdout matching the apply-side schema, containing status, action, review results, ledger state, autofix state (if applicable), handoff state, and error information.
 
 #### Scenario: Successful review result JSON
 - **WHEN** the review pipeline completes successfully
@@ -242,22 +287,6 @@ All subcommands SHALL output a unified result JSON schema to stdout containing s
 - **WHEN** any pipeline step fails fatally
 - **THEN** the result JSON SHALL contain `status: "error"` and `error` with a description
 
-### Requirement: Ledger library filename parameterization
-The `lib/specflow-ledger.sh` library SHALL provide a `ledger_init` function that allows callers to configure the ledger filename and backup filename. If `ledger_init` is not called, the default filenames (`review-ledger.json` and `review-ledger.json.bak`) SHALL be used for backward compatibility.
-
-#### Scenario: Default filename without ledger_init
-- **WHEN** `ledger_read` is called without a prior `ledger_init` call
-- **THEN** the library SHALL use `review-ledger.json` as the ledger filename and `review-ledger.json.bak` as the backup filename
-
-#### Scenario: Custom filename via ledger_init
-- **WHEN** `ledger_init "review-ledger-design.json"` is called before `ledger_read`
-- **THEN** the library SHALL use `review-ledger-design.json` as the ledger filename and `review-ledger-design.json.bak` as the backup filename
-
-#### Scenario: ledger_init with phase parameter
-- **WHEN** `ledger_init "review-ledger-design.json" "design"` is called
-- **THEN** the library SHALL use the specified filename AND set the default phase to `"design"` for newly created ledgers (via `_empty_ledger`)
-
-#### Scenario: Multiple ledger_init calls
-- **WHEN** `ledger_init` is called multiple times
-- **THEN** the most recent call's values SHALL take effect
-
+#### Scenario: Fix-review result includes re-review classification
+- **WHEN** the `fix-review` pipeline completes successfully
+- **THEN** the result JSON SHALL include a `rereview_classification` object with `resolved`, `still_open`, and `new_findings` arrays containing finding IDs, enabling the slash command to display the classification table

--- a/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/tasks.md
+++ b/openspec/changes/archive/2026-04-09-design-orchestrator-extraction/tasks.md
@@ -1,0 +1,58 @@
+## 1. Ledger Library Parameterization
+
+- [x] 1.1 Remove `readonly` from `LEDGER_FILENAME` and `LEDGER_BAK_FILENAME` in `lib/specflow-ledger.sh`, keep them as default values
+- [x] 1.2 Add `ledger_init` function that accepts filename (required) and phase (optional) parameters, setting module-level `LEDGER_FILENAME`, `LEDGER_BAK_FILENAME`, and `LEDGER_DEFAULT_PHASE` variables
+- [x] 1.3 Update `_empty_ledger` to use `LEDGER_DEFAULT_PHASE` (defaulting to `"impl"` for backward compatibility)
+- [x] 1.4 Verify `bin/specflow-review-apply` still works without calling `ledger_init` (backward compatibility)
+
+## 2. Design Artifact Loop Script
+
+- [x] 2.1 Create `bin/specflow-design-artifacts` with `next` and `validate` subcommands and argument parsing
+- [x] 2.2 Implement `next` subcommand: poll `openspec status`, find next ready artifact, fetch instructions via `openspec instructions`, output single JSON object (stateless, one-artifact-at-a-time)
+- [x] 2.3 Implement completion/blocked detection: output `{"status": "complete"}` or `{"status": "blocked", "blocked": [...]}`
+- [x] 2.4 Implement the `validate` subcommand wrapping `openspec validate` with consistent JSON output
+- [x] 2.5 Make the script executable and add to `bin/`
+
+## 3. Design Review Orchestrator - Core Pipeline
+
+- [x] 3.1 Create `bin/specflow-review-design` with subcommand dispatch (`review`, `fix-review`, `autofix-loop`) and argument parsing
+- [x] 3.2 Implement artifact file reading: read proposal.md, design.md, tasks.md, and spec files, assembling them into the Codex prompt
+- [x] 3.3 Implement `build_review_prompt` for initial design review (concatenate `review_design_prompt.md` + artifact contents)
+- [x] 3.4 Implement `build_rereview_prompt` for design re-review (concatenate `review_design_rereview_prompt.md` + previous findings + artifact contents)
+- [x] 3.5 Implement Codex invocation and response parsing (reuse `call_codex` pattern from apply-side)
+- [x] 3.6 Call `ledger_init "review-ledger-design.json" "design"` at script initialization
+
+## 4. Design Review Orchestrator - Ledger Integration
+
+- [x] 4.1 Implement the `review` subcommand pipeline: artifact reading → codex → ledger read/create → validate → increment → match findings → summary → status → score → backup → write
+- [x] 4.2 Implement the `fix-review` subcommand pipeline: artifact reading → codex re-review → `ledger_match_rereview` → severity re-evaluation for still_open → `ledger_error: true` handling (clear findings, use new_findings only) → summary → status → score → backup → write
+- [x] 4.3 Implement `--reset-ledger` flag for `review` and `fix-review`: create fresh empty ledger before normal pipeline, used after slash command AskUserQuestion approval for corrupt-ledger recovery
+- [x] 4.4 Implement `generate_current_phase` for design-specific phases (`design-review`, `design-fix-review`) and next-action derivation (`/specflow.fix_design` or `/specflow.apply`)
+- [x] 4.5 Implement handoff state determination (`review_with_findings`, `review_no_findings`, `loop_no_findings`, `loop_with_findings`)
+- [x] 4.6 Implement result JSON output matching the apply-side schema, with `rereview_classification` object (resolved/still_open/new_findings IDs) included in fix-review results for slash command display
+
+## 5. Design Review Orchestrator - Auto-fix Loop
+
+- [x] 5.1 Create `fix_design_prompt.md` prompt file and add to `specflow-install` delivery list; implement `build_fix_prompt` with fallback to generic fix instruction if prompt file is missing
+- [x] 5.2 Implement autofix-loop ledger auto-reinitialization: create fresh empty ledger on missing/corrupt file with warning to stderr (non-interactive, no prompt_user)
+- [x] 5.3 Implement baseline snapshot recording (baseline_score, baseline_new_high_count, baseline high finding titles)
+- [x] 5.4 Implement round iteration: each round calls codex CLI to fix artifacts via `build_fix_prompt`, then runs the re-review pipeline (codex re-review → ledger update → score)
+- [x] 5.5 Implement stop conditions: success (unresolved_high == 0), max rounds reached, no_progress (2 consecutive no-change rounds)
+- [x] 5.6 Implement round failure handling: codex fix failure → skip round; re-review parse failure → skip ledger update; fatal errors → terminate with result "error"
+- [x] 5.7 Implement divergence warnings: quality gate degradation, finding re-emergence, new high increase
+- [x] 5.8 Implement loop summary output (score progression table, divergence warning history)
+
+## 6. Slash Command Simplification
+
+- [x] 6.1 Update `global/commands/specflow.review_design.md` to call `bin/specflow-review-design review` for initial review, and replace the inline auto-fix loop with a call to `bin/specflow-review-design autofix-loop`; parse result JSON for display and handoff
+- [x] 6.2 Update `global/commands/specflow.fix_design.md` to call `bin/specflow-review-design fix-review` for re-review after LLM fixes; parse result JSON
+- [x] 6.3 Update `global/commands/specflow.design.md` to: (a) call `bin/specflow-design-artifacts next` in a loop (slash command drives loop, LLM generates content per artifact); handle `{"status": "blocked"}` by reporting blocked artifacts and asking user how to proceed, (b) call `bin/specflow-design-artifacts validate` for structural validation; present validation issues and let user decide (fix/continue/abort, matching current behavior), (c) invoke `bin/specflow-review-design review` or the review wrapper after validation for the design review handoff
+- [x] 6.4 Wire corrupt-ledger recovery: when orchestrator returns `ledger_recovery: "prompt_user"`, show AskUserQuestion and re-invoke with `--reset-ledger` on user approval
+- [x] 6.5 Verify all AskUserQuestion handoffs and user-facing messages remain unchanged
+
+## 7. Integration Verification
+
+- [x] 7.1 End-to-end test: `/specflow.design` on a new change produces all artifacts and runs design review via orchestrator
+- [x] 7.2 End-to-end test: `/specflow.fix_design` modifies artifacts and runs re-review via orchestrator with correct ledger update
+- [x] 7.3 End-to-end test: auto-fix loop runs multiple rounds and terminates correctly
+- [x] 7.4 Verify apply-side orchestrator (`specflow-review-apply`) backward compatibility with parameterized ledger library

--- a/openspec/specs/design-artifact-loop/spec.md
+++ b/openspec/specs/design-artifact-loop/spec.md
@@ -1,0 +1,46 @@
+# design-artifact-loop Specification
+
+## Purpose
+TBD - created by archiving change design-orchestrator-extraction. Update Purpose after archive.
+## Requirements
+### Requirement: Artifact loop script entry point
+The system SHALL provide `bin/specflow-design-artifacts` as a Bash script with two subcommands: `next` and `validate`. The script SHALL exit with code 0 on success and non-zero on error.
+
+#### Scenario: Next subcommand invocation
+- **WHEN** `specflow-design-artifacts next <CHANGE_ID>` is executed
+- **THEN** the script SHALL poll `openspec status`, find the next ready artifact, fetch its instructions, and output a single JSON object to stdout
+
+#### Scenario: Validate subcommand invocation
+- **WHEN** `specflow-design-artifacts validate <CHANGE_ID>` is executed
+- **THEN** the script SHALL run `openspec validate` and output the validation result JSON to stdout
+
+#### Scenario: Missing CHANGE_ID argument
+- **WHEN** `specflow-design-artifacts next` is executed without a CHANGE_ID
+- **THEN** the script SHALL exit with code 1 and print usage to stderr
+
+### Requirement: One-artifact-at-a-time dependency resolution
+The `next` subcommand SHALL be stateless: each invocation polls `openspec status` fresh, identifies the next ready artifact, fetches its instructions, and returns. The calling slash command drives the loop by invoking `next` repeatedly.
+
+#### Scenario: Ready artifact found
+- **WHEN** `openspec status --change <CHANGE_ID> --json` reports one or more artifacts with `status: "ready"`
+- **THEN** the script SHALL select the first ready artifact, run `openspec instructions <artifact-id> --change <CHANGE_ID> --json`, and output: `{"status": "ready", "artifactId": "<id>", "outputPath": "<path>", "template": "<template>", "instruction": "<instruction>", "dependencies": [...]}`
+
+#### Scenario: All artifacts complete
+- **WHEN** all artifacts in `applyRequires` have `status: "done"`
+- **THEN** the script SHALL output `{"status": "complete"}` and exit with code 0
+
+#### Scenario: Blocked — no ready artifacts remain
+- **WHEN** no artifacts have `status: "ready"` and blocked artifacts remain
+- **THEN** the script SHALL output `{"status": "blocked", "blocked": ["<artifact-ids>"]}` and exit with code 1
+
+### Requirement: Structural validation wrapper
+The `validate` subcommand SHALL wrap `openspec validate` with consistent output formatting.
+
+#### Scenario: Validation pass
+- **WHEN** `openspec validate <CHANGE_ID> --type change --json` returns `valid: true`
+- **THEN** the script SHALL output `{"status": "valid"}` and exit with code 0
+
+#### Scenario: Validation failure
+- **WHEN** `openspec validate <CHANGE_ID> --type change --json` returns `valid: false`
+- **THEN** the script SHALL output the full validation JSON (including issues) and exit with code 1
+

--- a/openspec/specs/design-orchestrator/spec.md
+++ b/openspec/specs/design-orchestrator/spec.md
@@ -1,48 +1,44 @@
-# apply-orchestrator Specification
+# design-orchestrator Specification
 
 ## Purpose
-TBD - created by archiving change bash-orchestrator-extraction. Update Purpose after archive.
+TBD - created by archiving change design-orchestrator-extraction. Update Purpose after archive.
 ## Requirements
 ### Requirement: Orchestrator script entry point
-The system SHALL provide `bin/specflow-review-apply` as a Bash script with three subcommands: `review`, `fix-review`, and `autofix-loop`. The script SHALL exit with code 0 on success and non-zero on error, outputting result JSON to stdout and log messages to stderr.
+The system SHALL provide `bin/specflow-review-design` as a Bash script with three subcommands: `review`, `fix-review`, and `autofix-loop`. The script SHALL exit with code 0 on success and non-zero on error, outputting result JSON to stdout and log messages to stderr.
 
 #### Scenario: Review subcommand invocation
-- **WHEN** `specflow-review-apply review <CHANGE_ID>` is executed
-- **THEN** the script SHALL run the full review pipeline (diff → codex → ledger → score) and output result JSON to stdout
+- **WHEN** `specflow-review-design review <CHANGE_ID>` is executed
+- **THEN** the script SHALL run the full design review pipeline (read artifacts → codex → ledger → score → current-phase.md) and output result JSON to stdout
 
 #### Scenario: Fix-review subcommand invocation
-- **WHEN** `specflow-review-apply fix-review <CHANGE_ID>` is executed
-- **THEN** the script SHALL run the fix-review pipeline (diff → codex re-review → ledger → score) and output result JSON to stdout
+- **WHEN** `specflow-review-design fix-review <CHANGE_ID>` is executed
+- **THEN** the script SHALL run the re-review pipeline (codex re-review → ledger → score) and output result JSON to stdout
 
 #### Scenario: Autofix-loop subcommand invocation
-- **WHEN** `specflow-review-apply autofix-loop <CHANGE_ID> --max-rounds 4` is executed
+- **WHEN** `specflow-review-design autofix-loop <CHANGE_ID> --max-rounds 4` is executed
 - **THEN** the script SHALL run the auto-fix loop up to the specified max rounds and output result JSON to stdout
 
 #### Scenario: Missing CHANGE_ID argument
-- **WHEN** `specflow-review-apply review` is executed without a CHANGE_ID
+- **WHEN** `specflow-review-design review` is executed without a CHANGE_ID
 - **THEN** the script SHALL exit with code 1 and print usage to stderr
 
 #### Scenario: Invalid subcommand
-- **WHEN** `specflow-review-apply invalid-cmd` is executed
+- **WHEN** `specflow-review-design invalid-cmd` is executed
 - **THEN** the script SHALL exit with code 1 and print available subcommands to stderr
 
-### Requirement: Diff filtering pipeline
-The orchestrator SHALL invoke `specflow-filter-diff` to produce a filtered diff and parse the summary JSON. The orchestrator SHALL detect empty diffs and line count threshold exceedance.
+### Requirement: Artifact file reading pipeline
+The orchestrator SHALL read artifact files (proposal.md, design.md, tasks.md, and spec files under specs/) from the change directory and pass their contents directly to Codex. No diff filtering SHALL be applied.
 
-#### Scenario: Normal diff filtering
-- **WHEN** the review subcommand runs and `specflow-filter-diff` produces a non-empty diff
-- **THEN** the result JSON SHALL contain `diff_summary` with `excluded_count`, `included_count`, and `total_lines`
+#### Scenario: Normal artifact reading
+- **WHEN** the review subcommand runs and all required artifact files exist in the change directory
+- **THEN** the prompt SHALL contain the full contents of proposal.md, design.md, tasks.md, and any spec.md files under specs/
 
-#### Scenario: Empty diff detection
-- **WHEN** `specflow-filter-diff` produces an empty diff (0 bytes)
-- **THEN** the orchestrator SHALL exit with code 0 and set `status: "error"` with `error: "no_changes"` in the result JSON
+#### Scenario: Missing artifact detection
+- **WHEN** a required artifact file (design.md or tasks.md) is missing from the change directory
+- **THEN** the orchestrator SHALL exit with code 1 and set `status: "error"` with `error: "missing_artifacts"` in the result JSON
 
-#### Scenario: Line count threshold exceedance
-- **WHEN** the filtered diff `total_lines` exceeds the configured `diff_warn_threshold`
-- **THEN** the result JSON SHALL contain `diff_warning: true` and `diff_total_lines` so the slash command can prompt the user
-
-### Requirement: Codex CLI invocation
-The orchestrator SHALL invoke `codex --approval-mode full-auto -q` with the review prompt and parse the JSON response. The orchestrator SHALL handle parse failures gracefully.
+### Requirement: Codex CLI invocation for design review
+The orchestrator SHALL invoke `codex --approval-mode full-auto -q` with the design review prompt and parse the JSON response. The orchestrator SHALL handle parse failures gracefully.
 
 #### Scenario: Successful Codex invocation
 - **WHEN** codex CLI returns valid JSON
@@ -53,26 +49,40 @@ The orchestrator SHALL invoke `codex --approval-mode full-auto -q` with the revi
 - **THEN** the result JSON SHALL contain `review.parse_error: true` and `review.raw_response` with the raw output
 - **THEN** ledger update SHALL be skipped
 
-#### Scenario: Review prompt selection
-- **WHEN** the subcommand is `review` (initial)
-- **THEN** the orchestrator SHALL use `review_apply_prompt.md`
-- **WHEN** the subcommand is `fix-review` (re-review)
-- **THEN** the orchestrator SHALL use `review_apply_rereview_prompt.md`
+#### Scenario: Review prompt selection for initial review
+- **WHEN** the subcommand is `review`
+- **THEN** the orchestrator SHALL use `review_design_prompt.md`
 
-### Requirement: Ledger lifecycle management
-The orchestrator SHALL manage the full ledger lifecycle: read (with corruption recovery), validate, increment round, match findings, compute summary, compute status, backup, and write. The ledger filename SHALL be configurable via the `ledger_init` function in `lib/specflow-ledger.sh`.
+#### Scenario: Review prompt selection for re-review
+- **WHEN** the subcommand is `fix-review`
+- **THEN** the orchestrator SHALL use `review_design_rereview_prompt.md`
+
+### Requirement: Design ledger lifecycle management
+The orchestrator SHALL manage the full design ledger lifecycle using `review-ledger-design.json`: read (with corruption recovery), validate, increment round, match findings, compute summary, compute status, backup, and write. The orchestrator SHALL call `ledger_init "review-ledger-design.json"` before any ledger operations.
 
 #### Scenario: Ledger creation on first review
-- **WHEN** the ledger file (as configured by `ledger_init` or default `review-ledger.json`) does not exist and `review` subcommand runs
-- **THEN** the orchestrator SHALL create a new ledger with `current_round: 0`, empty `findings`, and empty `round_summaries`
+- **WHEN** `review-ledger-design.json` does not exist and `review` subcommand runs
+- **THEN** the orchestrator SHALL create a new ledger with `phase: "design"`, `current_round: 0`, empty `findings`, and empty `round_summaries`
 
 #### Scenario: Ledger corruption recovery from backup
-- **WHEN** the ledger file exists but JSON parse fails and the corresponding `.bak` file exists and is valid
+- **WHEN** `review-ledger-design.json` exists but JSON parse fails and `review-ledger-design.json.bak` exists and is valid
 - **THEN** the orchestrator SHALL rename the corrupt file to `.corrupt`, use the backup, and log a warning to stderr
 
 #### Scenario: Ledger corruption with no backup
-- **WHEN** the ledger file is corrupt and no valid backup exists
+- **WHEN** `review-ledger-design.json` is corrupt and no valid backup exists
 - **THEN** the result JSON SHALL contain `ledger_recovery: "prompt_user"` so the slash command can ask the user whether to create a new ledger or abort
+
+#### Scenario: Ledger reset via --reset-ledger flag
+- **WHEN** `specflow-review-design review <CHANGE_ID> --reset-ledger` is executed
+- **THEN** the orchestrator SHALL create a fresh empty ledger (overwriting any existing file) before proceeding with the normal review pipeline
+
+#### Scenario: Autofix-loop auto-reinitialization on missing ledger
+- **WHEN** `autofix-loop` runs and `review-ledger-design.json` does not exist
+- **THEN** the orchestrator SHALL create a fresh empty ledger with a warning to stderr and continue the loop (no user prompt)
+
+#### Scenario: Autofix-loop auto-reinitialization on corrupt ledger
+- **WHEN** `autofix-loop` runs and `review-ledger-design.json` is corrupt with no valid backup
+- **THEN** the orchestrator SHALL create a fresh empty ledger with a warning to stderr and continue the loop (no user prompt)
 
 #### Scenario: High-severity override notes validation
 - **WHEN** a high-severity finding has status `accepted_risk` or `ignored` with empty notes
@@ -83,7 +93,7 @@ The orchestrator SHALL manage the full ledger lifecycle: read (with corruption r
 - **THEN** `current_round` SHALL be incremented by 1
 
 ### Requirement: Finding matching algorithm (initial review)
-For initial reviews (no re-review mode), the orchestrator SHALL use a 3-stage matching algorithm: same match, reframed match, remaining.
+For initial reviews, the orchestrator SHALL use the same 3-stage matching algorithm as the apply-side: same match, reframed match, remaining.
 
 #### Scenario: Same match (file + category + severity)
 - **WHEN** a Codex finding matches an existing ledger finding by file, category, and severity
@@ -121,6 +131,14 @@ For re-reviews, the orchestrator SHALL apply the Codex-provided classification (
 - **WHEN** a finding ID in the Codex response does not exist in prior findings
 - **THEN** the orchestrator SHALL exclude it from ledger update and log a warning
 
+#### Scenario: Severity re-evaluation for still_open findings
+- **WHEN** a still_open finding has a different severity in the Codex re-review response
+- **THEN** the orchestrator SHALL update the finding's severity in the ledger to the re-evaluated value
+
+#### Scenario: ledger_error true handling
+- **WHEN** the Codex re-review response contains `ledger_error: true`
+- **THEN** the orchestrator SHALL clear all existing findings and use only `new_findings` from the response, setting `max_finding_id` from new_findings only
+
 ### Requirement: Zero-findings edge case
 The orchestrator SHALL handle the case where Codex returns zero findings.
 
@@ -153,7 +171,7 @@ The orchestrator SHALL create a backup before writing and use atomic writes.
 
 #### Scenario: Backup creation on clean read
 - **WHEN** the ledger was read successfully (not recovered from backup)
-- **THEN** the pre-update content SHALL be written to `review-ledger.json.bak` before the updated ledger is written
+- **THEN** the pre-update content SHALL be written to `review-ledger-design.json.bak` before the updated ledger is written
 
 #### Scenario: No backup on recovery
 - **WHEN** the ledger was recovered from backup or newly created
@@ -175,7 +193,11 @@ The orchestrator SHALL maintain `max_finding_id` in the ledger to prevent ID col
 - **THEN** `max_finding_id` SHALL be 0
 
 ### Requirement: Auto-fix loop orchestration
-The orchestrator `autofix-loop` subcommand SHALL manage the full auto-fix cycle with baseline snapshot, round iteration, and stop conditions.
+The orchestrator `autofix-loop` subcommand SHALL manage the full auto-fix cycle with baseline snapshot, round iteration, and stop conditions. Each round SHALL use the `codex` CLI to both fix design.md/tasks.md (via `fix_design_prompt.md`) AND re-review them. The slash command is NOT invoked during the loop.
+
+#### Scenario: Round fix step via codex CLI
+- **WHEN** an auto-fix round begins
+- **THEN** the orchestrator SHALL build a fix prompt containing current findings and artifact contents, invoke `codex --approval-mode full-auto -q` to modify design.md/tasks.md, then proceed to re-review
 
 #### Scenario: Baseline snapshot before loop
 - **WHEN** autofix-loop starts
@@ -201,6 +223,26 @@ The orchestrator `autofix-loop` subcommand SHALL manage the full auto-fix cycle 
 - **WHEN** `current_new_high_count > previous_new_high_count` in round 2 or later
 - **THEN** the orchestrator SHALL record a divergence warning of type `new_high_increase`
 
+#### Scenario: Fix prompt file fallback
+- **WHEN** `fix_design_prompt.md` is not found at `~/.config/specflow/global/prompts/`
+- **THEN** the orchestrator SHALL use a generic fix instruction as fallback
+
+#### Scenario: Codex fix step failure in autofix round
+- **WHEN** the codex fix invocation fails (non-zero exit or empty output) during a round
+- **THEN** the orchestrator SHALL log a warning, skip the round, and continue to the next round
+
+#### Scenario: Re-review parse failure in autofix round
+- **WHEN** the codex re-review returns invalid JSON during a round
+- **THEN** the orchestrator SHALL log a warning, skip ledger update for this round, and continue
+
+#### Scenario: No-progress stop condition
+- **WHEN** 2 consecutive autofix rounds produce no effective artifact changes
+- **THEN** the loop SHALL terminate with `result: "no_progress"`
+
+#### Scenario: Fatal error stop condition
+- **WHEN** a fatal error occurs during autofix (ledger write failure, etc.)
+- **THEN** the loop SHALL terminate with `result: "error"`
+
 ### Requirement: Handoff state determination
 The orchestrator SHALL determine the handoff state based on actionable findings count and include it in the result JSON.
 
@@ -225,14 +267,20 @@ The orchestrator SHALL generate `current-phase.md` after ledger update with phas
 
 #### Scenario: current-phase.md content after initial review
 - **WHEN** the review completes at round 1
-- **THEN** `current-phase.md` SHALL contain `Phase: impl-review`, `Round: 1`, and the computed status
+- **THEN** `current-phase.md` SHALL contain `Phase: design-review`, `Round: 1`, and the computed status
 
 #### Scenario: current-phase.md content after fix review
 - **WHEN** the fix-review completes at round > 1
-- **THEN** `current-phase.md` SHALL contain `Phase: fix-review` and the current round number
+- **THEN** `current-phase.md` SHALL contain `Phase: design-fix-review` and the current round number
+
+#### Scenario: Next recommended action derivation
+- **WHEN** open high findings exist
+- **THEN** next action SHALL be `/specflow.fix_design`
+- **WHEN** no open high findings exist
+- **THEN** next action SHALL be `/specflow.apply`
 
 ### Requirement: Result JSON schema
-All subcommands SHALL output a unified result JSON schema to stdout containing status, action, review results, ledger state, autofix state (if applicable), handoff state, and error information.
+All subcommands SHALL output a unified result JSON schema to stdout matching the apply-side schema, containing status, action, review results, ledger state, autofix state (if applicable), handoff state, and error information.
 
 #### Scenario: Successful review result JSON
 - **WHEN** the review pipeline completes successfully
@@ -242,22 +290,7 @@ All subcommands SHALL output a unified result JSON schema to stdout containing s
 - **WHEN** any pipeline step fails fatally
 - **THEN** the result JSON SHALL contain `status: "error"` and `error` with a description
 
-### Requirement: Ledger library filename parameterization
-The `lib/specflow-ledger.sh` library SHALL provide a `ledger_init` function that allows callers to configure the ledger filename and backup filename. If `ledger_init` is not called, the default filenames (`review-ledger.json` and `review-ledger.json.bak`) SHALL be used for backward compatibility.
-
-#### Scenario: Default filename without ledger_init
-- **WHEN** `ledger_read` is called without a prior `ledger_init` call
-- **THEN** the library SHALL use `review-ledger.json` as the ledger filename and `review-ledger.json.bak` as the backup filename
-
-#### Scenario: Custom filename via ledger_init
-- **WHEN** `ledger_init "review-ledger-design.json"` is called before `ledger_read`
-- **THEN** the library SHALL use `review-ledger-design.json` as the ledger filename and `review-ledger-design.json.bak` as the backup filename
-
-#### Scenario: ledger_init with phase parameter
-- **WHEN** `ledger_init "review-ledger-design.json" "design"` is called
-- **THEN** the library SHALL use the specified filename AND set the default phase to `"design"` for newly created ledgers (via `_empty_ledger`)
-
-#### Scenario: Multiple ledger_init calls
-- **WHEN** `ledger_init` is called multiple times
-- **THEN** the most recent call's values SHALL take effect
+#### Scenario: Fix-review result includes re-review classification
+- **WHEN** the `fix-review` pipeline completes successfully
+- **THEN** the result JSON SHALL include a `rereview_classification` object with `resolved`, `still_open`, and `new_findings` arrays containing finding IDs, enabling the slash command to display the classification table
 


### PR DESCRIPTION
## Summary
- New `bin/specflow-review-design` orchestrator with `review`, `fix-review`, `autofix-loop` subcommands — mirrors apply-side pattern
- New `bin/specflow-design-artifacts` with stateless `next` and `validate` subcommands for artifact dependency loop
- Parameterized `lib/specflow-ledger.sh` via `ledger_init` function for design-side `review-ledger-design.json` (backward-compatible)
- Simplified `specflow.design`, `specflow.review_design`, `specflow.fix_design` slash commands to thin UI wrappers
- New `fix_design_prompt.md` for design autofix-loop

## Issue
Closes https://github.com/skr19930617/specflow/issues/78

## Test plan
- [ ] Verify `specflow-review-apply` backward compatibility with parameterized ledger library
- [ ] Run `/specflow.design` on a new change to confirm artifact loop with `next` invocations
- [ ] Test corrupt ledger recovery via `--reset-ledger` flag
- [ ] Run `specflow-install` and confirm all new files are deployed
- [ ] Verify all AskUserQuestion handoffs remain unchanged in slash commands