### PR TITLE
docs: define core dependency boundary (#91)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,8 @@ The previous Bash implementation is archived at git tag `legacy-v1-final`. Activ
 
 ### This repo owns
 
+> **Target state vs. current support:** The ownership descriptions below reflect the target state — what all runtimes will eventually implement. Currently, only the state machine schema is supported for external runtimes. Full workflow execution (including persistence and review orchestration) is not yet supported for external runtimes until the persistence field split and review transport contract are defined. See the [Core Dependency Boundary](#core-dependency-boundary) section and the [Dependency Decision Heuristic](#dependency-decision-heuristic) for the dependency placement rules that govern borderline components.
+
 - **Workflow core** — the authoritative workflow definition and supporting logic that all runtimes must implement:
   - State machine definition (`src/lib/workflow-machine.ts` and rendered `state-machine.json`)
   - Run-state management (persisted run-state JSON lifecycle)
@@ -85,14 +87,152 @@ Use the following heuristic to classify borderline components:
 
 ### Workflow Core Contract Surface (Inventory)
 
-> **Non-normative inventory.** This section lists the contract surfaces that external runtimes must conform to. It is not the authoritative specification for any of these contracts. Normative contract specification, versioning, and change ownership are deferred to a separate follow-up proposal.
+> **Non-normative inventory.** This section lists the contract surfaces that external runtimes must conform to. It is not the authoritative specification for any of these contracts. Normative contract specification, versioning, and change ownership are deferred to a separate follow-up proposal. Until that proposal lands, the source-location column points to the current normative source where one is identified, while implementation-specific details are called out separately in the support notes.
 
 The workflow core contract comprises:
 
-| Contract Surface | Current Source Location | Description |
-|-----------------|----------------------|-------------|
-| State machine schema | `src/lib/workflow-machine.ts` → `dist/.../state-machine.json` | Phase transitions, allowed events, and terminal states |
-| Run-state JSON structure | `specflow-run` runtime | Persisted run-state shape including phase, history, agents, and metadata |
-| Review protocol interface | `specflow-review-*` orchestrators | Review request/response schema, ledger structure, finding format |
+| Contract Surface | Current Source Location | Description | External Runtime Support |
+|-----------------|----------------------|-------------|--------------------------|
+| State machine schema | `src/lib/workflow-machine.ts` → `dist/.../state-machine.json` | Phase transitions, allowed events, and terminal states | **Supported** |
+| Run-state JSON structure | `src/types/contracts.ts` (`RunState`) | Persisted run-state shape including phase, history, agents, and metadata | **Not yet supported** — `RunState` mixes core and local-adapter fields; field-level split deferred. `specflow-run` remains the current local implementation of this contract surface. |
+| Review protocol interface | `specflow-review-*` orchestrators | Review request/response schema, ledger structure, finding format | **Not yet supported** — canonical transport contract deferred |
 
 **Excluded from core contract:** CLI entry-point contracts (command names, argument signatures, output format) are implementation details of the bundled local reference. External runtimes conform to the workflow core contract only — they are not required to replicate the CLI surface.
+
+## Core Dependency Boundary
+
+This section defines the internal module classification and dependency rules for workflow core. These rules govern which modules may import which within this repository. They are an **internal architectural boundary**, not an external API guarantee — see [Classification vs. Support Status](#classification-vs-support-status) below.
+
+### Module Inventory
+
+Every module in `src/lib/` is classified as exactly one of **core**, **adapter**, or **mixed** (a known violation). This inventory is **authoritative**.
+
+| Module | Classification | Description |
+|--------|---------------|-------------|
+| `workflow-machine.ts` | Core | XState state machine definition |
+| `schemas.ts` | Core | JSON schema validation logic |
+| `json.ts` | Core | Pure JSON parsing utilities |
+| `git.ts` | Adapter | Git CLI wrapper |
+| `fs.ts` | Adapter | Filesystem operations (ensureDir, writeText, copyPath) |
+| `paths.ts` | Adapter | Repository-relative path resolution |
+| `process.ts` | Adapter | Command execution and process control |
+| `glob.ts` | Adapter | Glob pattern matching |
+| `template-files.ts` | Adapter | Template file operations |
+| `project-gitignore.ts` | Adapter | Project .gitignore management |
+| `review-ledger.ts` | Mixed | Ledger state machine logic + file I/O |
+| `review-runtime.ts` | Mixed | Review orchestration + subprocess/FS coupling |
+| `contracts.ts` | Mixed | Contract validation + filesystem access |
+| `proposal-source.ts` | Mixed | Proposal source processing + filesystem access |
+
+### Core Allowed Dependencies
+
+Core modules may import **only** the following (exhaustive allowlist):
+
+- **Other core modules** within `src/lib/`
+- **Core-adjacent modules**: `src/types/contracts.ts` — this module contains type definitions and runtime const objects (e.g., `AssetType`) with no Node.js or adapter imports. Both value and type imports from this module are allowed in core. Note: some types in this module (e.g., `RunState`) currently mix core-contract and local-adapter concerns — these are treated as transitional. The field-level split is deferred to a separate follow-up proposal.
+- **ECMAScript globals and built-in objects**: `JSON`, `Map`, `Set`, `Array`, `Promise`, `Error`, `RegExp`, `Date`, `URL`, `TextEncoder`/`TextDecoder`, `structuredClone`, etc.
+- **Third-party allowlist** (complete): `xstate` — no other third-party packages are permitted in core without updating this list
+
+**Type-only imports** follow the same source restrictions as value imports. Type-only imports from adapter modules, `src/bin/*`, `src/contracts/*`, or DB-specific packages are forbidden — they would leak adapter semantics into core's type surface.
+
+`src/contracts/` modules (which contain build-time asset definitions and may import filesystem utilities) are **not** core-adjacent and remain outside the core boundary allowlist.
+
+### Core Forbidden Dependencies
+
+Core modules must **not** import any of the following:
+
+- **All Node.js built-in modules**: `fs`, `path`, `os`, `child_process`, `net`, `http`, `crypto`, `stream`, `buffer`, `util`, `url` (including `node:` prefixed imports), and any other Node-specific APIs
+- **`src/bin/*`** entry-point modules
+- **Adapter or mixed modules** within `src/lib/`
+- **Slash command surface** (command names, argument shapes)
+- **DB vendor specifics** (SQL drivers, ORM imports)
+
+### Boundary Status Model
+
+This section describes the **target state**. Known violations in mixed modules are tracked in the [Known Boundary Violations](#known-boundary-violations) table below. Existing violations are expected until follow-up refactoring proposals land — they are not treated as present-day errors, but as transitional exceptions to be resolved.
+
+**New boundary violations must not be introduced.** Any new module or import that violates the core dependency rules must be refactored before merging.
+
+### Known Boundary Violations
+
+| Module | Violation | Tracking Reference |
+|--------|-----------|-------------------|
+| `review-ledger.ts` | Imports `fs.ts` (atomicWriteText) and Node.js `fs`/`path` for file I/O | TBD — to be filed before next release |
+| `review-runtime.ts` | Imports `fs.ts`, `git.ts`, `process.ts`, Node.js `fs`/`path`/`os` for subprocess and file operations | TBD — to be filed before next release |
+| `contracts.ts` | Imports `paths.ts` and Node.js `node:fs` (`existsSync`, `readdirSync`, `statSync`) for contract validation against filesystem | TBD — to be filed before next release |
+| `proposal-source.ts` | Imports Node.js `node:fs` (`readFileSync`) for reading proposal source files from disk | TBD — to be filed before next release |
+
+Every tracking reference must use the exact `<repo>#<issue-number>` format when a follow-up issue exists, or `TBD — to be filed before next release` as a placeholder when the issue has not yet been created.
+
+### Mixed-Module Interim Rules
+
+Mixed modules are treated as **adapter-side code** for boundary enforcement purposes:
+
+1. **Core must not import mixed modules** — new core modules may only import other core modules
+2. **Adapter modules and `src/bin/*` may freely import mixed modules**
+3. **External runtimes must not depend on mixed module APIs** — these are unsupported transitional code that will be refactored into separate core and adapter parts in follow-up proposals
+4. **Mixed modules may import both core and adapter modules** — this is the violation being tracked, not a permission to extend
+
+### Default Classification Rule
+
+Any new module added to `src/lib/` is classified as **adapter** unless it satisfies the core dependency rules above and is explicitly added to the core list in the Module Inventory. This prevents accidental expansion of the core surface.
+
+### Inventory Maintenance Rule
+
+The Module Inventory in this document is the authoritative classification. Any PR that adds, removes, or renames a module in `src/lib/` must update the inventory as part of that PR. If the inventory does not list a module, it is treated as adapter by default. Drift between the inventory and the actual `src/lib/` contents is a documentation bug that should be fixed but does not block runtime behavior.
+
+### Dependency Decision Heuristic
+
+Use the following heuristic alongside the [Repository Scope](#repository-scope) ownership rules when deciding whether a dependency belongs in core or an adapter:
+
+> If the dependency is **runtime-agnostic** (works regardless of storage, transport, or execution backend) and uses only allowlisted imports, it belongs in core. If it **requires a specific backend** (filesystem, subprocess, network, database), it belongs in an adapter.
+
+**Borderline Examples:**
+
+| Component | Decision | Rationale |
+|-----------|----------|-----------|
+| State machine transition validator | **Core** | Pure logic operating on schema data, no I/O |
+| Review finding matcher (by ID/title) | **Core** | String comparison logic, no storage dependency |
+| Ledger file writer (atomic write + backup) | **Adapter** | Requires `fs` for file operations |
+| Review subprocess invoker (codex CLI) | **Adapter** | Requires `child_process` for subprocess control |
+| Schema validation against manifest | **Depends** | If validation uses only in-memory data → core; if it reads files → adapter |
+
+When the heuristic does not clearly resolve placement, refer to the Repository Scope ownership rules: if the component is runtime-agnostic and belongs to workflow core concerns, place it in core; if it requires a specific deployment topology or storage backend, place it in the adapter layer.
+
+### Classification vs. Support Status
+
+The core/adapter/mixed module classification is an **internal architectural boundary** that governs which modules may import which within this repository. It is **not** an external API guarantee. Being classified as "core" does not mean a module's exports are stable or supported for direct import by external runtimes.
+
+External runtimes should depend only on the documented contract surfaces (rendered artifacts like `state-machine.json`), not on internal module APIs, regardless of their classification.
+
+### Adapter Contract Categories
+
+Adapter contract categories define the seams where core delegates to runtime-specific implementations:
+
+**Deferred-required** (every runtime will eventually need to implement, but the canonical contract is not yet fully defined):
+
+- **Persistence** — reading/writing run-state JSON. The current `RunState` type in `src/types/contracts.ts` contains both core-contract fields (`current_phase`, `history`, `agents`, `status`) and local-adapter-specific fields (`repo_path`, `worktree_path`, `last_summary_path`). The field-level split between core and local-adapter fields is deferred to a separate follow-up proposal. Until that split is defined, external runtimes cannot reliably determine which fields they must persist.
+- **Review transport** — sending review requests and receiving review responses. The current local adapter uses subprocess-based codex invocation, but this is an implementation detail. The canonical review transport contract (request/response payload schema, lifecycle protocol) is deferred to a follow-up proposal. External runtimes must not depend on the current subprocess-based mechanism.
+
+**Local-runtime-only** (external runtimes use alternative mechanisms):
+
+- **Process lifecycle** — spawning and monitoring external tool processes (e.g., codex CLI, git commands)
+- **Path resolution** — resolving project-relative paths to absolute filesystem locations
+- **Directory layout** — OpenSpec directory traversal (`openspec/changes/*`, `openspec/specs/*`)
+- **CLI surface** — slash command names, argument parsing, and output formatting
+
+Formal TypeScript adapter interfaces and automated enforcement (lint rules, import restrictions) are deferred to follow-up proposals.
+
+### Local Adapter Responsibility
+
+The bundled local reference implementation owns:
+
+- Git/FS access (`git.ts`, `fs.ts`, `paths.ts`)
+- OpenSpec directory traversal
+- CLI argument parsing (`src/bin/*`)
+- Process orchestration (`process.ts`)
+- File-based run-state persistence
+
+### External Runtime Adapter Responsibility
+
+External runtimes own their own storage, transport, and CLI surface while conforming to core contracts only. **Currently supported scope**: external runtimes may consume the state machine schema for phase transition logic. Full workflow execution (including persistence and review orchestration) is not yet supported until the persistence field split and review transport contract are defined in follow-up proposals.

--- a/openspec/changes/core-dependency-boundary/.openspec.yaml
+++ b/openspec/changes/core-dependency-boundary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/openspec/changes/core-dependency-boundary/approval-summary.md
+++ b/openspec/changes/core-dependency-boundary/approval-summary.md
@@ -1,0 +1,74 @@
+# Approval Summary: core-dependency-boundary
+
+**Generated**: 2026-04-11T02:45:16Z
+**Branch**: core-dependency-boundary
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+```
+ docs/architecture.md | 98 ++
+ 1 file changed (this change only — full branch diff includes prior work)
+```
+
+Note: The branch `core-dependency-boundary` was created from `repo-responsibility-nongoals` which had significant prior changes. The only implementation file modified by this change is `docs/architecture.md`.
+
+## Files Touched
+
+- `docs/architecture.md` — added "Core Dependency Boundary" section and amended existing "Repository Scope" and "Workflow Core Contract Surface" sections
+- `openspec/changes/core-dependency-boundary/` — proposal, specs, design, tasks, review ledgers (workflow artifacts)
+
+## Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 1     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 3     |
+
+### Impl Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 3     |
+
+## Proposal Coverage
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | Core Dependency Boundary section exists in docs/architecture.md | Yes | docs/architecture.md |
+| 2 | Authoritative module inventory classifies every src/lib module | Yes | docs/architecture.md |
+| 3 | Core allowed dependencies are exhaustively enumerated | Yes | docs/architecture.md |
+| 4 | Core forbidden dependencies are explicitly listed | Yes | docs/architecture.md |
+| 5 | Known boundary violations are tracked | Yes | docs/architecture.md |
+| 6 | Mixed-module interim rules are defined | Yes | docs/architecture.md |
+| 7 | Adapter contract categories are classified by requirement level | Yes | docs/architecture.md |
+| 8 | Classification vs support status distinction is documented | Yes | docs/architecture.md |
+| 9 | Inventory maintenance rule is defined | Yes | docs/architecture.md |
+| 10 | Contract surface inventory annotated with support status (modified repo-responsibility) | Yes | docs/architecture.md |
+| 11 | Repository Scope distinguishes target state from current support (modified repo-responsibility) | Yes | docs/architecture.md |
+
+**Coverage Rate**: 11/11 (100%)
+
+## Remaining Risks
+
+No deterministic risks (all review findings resolved).
+
+No untested new files (only documentation changed).
+
+No uncovered criteria.
+
+## Human Checkpoints
+
+- [ ] Verify the module inventory table in `docs/architecture.md` lists every file currently in `src/lib/` (run `ls src/lib/` and cross-check)
+- [ ] Confirm the `RunState` field names cited in the Persistence section (`current_phase`, `history`, `agents`, `status`) match `src/types/contracts.ts`
+- [ ] Check that the "Known Boundary Violations" table accurately describes each mixed module's actual imports (compare with `import` statements in each file)
+- [ ] Review the amended "Workflow Core Contract Surface" table to ensure the "External Runtime Support" column is clear to external runtime authors

--- a/openspec/changes/core-dependency-boundary/current-phase.md
+++ b/openspec/changes/core-dependency-boundary/current-phase.md
@@ -1,0 +1,15 @@
+# Current Phase: core-dependency-boundary
+
+- Phase: fix-review
+- Round: 3
+- Status: all_resolved
+- Open High Findings: 0 件
+- Actionable Findings: 0
+- Accepted Risks: none
+- Latest Changes:
+  - 2e56855 fix: sync specflow review and approve contracts
+  - aba69ff docs: define repository responsibility and non-goals (#89)
+  - f829ed5 refactor: decouple specflow entry flow
+  - ef4c5a2 fixes
+  - 5b8b389 refactor: source project gitignore from template
+- Next Recommended Action: /specflow.approve

--- a/openspec/changes/core-dependency-boundary/design.md
+++ b/openspec/changes/core-dependency-boundary/design.md
@@ -1,0 +1,89 @@
+## Context
+
+`docs/architecture.md` already contains a "Repository Scope" section (added in the `repo-responsibility-nongoals` change) that defines ownership boundaries and a non-normative "Workflow Core Contract Surface" inventory. However, there is no explicit rule about what `src/lib/` modules may or may not import — Git/FS/CLI concerns leak into modules that contain reusable core logic (`review-ledger.ts`, `review-runtime.ts`, `contracts.ts`, `proposal-source.ts`).
+
+This change adds a "Core Dependency Boundary" section to `docs/architecture.md` and amends the existing contract surface inventory with external-runtime support status annotations. It is documentation-only — no code changes, no new files beyond the architecture doc update.
+
+The target file is `docs/architecture.md` (currently 99 lines). The new section will be appended below the existing "Workflow Core Contract Surface" subsection and will explicitly cover the boundary status model, the required tracking-reference format, the rule that type-only imports follow the same boundary as value imports, the continued exclusion of `src/contracts/*` from the core-adjacent allowlist, and the dependency decision heuristic that ties borderline import decisions back to the existing "Repository Scope" ownership rules.
+
+Those boundary details are normative requirements, not implications to leave embedded in surrounding prose. The design must therefore call them out as explicit subsection content so the eventual documentation edit cannot omit them accidentally while still appearing to satisfy the larger section-level changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Document the authoritative module classification (core / adapter / mixed) for every `src/lib/` module
+- Define exhaustive dependency allowlist and forbidden list for core modules, including type-only import treatment and the exclusion of `src/contracts/*` from the core-adjacent allowlist
+- Make the target-state versus known-violation status model explicit, including how violations are tracked, that current mixed-module violations are transitional rather than accepted steady state, and that new violations must not be introduced
+- Record known boundary violations with tracking references in the required `<repo>#<issue-number>` or `TBD — to be filed before next release` formats
+- Define adapter contract categories with requirement levels
+- Annotate existing contract surface inventory with external-runtime support status
+- Document the dependency decision heuristic and its linkage back to "Repository Scope"
+- Provide actionable rules for inventory maintenance and mixed-module interim usage
+
+**Non-Goals:**
+- No code refactoring — mixed modules remain as-is
+- No TypeScript interface extraction for adapter contracts
+- No lint rules or automated import enforcement
+- No `RunState` field-level split between core and local-adapter
+- No review transport contract specification
+- No changes to any file other than `docs/architecture.md`
+
+## Decisions
+
+### D1: Single file, appended section
+
+**Decision:** Add the "Core Dependency Boundary" section as a new top-level section in `docs/architecture.md`, placed after the existing "Workflow Core Contract Surface" subsection (which is the last subsection of "Repository Scope").
+
+**Rationale:** The boundary rules are architecturally coupled to the existing scope definitions. A single-file approach keeps all architectural context co-located, avoids cross-file references, and matches the pattern established by the `repo-responsibility-nongoals` change.
+
+**Alternative considered:** Separate `docs/dependency-boundary.md` — rejected because it would fragment architectural context and require cross-references that increase maintenance burden.
+
+### D2: Module inventory as markdown table
+
+**Decision:** Present the module inventory as a markdown table with columns: Module, Classification, Description.
+
+**Rationale:** Tables are scannable, diff-friendly, and easy to maintain. Each row maps directly to a file in `src/lib/`, making exhaustiveness verifiable by inspection.
+
+### D3: Known violations as a separate table
+
+**Decision:** Place the "Known Boundary Violations" table separately from the module inventory, with columns: Module, Violation, Tracking Reference. Tracking Reference entries are normative and must use exactly one of the proposal's required formats: `<repo>#<issue-number>` when a follow-up issue exists, or `TBD — to be filed before next release` when it does not.
+
+**Rationale:** Separating violations from the inventory emphasizes that violations are temporary exceptions to be resolved, not permanent classifications. The tracking reference column provides accountability.
+
+### D4: Amend existing contract surface table in-place
+
+**Decision:** Add a "External Runtime Support" column to the existing "Workflow Core Contract Surface" table rather than creating a parallel section.
+
+**Rationale:** Keeps the contract surface information consolidated. Adding a column to an existing table is a minimal, non-destructive edit that preserves the non-normative label while adding support-status context.
+
+### D5: Inline all rules in a single section
+
+**Decision:** Place the allowed/forbidden dependency rules, type-only import rule, explicit exclusion of `src/contracts/*` from the core-adjacent allowlist, mixed-module interim rules, boundary status model, default classification rule, inventory maintenance rule, dependency decision heuristic, and classification-vs-support-status statement as subsections within the "Core Dependency Boundary" section. The "Core Allowed Dependencies" subsection will explicitly call out that `src/types/contracts.ts` is the only core-adjacent local module, that both value and type imports from it are allowed, and that type-only imports from adapter modules, `src/bin/*`, `src/contracts/*`, or DB-specific packages remain forbidden.
+
+**Rationale:** All rules are interdependent and should be read together. Fragmenting them across multiple top-level sections would force readers to assemble context from scattered locations.
+
+### D6: Explicit status model and heuristic subsections
+
+**Decision:** Add dedicated "Boundary Status Model" and "Dependency Decision Heuristic" subsections. The status model will describe the documented boundary as the target state, explain that mixed modules are tracked as known violations rather than accepted steady-state design, note that existing violations are expected until follow-up refactors land rather than being treated as present-day errors, and state that new violations must not be introduced. The heuristic will give concrete borderline examples and explicitly direct readers back to the "Repository Scope" ownership guidance when deciding whether a dependency belongs in core or an adapter.
+
+**Rationale:** These are normative rules for how contributors interpret and apply the boundary. Giving them explicit subsections prevents the requirements from being lost inside table descriptions or inferred indirectly from the allowlist.
+
+**Alternative considered:** Fold the status and heuristic guidance into surrounding prose near the tables and support-status note — rejected because those requirements are too easy to miss when they are not called out as standalone rules.
+
+### D7: Make boundary-adjacent rules independently traceable
+
+**Decision:** Treat the tracking-reference format, the type-only-import parity rule, the explicit exclusion of `src/contracts/*` from the core-adjacent allowlist, and the Repository Scope linkage for the dependency heuristic as independently called out requirements in both the design and task plan, rather than relying on combined checklist items to imply them.
+
+**Rationale:** These rules are small but normative, and review feedback showed they are easy to miss when bundled into broader section-edit tasks. Making them independently traceable keeps the implementation focused without changing the underlying architecture decisions.
+
+**Alternative considered:** Leave the rules embedded inside the broader allowlist/status/heuristic tasks — rejected because that approach already proved too implicit for review.
+
+## Risks / Trade-offs
+
+**[Manual inventory drift]** The module inventory is manually maintained and may fall out of sync with `src/lib/`. → **Mitigation:** The inventory maintenance rule requires PR-level updates. Drift is explicitly classified as a documentation bug (non-blocking) rather than a validation error, keeping the bar practical. Automated enforcement is deferred to a follow-up proposal.
+
+**[Overly restrictive core boundary]** The strict allowlist (only `xstate` + ECMAScript globals) may block legitimate future core needs. → **Mitigation:** The allowlist is explicitly extensible — adding a new third-party dependency requires only updating the documented allowlist. The proposal makes this the expected path, not a workaround.
+
+**[Mixed-module interim rules are unenforceable]** Without lint rules, the boundary is advisory. Contributors may inadvertently create new core→mixed imports. → **Mitigation:** This is accepted as a known limitation. The documentation establishes the contract that automated enforcement will reference. Code review processes can use the documented rules as a checklist in the interim.
+
+**[RunState type is transitional]** `src/types/contracts.ts` is allowlisted for core imports, but `RunState` contains local-adapter fields. Core modules importing `RunState` may inadvertently depend on local-adapter semantics. → **Mitigation:** The proposal explicitly marks these types as transitional and defers the field-level split. The documentation will note this caveat alongside the core-adjacent module description.

--- a/openspec/changes/core-dependency-boundary/proposal.md
+++ b/openspec/changes/core-dependency-boundary/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+Git CLI calls, filesystem path assumptions, OpenSpec directory layout knowledge, and slash command surface details are currently accessible to — and in some cases leaking into — workflow core modules (`src/lib/workflow-machine.ts`, review orchestration, run-state management). This makes it impractical to reuse the workflow core from a separate server or external runtime repository, because those runtimes would need to carry Git/FS/CLI baggage they cannot satisfy.
+
+Defining an explicit dependency boundary for core eliminates ambiguity about what core may import, guides future contributors away from accidental coupling, and provides a contract that external runtimes can rely on.
+
+## What Changes
+
+- Add a "Core Dependency Boundary" section to `docs/architecture.md` that defines:
+  - **Core surface definition**: the boundary is an explicit module classification within `src/lib/`. Every module in `src/lib/` is classified as exactly one of: **core**, **adapter**, or **mixed** (a known violation). The following inventory is **authoritative** — it lists every `src/lib/` module as of this proposal:
+    - **Core modules**: `workflow-machine.ts`, `schemas.ts`, `json.ts`
+    - **Adapter modules**: `git.ts`, `fs.ts`, `paths.ts`, `process.ts`, `glob.ts`, `template-files.ts`, `project-gitignore.ts`
+    - **Mixed modules (known violations)**: `review-ledger.ts`, `review-runtime.ts`, `contracts.ts`, `proposal-source.ts` — these contain core business logic but currently import adapter modules
+    - **Default classification rule**: any new module added to `src/lib/` is classified as **adapter** unless it satisfies the core dependency rules and is explicitly added to the core list in the documentation. This prevents accidental expansion of the core surface
+    - **Inventory maintenance rule**: the module inventory in `docs/architecture.md` is the authoritative classification. Any PR that adds, removes, or renames a module in `src/lib/` must update the inventory as part of that PR. If the inventory does not list a module, it is treated as adapter by default. Drift between the inventory and the actual `src/lib/` contents is a documentation bug that should be fixed but does not block runtime behavior
+    - **Mixed-module interim rules**: mixed modules are treated as **adapter-side code** for boundary enforcement purposes. Specifically: (1) new core modules must not import mixed modules — they must only import other core modules; (2) adapter modules and `src/bin/*` entry-points may freely import mixed modules; (3) external runtimes must not depend on mixed module APIs — these are unsupported transitional code that will be refactored into separate core and adapter parts in follow-up proposals; (4) mixed modules may import both core and adapter modules (this is the violation being tracked, not a permission to extend)
+  - **Core allowed dependencies** (exhaustive allowlist):
+    - Other core modules within `src/lib/`
+    - **Core-adjacent modules**: `src/types/contracts.ts` — this module contains type definitions and runtime const objects (e.g., `AssetType`) with no Node.js or adapter imports; both value and type imports from this module are allowed in core. Note: some types in this module (e.g., `RunState`) currently mix core-contract and local-adapter concerns — these are treated as transitional and the field-level split is deferred to a separate follow-up proposal, not to this change. `src/contracts/` modules (which contain build-time asset definitions and may import filesystem utilities) are **not** core-adjacent and remain outside the core boundary
+    - ECMAScript globals and built-in objects (`JSON`, `Map`, `Set`, `Array`, `Promise`, `Error`, `RegExp`, `Date`, `URL`, `TextEncoder`/`TextDecoder`, `structuredClone`, etc.)
+    - Third-party allowlist (complete): `xstate` — no other third-party packages are permitted in core without updating this list
+    - Type-only imports follow the same rules as value imports: allowed only from core modules, core-adjacent type modules, and allowlisted third-party libraries — type-only imports from adapter modules, `src/bin/*`, `src/contracts/*`, or DB-specific packages are forbidden
+  - **Core forbidden dependencies** (all Node.js built-in modules and everything not on the allowlist):
+    - All Node.js built-in modules: `fs`, `path`, `os`, `child_process`, `net`, `http`, `crypto`, `stream`, `buffer`, `util`, `url` (the `node:` prefixed imports), and any other Node-specific APIs
+    - `src/bin/*` entry-point modules
+    - Slash command surface (command names, argument shapes)
+    - DB vendor specifics (SQL drivers, ORM imports)
+    - Any `src/lib/` module classified as adapter or mixed
+  - **Boundary status model**: the document describes the **target state**. Known violations in mixed modules are recorded in a "Known Boundary Violations" table with module name, violation description, and tracking reference to follow-up refactoring work. Tracking references use the format `<repo>#<issue-number>` when a GitHub issue exists, or `TBD — to be filed before next release` as a placeholder when the follow-up issue has not yet been created. Violations are expected until refactoring proposals land — they are not treated as errors, but new violations must not be introduced
+- Define **local adapter responsibility**: the bundled local reference implementation owns Git/FS access (`git.ts`, `fs.ts`, `paths.ts`), OpenSpec directory traversal, CLI argument parsing (`src/bin/*`), process orchestration (`process.ts`), and file-based run-state persistence
+- Define **external runtime adapter responsibility**: external runtimes own their own storage, transport, and CLI surface while conforming to core contracts only
+- Add an explicit **"Classification vs. Support Status"** statement: the core/adapter/mixed module classification is an **internal architectural boundary** that governs which modules may import which within this repository. It is **not** an external API guarantee — being classified as "core" does not mean a module's exports are stable or supported for direct import by external runtimes. External runtimes should depend only on the documented contract surfaces (rendered artifacts like `state-machine.json`), not on internal module APIs, regardless of their classification
+- Define **adapter contract categories** that core exposes for adapters to implement, classified by requirement level:
+  - **Deferred-required** (every runtime will eventually need to implement, but canonical contract is not yet fully defined):
+    - **Persistence**: reading/writing run-state JSON. The current `RunState` type contains both core-contract fields (phase, history, agents, status) and local-adapter-specific fields (`repo_path`, `worktree_path`, `last_summary_path`). The field-level split between core and local-adapter fields is deferred entirely to a separate follow-up proposal (not this change). Until that split is defined, persistence is recognized as a required adapter seam but external runtimes cannot reliably determine which fields they must persist
+    - **Review transport**: sending review requests and receiving review responses. The current local adapter uses subprocess-based codex invocation, but this is an implementation detail. The canonical review transport contract (request/response payload schema, lifecycle protocol) is deferred to a follow-up proposal. Until that proposal lands, review transport is documented as a recognized adapter seam without a stable external contract
+  - **Local-runtime-only** (external runtimes use alternative mechanisms):
+    - **Process lifecycle**: spawning and monitoring external tool processes (e.g., codex CLI, git commands)
+    - **Path resolution**: resolving project-relative paths to absolute filesystem locations
+    - **Directory layout**: OpenSpec directory traversal (`openspec/changes/*`, `openspec/specs/*`)
+    - **CLI surface**: slash command names, argument parsing, and output formatting
+  - Note: defining the formal TypeScript interfaces for these categories is explicitly out of scope — this proposal establishes the categories and their requirement levels only; interface definitions are deferred to a follow-up proposal
+- Provide a dependency decision heuristic with concrete examples for borderline cases
+
+## Capabilities
+
+### New Capabilities
+
+- `core-dependency-boundary`: Defines the canonical core surface (which modules are core), what core is allowed and forbidden to depend on, how known violations are tracked, adapter contract categories, and adapter responsibilities for local and external runtimes
+
+### Modified Capabilities
+
+- `repo-responsibility`: Extends the existing Repository Scope section with explicit core dependency rules, linking the boundary decision heuristic to the new dependency boundary definitions
+
+## Impact
+
+- `docs/architecture.md` gains a new "Core Dependency Boundary" section below the existing "Repository Scope" section
+- No code changes — this proposal is documentation-only, establishing the boundary contract that future refactoring and enforcement proposals will reference
+- Mixed modules (`review-ledger.ts`, `review-runtime.ts`, `contracts.ts`, `proposal-source.ts`) are documented as known violations with the expectation of follow-up refactoring
+- External runtime authors gain a conceptual dependency boundary and adapter contract categories. **Supported external-runtime scope**: external runtimes may consume the state machine schema for phase transition logic. Full workflow execution (including persistence and review orchestration) is **not yet supported** for external runtimes until the persistence field split and review transport contract are defined
+- This proposal amends the existing "Workflow Core Contract Surface" section in `docs/architecture.md` to distinguish between **target-state ownership** (what all runtimes will eventually implement, as described in the existing "Repository Scope") and **currently supported external-runtime contracts** (what external runtimes can reliably depend on today). The existing non-normative inventory label is preserved but annotated with support status per surface:
+  - **State machine**: `state-machine.json` schema — **supported for external runtimes** (phase transitions, allowed events, terminal states)
+  - **Persistence**: run-state JSON shape — **not yet supported for external runtimes**. The `RunState` type in `src/types/contracts.ts` is the normative source, but it currently mixes core-contract fields with local-adapter path fields. A separate follow-up proposal will split `RunState` into core and local-adapter field sets, after which persistence will become a supported external-runtime contract
+  - **Review transport**: review request/response protocol — **not yet supported for external runtimes**. Currently embedded in the local adapter's subprocess protocol. The canonical contract is deferred to a follow-up proposal. The existing "Repository Scope" statement that all runtimes implement review orchestration describes the target state, not the current supported scope
+  - Formal TypeScript adapter interfaces are deferred to a follow-up proposal
+- Formal adapter interfaces and automated enforcement (lint rules, import restrictions) are explicitly deferred to follow-up proposals

--- a/openspec/changes/core-dependency-boundary/review-ledger-design.json
+++ b/openspec/changes/core-dependency-boundary/review-ledger-design.json
@@ -1,0 +1,69 @@
+{
+  "feature_id": "core-dependency-boundary",
+  "phase": "design",
+  "current_round": 3,
+  "status": "all_resolved",
+  "max_finding_id": 1,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "title": "Several normative boundary rules are missing from the design and task plan",
+      "detail": "The design/tasks capture the major section and table edits, but they do not explicitly cover multiple rules that the proposal/spec makes normative: a boundary status model subsection explaining target-state vs. known violations and that new violations must not be introduced, the required `<repo>#<issue>` or `TBD` tracking-reference format for the Known Boundary Violations table, and the remaining boundary guidance around type-only imports following the same rules as value imports, `src/contracts/*` remaining outside the core-adjacent allowlist, and the dependency decision heuristic/linkage back to Repository Scope. Add explicit design coverage and tasks for these items so implementation cannot miss required documentation details.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "completeness",
+      "title": "Deferred adapter seams are underspecified in the task plan",
+      "detail": "The proposal makes the persistence and review-transport caveats part of the normative documentation: `src/types/contracts.ts` is core-adjacent but transitional because `RunState` still mixes local-adapter fields, review transport has no stable canonical contract yet, and formal adapter interfaces/enforcement are deferred to follow-up work. The design notes these limits in context/non-goals, but the tasks only say to add category labels and generic responsibility descriptions (`2.1`, `2.2`, `3.1`). That leaves room to implement the section without the specific caveats and exact local/external responsibility breakdown the proposal requires. Add explicit tasks for those deferred-contract statements and for enumerating the concrete local/external responsibilities so the doc cannot satisfy the checklist with only high-level labels.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R1-F01",
+      "notes": "",
+      "resolved_round": 3
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 1,
+      "open": 1,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 2,
+      "open": 1,
+      "new": 0,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1
+      }
+    },
+    {
+      "round": 3,
+      "total": 2,
+      "open": 0,
+      "new": 0,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/core-dependency-boundary/review-ledger-design.json
+++ b/openspec/changes/core-dependency-boundary/review-ledger-design.json
@@ -1,69 +1,69 @@
 {
-  "feature_id": "core-dependency-boundary",
-  "phase": "design",
-  "current_round": 3,
-  "status": "all_resolved",
-  "max_finding_id": 1,
-  "findings": [
-    {
-      "id": "R1-F01",
-      "severity": "high",
-      "category": "completeness",
-      "title": "Several normative boundary rules are missing from the design and task plan",
-      "detail": "The design/tasks capture the major section and table edits, but they do not explicitly cover multiple rules that the proposal/spec makes normative: a boundary status model subsection explaining target-state vs. known violations and that new violations must not be introduced, the required `<repo>#<issue>` or `TBD` tracking-reference format for the Known Boundary Violations table, and the remaining boundary guidance around type-only imports following the same rules as value imports, `src/contracts/*` remaining outside the core-adjacent allowlist, and the dependency decision heuristic/linkage back to Repository Scope. Add explicit design coverage and tasks for these items so implementation cannot miss required documentation details.",
-      "origin_round": 1,
-      "latest_round": 2,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R2-F01",
-      "severity": "medium",
-      "category": "completeness",
-      "title": "Deferred adapter seams are underspecified in the task plan",
-      "detail": "The proposal makes the persistence and review-transport caveats part of the normative documentation: `src/types/contracts.ts` is core-adjacent but transitional because `RunState` still mixes local-adapter fields, review transport has no stable canonical contract yet, and formal adapter interfaces/enforcement are deferred to follow-up work. The design notes these limits in context/non-goals, but the tasks only say to add category labels and generic responsibility descriptions (`2.1`, `2.2`, `3.1`). That leaves room to implement the section without the specific caveats and exact local/external responsibility breakdown the proposal requires. Add explicit tasks for those deferred-contract statements and for enumerating the concrete local/external responsibilities so the doc cannot satisfy the checklist with only high-level labels.",
-      "origin_round": 2,
-      "latest_round": 2,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": "R1-F01",
-      "notes": "",
-      "resolved_round": 3
-    }
-  ],
-  "round_summaries": [
-    {
-      "round": 1,
-      "total": 1,
-      "open": 1,
-      "new": 1,
-      "resolved": 0,
-      "overridden": 0,
-      "by_severity": {
-        "high": 1
-      }
-    },
-    {
-      "round": 2,
-      "total": 2,
-      "open": 1,
-      "new": 0,
-      "resolved": 1,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 1
-      }
-    },
-    {
-      "round": 3,
-      "total": 2,
-      "open": 0,
-      "new": 0,
-      "resolved": 2,
-      "overridden": 0,
-      "by_severity": {}
-    }
-  ]
+	"feature_id": "core-dependency-boundary",
+	"phase": "design",
+	"current_round": 3,
+	"status": "all_resolved",
+	"max_finding_id": 1,
+	"findings": [
+		{
+			"id": "R1-F01",
+			"severity": "high",
+			"category": "completeness",
+			"title": "Several normative boundary rules are missing from the design and task plan",
+			"detail": "The design/tasks capture the major section and table edits, but they do not explicitly cover multiple rules that the proposal/spec makes normative: a boundary status model subsection explaining target-state vs. known violations and that new violations must not be introduced, the required `<repo>#<issue>` or `TBD` tracking-reference format for the Known Boundary Violations table, and the remaining boundary guidance around type-only imports following the same rules as value imports, `src/contracts/*` remaining outside the core-adjacent allowlist, and the dependency decision heuristic/linkage back to Repository Scope. Add explicit design coverage and tasks for these items so implementation cannot miss required documentation details.",
+			"origin_round": 1,
+			"latest_round": 2,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R2-F01",
+			"severity": "medium",
+			"category": "completeness",
+			"title": "Deferred adapter seams are underspecified in the task plan",
+			"detail": "The proposal makes the persistence and review-transport caveats part of the normative documentation: `src/types/contracts.ts` is core-adjacent but transitional because `RunState` still mixes local-adapter fields, review transport has no stable canonical contract yet, and formal adapter interfaces/enforcement are deferred to follow-up work. The design notes these limits in context/non-goals, but the tasks only say to add category labels and generic responsibility descriptions (`2.1`, `2.2`, `3.1`). That leaves room to implement the section without the specific caveats and exact local/external responsibility breakdown the proposal requires. Add explicit tasks for those deferred-contract statements and for enumerating the concrete local/external responsibilities so the doc cannot satisfy the checklist with only high-level labels.",
+			"origin_round": 2,
+			"latest_round": 2,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": "R1-F01",
+			"notes": "",
+			"resolved_round": 3
+		}
+	],
+	"round_summaries": [
+		{
+			"round": 1,
+			"total": 1,
+			"open": 1,
+			"new": 1,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1
+			}
+		},
+		{
+			"round": 2,
+			"total": 2,
+			"open": 1,
+			"new": 0,
+			"resolved": 1,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 1
+			}
+		},
+		{
+			"round": 3,
+			"total": 2,
+			"open": 0,
+			"new": 0,
+			"resolved": 2,
+			"overridden": 0,
+			"by_severity": {}
+		}
+	]
 }

--- a/openspec/changes/core-dependency-boundary/review-ledger-design.json.bak
+++ b/openspec/changes/core-dependency-boundary/review-ledger-design.json.bak
@@ -1,0 +1,59 @@
+{
+  "feature_id": "core-dependency-boundary",
+  "phase": "design",
+  "current_round": 2,
+  "status": "in_progress",
+  "max_finding_id": 1,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "title": "Several normative boundary rules are missing from the design and task plan",
+      "detail": "The design/tasks capture the major section and table edits, but they do not explicitly cover multiple rules that the proposal/spec makes normative: a boundary status model subsection explaining target-state vs. known violations and that new violations must not be introduced, the required `<repo>#<issue>` or `TBD` tracking-reference format for the Known Boundary Violations table, and the remaining boundary guidance around type-only imports following the same rules as value imports, `src/contracts/*` remaining outside the core-adjacent allowlist, and the dependency decision heuristic/linkage back to Repository Scope. Add explicit design coverage and tasks for these items so implementation cannot miss required documentation details.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "completeness",
+      "title": "Deferred adapter seams are underspecified in the task plan",
+      "detail": "The proposal makes the persistence and review-transport caveats part of the normative documentation: `src/types/contracts.ts` is core-adjacent but transitional because `RunState` still mixes local-adapter fields, review transport has no stable canonical contract yet, and formal adapter interfaces/enforcement are deferred to follow-up work. The design notes these limits in context/non-goals, but the tasks only say to add category labels and generic responsibility descriptions (`2.1`, `2.2`, `3.1`). That leaves room to implement the section without the specific caveats and exact local/external responsibility breakdown the proposal requires. Add explicit tasks for those deferred-contract statements and for enumerating the concrete local/external responsibilities so the doc cannot satisfy the checklist with only high-level labels.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "open",
+      "relation": "reframed",
+      "supersedes": "R1-F01",
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 1,
+      "open": 1,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 2,
+      "open": 1,
+      "new": 0,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/core-dependency-boundary/review-ledger-proposal.json
+++ b/openspec/changes/core-dependency-boundary/review-ledger-proposal.json
@@ -1,0 +1,381 @@
+{
+  "feature_id": "core-dependency-boundary",
+  "phase": "proposal",
+  "current_round": 10,
+  "status": "all_resolved",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R9-F01",
+      "severity": "high",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Persistence contract is simultaneously deferred and implied to be designed now",
+      "detail": "The proposal says this is a documentation-only change and repeatedly marks persistence as not yet a stable external-runtime contract, but it also says the design phase of this change will split `RunState` into core and local-adapter fields. At the same time, `src/types/contracts.ts` is fully allowlisted for core even though it currently contains those mixed persistence fields. Designers cannot tell whether they must define the field-level persistence contract in this proposal or only document that it remains unsupported. Fix by choosing one scope: either make the `RunState` split an explicit in-scope deliverable with field-level acceptance criteria, or defer it entirely and mark persistence-related exports in `src/types/contracts.ts` as transitional/non-core until a follow-up proposal defines the split.",
+      "origin_round": 9,
+      "latest_round": 9,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 10
+    },
+    {
+      "id": "R9-F02",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Internal core classification is not cleanly separated from externally supported contracts",
+      "detail": "The proposal classifies modules such as `workflow-machine.ts` as core to enable reuse, but later says external runtimes can reliably depend only on `state-machine.json` today. Without an explicit rule that 'core' is an internal architectural classification and does not by itself mean 'supported external API', the design handoff can overstate what external runtimes may import or depend on. Fix by adding a clear support-status mapping for each core/core-adjacent surface, or an explicit statement that module classification and external support status are separate concepts.",
+      "origin_round": 9,
+      "latest_round": 9,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 10
+    },
+    {
+      "id": "R8-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Required persistence contract remains underspecified",
+      "detail": "The proposal says run-state persistence is a required, currently supported external-runtime contract, but it also defers the key split inside `RunState` between core fields and local-adapter-only fields to the design phase. That leaves the only required adapter contract partially undefined, so design cannot state what external runtimes must persist versus may omit or replace. Either enumerate the normative persistence fields in this proposal, or move persistence into the deferred set until that contract is defined.",
+      "origin_round": 8,
+      "latest_round": 8,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R8-F02",
+      "severity": "medium",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "Known-violation tracking references are not actionable yet",
+      "detail": "The proposal requires a 'Known Boundary Violations' table with a tracking reference for each mixed module, but it does not identify the follow-up proposals/issues those references should point to or define an acceptable placeholder if they do not exist yet. That makes the documentation deliverable incomplete and likely to drift at handoff. Specify the required tracking artifacts now, or explicitly allow a defined placeholder/reference format until the follow-up work is created.",
+      "origin_round": 8,
+      "latest_round": 8,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R6-F02",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Authoritative external-runtime contract is still ambiguous",
+      "detail": "The proposal says external runtimes should rely on the `Workflow Core Contract Surface` inventory as canonical/interim canonical, but the existing section is explicitly non-normative, and the proposal does not explicitly state that this status will change. It also narrows supported external-runtime scope to exclude review orchestration until review transport is defined, while the current `Repository Scope` says all runtimes must implement review orchestration. This leaves design with conflicting sources of truth. Fix by explicitly amending the existing architecture sections so they distinguish target-state ownership from currently supported external-runtime contracts and identify one normative place for the contract surface.",
+      "origin_round": 6,
+      "latest_round": 7,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R7-F01",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "The core-adjacent allowlist misstates `src/types/contracts.ts` as type-only",
+      "detail": "The proposal describes `src/types/contracts.ts` as a pure type module, but the current codebase exports runtime values from it and value-imports them elsewhere. If design or enforcement work treats it as type-only, it will produce the wrong boundary rules. Fix by clarifying that value imports from this module are allowed, or by splitting runtime constants from type-only definitions before using this document as the boundary source of truth.",
+      "origin_round": 7,
+      "latest_round": 7,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R6-F01",
+      "severity": "high",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Boundary scope excludes source trees that current core already depends on",
+      "detail": "The proposal defines the dependency boundary only as a classification of modules under `src/lib/`, but one of the proposed core modules (`schemas.ts`) already depends on `src/types/contracts.ts`, and the current architecture document treats `src/contracts/` as source-of-truth for workflow/build contracts. As written, the allowlist would make the declared core inventory immediately inconsistent while only `mixed` modules are tracked as violations. Fix by explicitly deciding how `src/types/*` and any relevant `src/contracts/*` modules relate to the boundary: include them in the boundary model, allowlist them as core-adjacent dependencies, or reclassify affected `src/lib` modules and record them as violations.",
+      "origin_round": 6,
+      "latest_round": 6,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F01",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Core dependency allowlist is not precise enough to enforce",
+      "detail": "The proposal's main contract is the core boundary, but the allowed/forbidden dependency rules are still ambiguous. It allows 'standard JavaScript built-ins' while only forbidding some Node modules (`fs`/`path`/`os`) and references 'explicitly allowed third-party libraries' without fully enumerating them. That leaves unclear whether other Node built-ins or future package imports are allowed in core, which directly affects portability and any later lint/enforcement design. Fix by making the rule exhaustive: explicitly distinguish ECMAScript globals from Node built-in modules, forbid all non-core local imports unless listed, and enumerate the complete third-party allowlist.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R4-F01",
+      "notes": ""
+    },
+    {
+      "id": "R5-F02",
+      "severity": "medium",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "Authoritative module inventory can drift without a maintenance rule",
+      "detail": "The proposal says the `src/lib/` inventory is 'authoritative' and lists every module 'as of this proposal', but it does not define how that inventory stays valid after adds/removes/renames. The default classification rule only covers new core modules, not whether all `src/lib/` changes must update the documented inventory or what counts as a validation failure when the list drifts. Fix by stating whether the inventory must always be kept in sync for any `src/lib/` change, or by reframing it as a snapshot plus separate normative classification rules.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F03",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Near-term external runtime scope is still underspecified",
+      "detail": "The proposal presents this boundary as a contract external runtimes can rely on, but one of the core adapter seams, review transport, is explicitly deferred and non-canonical. That leaves unclear what external runtimes are actually expected to support before the follow-up proposal lands: full workflow execution, only state persistence/state-machine use, or some temporary local-only review path. Fix by explicitly bounding the supported external-runtime scenarios until the review transport contract is defined.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F01",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Mixed-module handling remains ambiguous",
+      "detail": "The proposal lists several modules as 'mixed' known violations, but it does not define their interim usage rules. It is unclear whether new core code may import mixed modules, whether they should be treated as adapter-side internals, or whether external runtimes must treat them as unsupported transitional code. Add explicit interim rules for mixed modules so the boundary is actionable before follow-up refactors land.",
+      "origin_round": 4,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R3-F01",
+      "notes": ""
+    },
+    {
+      "id": "R4-F02",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Required review transport has no stable contract",
+      "detail": "The proposal says every runtime must implement review transport, but the Impact section also says that transport is not yet a canonical contract and external runtimes should not rely on the current subprocess-based mechanism. That leaves a required adapter boundary undefined enough that design cannot state what external runtimes are expected to implement. Either remove review transport from the required runtime categories in this proposal, or define the minimal canonical request/response/lifecycle contract here.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R3-F01",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Core boundary definition is internally ambiguous",
+      "detail": "The proposal says the boundary is directory/module-based and that core consists of modules in `src/lib/`, but it also lists adapter and mixed modules that appear to live in the same directory. It is also unclear whether the listed core/adapter/mixed modules are exhaustive. That leaves the canonical core surface underdefined, which is the main thing downstream design would need to anchor on. Fix by defining the boundary as an explicit module classification within `src/lib/` and making the current inventory authoritative, or by stating exactly how any unlisted module is classified.",
+      "origin_round": 3,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R2-F02",
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Adapter contracts are too high-level for design handoff",
+      "detail": "The proposal assigns broad responsibilities to local and external adapters, but it does not identify the minimum core-side interfaces needed around persistence, run state, review transport, or process lifecycle. Since vendor-specific storage is forbidden in core, this leaves a key design seam open to interpretation. Fix by naming the required contract categories or explicitly deferring those interface definitions as out of scope.",
+      "origin_round": 1,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F02",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "The claimed external contract surface is still too abstract",
+      "detail": "The impact section says external runtime authors gain a clear contract surface, but formal interfaces are deferred and `contracts.ts` is itself listed as a mixed-module violation. As written, the proposal defines categories but not the authoritative artifact or location external runtimes should depend on. Either identify the interim canonical contract surface in the docs or narrow the claim to a conceptual boundary until follow-up interface work lands.",
+      "origin_round": 2,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Type-only import exception undermines the boundary",
+      "detail": "Allowing core to take type-only imports from any module conflicts with the stated goal of keeping Git/FS/CLI/vendor concerns out of core. Core could still be typed against `src/bin/*`, adapter modules, or DB-specific types, which would leak local-runtime semantics into the core contract. Tighten the rule so forbidden surfaces are also forbidden for type-only imports, or define a narrow shared-types exception that is explicitly boundary-safe.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "Boundary status versus current implementation is undefined",
+      "detail": "The proposal creates a normative core dependency contract while also stating that Git/FS/CLI concerns currently leak into core, but it never says whether the architecture update should describe current state, target state, or target state with known exceptions. That would make the document immediately drift from the codebase and leave validation unable to tell whether a violation is expected. Fix by stating the boundary status model and how existing leaks are recorded or exempted until follow-up refactors land.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "\"Workflow core\" is not scoped precisely enough",
+      "detail": "The draft names example modules and concepts, but it never defines the authoritative surface the boundary governs: which modules count as core, whether the boundary is package-, directory-, or concept-based, and how mixed modules are handled. Designers cannot consistently apply or extend the boundary without that scope. Fix by defining the canonical core surface and clear inclusion/exclusion rules.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 3,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 5,
+      "open": 3,
+      "new": 2,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 1
+      }
+    },
+    {
+      "round": 3,
+      "total": 6,
+      "open": 2,
+      "new": 0,
+      "resolved": 4,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "high": 1
+      }
+    },
+    {
+      "round": 4,
+      "total": 8,
+      "open": 2,
+      "new": 1,
+      "resolved": 6,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "high": 1
+      }
+    },
+    {
+      "round": 5,
+      "total": 11,
+      "open": 3,
+      "new": 2,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 2
+      }
+    },
+    {
+      "round": 6,
+      "total": 13,
+      "open": 2,
+      "new": 2,
+      "resolved": 11,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2
+      }
+    },
+    {
+      "round": 7,
+      "total": 14,
+      "open": 2,
+      "new": 1,
+      "resolved": 12,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      }
+    },
+    {
+      "round": 8,
+      "total": 16,
+      "open": 2,
+      "new": 2,
+      "resolved": 14,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      }
+    },
+    {
+      "round": 9,
+      "total": 18,
+      "open": 2,
+      "new": 2,
+      "resolved": 16,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      }
+    },
+    {
+      "round": 10,
+      "total": 18,
+      "open": 0,
+      "new": 0,
+      "resolved": 18,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/core-dependency-boundary/review-ledger-proposal.json
+++ b/openspec/changes/core-dependency-boundary/review-ledger-proposal.json
@@ -1,381 +1,381 @@
 {
-  "feature_id": "core-dependency-boundary",
-  "phase": "proposal",
-  "current_round": 10,
-  "status": "all_resolved",
-  "max_finding_id": 3,
-  "findings": [
-    {
-      "id": "R9-F01",
-      "severity": "high",
-      "category": "scope",
-      "file": "proposal.md",
-      "title": "Persistence contract is simultaneously deferred and implied to be designed now",
-      "detail": "The proposal says this is a documentation-only change and repeatedly marks persistence as not yet a stable external-runtime contract, but it also says the design phase of this change will split `RunState` into core and local-adapter fields. At the same time, `src/types/contracts.ts` is fully allowlisted for core even though it currently contains those mixed persistence fields. Designers cannot tell whether they must define the field-level persistence contract in this proposal or only document that it remains unsupported. Fix by choosing one scope: either make the `RunState` split an explicit in-scope deliverable with field-level acceptance criteria, or defer it entirely and mark persistence-related exports in `src/types/contracts.ts` as transitional/non-core until a follow-up proposal defines the split.",
-      "origin_round": 9,
-      "latest_round": 9,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": "",
-      "resolved_round": 10
-    },
-    {
-      "id": "R9-F02",
-      "severity": "medium",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Internal core classification is not cleanly separated from externally supported contracts",
-      "detail": "The proposal classifies modules such as `workflow-machine.ts` as core to enable reuse, but later says external runtimes can reliably depend only on `state-machine.json` today. Without an explicit rule that 'core' is an internal architectural classification and does not by itself mean 'supported external API', the design handoff can overstate what external runtimes may import or depend on. Fix by adding a clear support-status mapping for each core/core-adjacent surface, or an explicit statement that module classification and external support status are separate concepts.",
-      "origin_round": 9,
-      "latest_round": 9,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": "",
-      "resolved_round": 10
-    },
-    {
-      "id": "R8-F01",
-      "severity": "high",
-      "category": "completeness",
-      "file": "proposal.md",
-      "title": "Required persistence contract remains underspecified",
-      "detail": "The proposal says run-state persistence is a required, currently supported external-runtime contract, but it also defers the key split inside `RunState` between core fields and local-adapter-only fields to the design phase. That leaves the only required adapter contract partially undefined, so design cannot state what external runtimes must persist versus may omit or replace. Either enumerate the normative persistence fields in this proposal, or move persistence into the deferred set until that contract is defined.",
-      "origin_round": 8,
-      "latest_round": 8,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R8-F02",
-      "severity": "medium",
-      "category": "validation",
-      "file": "proposal.md",
-      "title": "Known-violation tracking references are not actionable yet",
-      "detail": "The proposal requires a 'Known Boundary Violations' table with a tracking reference for each mixed module, but it does not identify the follow-up proposals/issues those references should point to or define an acceptable placeholder if they do not exist yet. That makes the documentation deliverable incomplete and likely to drift at handoff. Specify the required tracking artifacts now, or explicitly allow a defined placeholder/reference format until the follow-up work is created.",
-      "origin_round": 8,
-      "latest_round": 8,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R6-F02",
-      "severity": "high",
-      "category": "consistency",
-      "file": "proposal.md",
-      "title": "Authoritative external-runtime contract is still ambiguous",
-      "detail": "The proposal says external runtimes should rely on the `Workflow Core Contract Surface` inventory as canonical/interim canonical, but the existing section is explicitly non-normative, and the proposal does not explicitly state that this status will change. It also narrows supported external-runtime scope to exclude review orchestration until review transport is defined, while the current `Repository Scope` says all runtimes must implement review orchestration. This leaves design with conflicting sources of truth. Fix by explicitly amending the existing architecture sections so they distinguish target-state ownership from currently supported external-runtime contracts and identify one normative place for the contract surface.",
-      "origin_round": 6,
-      "latest_round": 7,
-      "status": "resolved",
-      "relation": "same",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R7-F01",
-      "severity": "medium",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "The core-adjacent allowlist misstates `src/types/contracts.ts` as type-only",
-      "detail": "The proposal describes `src/types/contracts.ts` as a pure type module, but the current codebase exports runtime values from it and value-imports them elsewhere. If design or enforcement work treats it as type-only, it will produce the wrong boundary rules. Fix by clarifying that value imports from this module are allowed, or by splitting runtime constants from type-only definitions before using this document as the boundary source of truth.",
-      "origin_round": 7,
-      "latest_round": 7,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R6-F01",
-      "severity": "high",
-      "category": "scope",
-      "file": "proposal.md",
-      "title": "Boundary scope excludes source trees that current core already depends on",
-      "detail": "The proposal defines the dependency boundary only as a classification of modules under `src/lib/`, but one of the proposed core modules (`schemas.ts`) already depends on `src/types/contracts.ts`, and the current architecture document treats `src/contracts/` as source-of-truth for workflow/build contracts. As written, the allowlist would make the declared core inventory immediately inconsistent while only `mixed` modules are tracked as violations. Fix by explicitly deciding how `src/types/*` and any relevant `src/contracts/*` modules relate to the boundary: include them in the boundary model, allowlist them as core-adjacent dependencies, or reclassify affected `src/lib` modules and record them as violations.",
-      "origin_round": 6,
-      "latest_round": 6,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R5-F01",
-      "severity": "high",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Core dependency allowlist is not precise enough to enforce",
-      "detail": "The proposal's main contract is the core boundary, but the allowed/forbidden dependency rules are still ambiguous. It allows 'standard JavaScript built-ins' while only forbidding some Node modules (`fs`/`path`/`os`) and references 'explicitly allowed third-party libraries' without fully enumerating them. That leaves unclear whether other Node built-ins or future package imports are allowed in core, which directly affects portability and any later lint/enforcement design. Fix by making the rule exhaustive: explicitly distinguish ECMAScript globals from Node built-in modules, forbid all non-core local imports unless listed, and enumerate the complete third-party allowlist.",
-      "origin_round": 5,
-      "latest_round": 5,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": "R4-F01",
-      "notes": ""
-    },
-    {
-      "id": "R5-F02",
-      "severity": "medium",
-      "category": "validation",
-      "file": "proposal.md",
-      "title": "Authoritative module inventory can drift without a maintenance rule",
-      "detail": "The proposal says the `src/lib/` inventory is 'authoritative' and lists every module 'as of this proposal', but it does not define how that inventory stays valid after adds/removes/renames. The default classification rule only covers new core modules, not whether all `src/lib/` changes must update the documented inventory or what counts as a validation failure when the list drifts. Fix by stating whether the inventory must always be kept in sync for any `src/lib/` change, or by reframing it as a snapshot plus separate normative classification rules.",
-      "origin_round": 5,
-      "latest_round": 5,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R5-F03",
-      "severity": "medium",
-      "category": "completeness",
-      "file": "proposal.md",
-      "title": "Near-term external runtime scope is still underspecified",
-      "detail": "The proposal presents this boundary as a contract external runtimes can rely on, but one of the core adapter seams, review transport, is explicitly deferred and non-canonical. That leaves unclear what external runtimes are actually expected to support before the follow-up proposal lands: full workflow execution, only state persistence/state-machine use, or some temporary local-only review path. Fix by explicitly bounding the supported external-runtime scenarios until the review transport contract is defined.",
-      "origin_round": 5,
-      "latest_round": 5,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R4-F01",
-      "severity": "medium",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Mixed-module handling remains ambiguous",
-      "detail": "The proposal lists several modules as 'mixed' known violations, but it does not define their interim usage rules. It is unclear whether new core code may import mixed modules, whether they should be treated as adapter-side internals, or whether external runtimes must treat them as unsupported transitional code. Add explicit interim rules for mixed modules so the boundary is actionable before follow-up refactors land.",
-      "origin_round": 4,
-      "latest_round": 5,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": "R3-F01",
-      "notes": ""
-    },
-    {
-      "id": "R4-F02",
-      "severity": "high",
-      "category": "consistency",
-      "file": "proposal.md",
-      "title": "Required review transport has no stable contract",
-      "detail": "The proposal says every runtime must implement review transport, but the Impact section also says that transport is not yet a canonical contract and external runtimes should not rely on the current subprocess-based mechanism. That leaves a required adapter boundary undefined enough that design cannot state what external runtimes are expected to implement. Either remove review transport from the required runtime categories in this proposal, or define the minimal canonical request/response/lifecycle contract here.",
-      "origin_round": 4,
-      "latest_round": 4,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R3-F01",
-      "severity": "high",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Core boundary definition is internally ambiguous",
-      "detail": "The proposal says the boundary is directory/module-based and that core consists of modules in `src/lib/`, but it also lists adapter and mixed modules that appear to live in the same directory. It is also unclear whether the listed core/adapter/mixed modules are exhaustive. That leaves the canonical core surface underdefined, which is the main thing downstream design would need to anchor on. Fix by defining the boundary as an explicit module classification within `src/lib/` and making the current inventory authoritative, or by stating exactly how any unlisted module is classified.",
-      "origin_round": 3,
-      "latest_round": 4,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": "R2-F02",
-      "notes": ""
-    },
-    {
-      "id": "R1-F03",
-      "severity": "medium",
-      "category": "completeness",
-      "file": "proposal.md",
-      "title": "Adapter contracts are too high-level for design handoff",
-      "detail": "The proposal assigns broad responsibilities to local and external adapters, but it does not identify the minimum core-side interfaces needed around persistence, run state, review transport, or process lifecycle. Since vendor-specific storage is forbidden in core, this leaves a key design seam open to interpretation. Fix by naming the required contract categories or explicitly deferring those interface definitions as out of scope.",
-      "origin_round": 1,
-      "latest_round": 3,
-      "status": "resolved",
-      "relation": "same",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R2-F02",
-      "severity": "medium",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "The claimed external contract surface is still too abstract",
-      "detail": "The impact section says external runtime authors gain a clear contract surface, but formal interfaces are deferred and `contracts.ts` is itself listed as a mixed-module violation. As written, the proposal defines categories but not the authoritative artifact or location external runtimes should depend on. Either identify the interim canonical contract surface in the docs or narrow the claim to a conceptual boundary until follow-up interface work lands.",
-      "origin_round": 2,
-      "latest_round": 3,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R2-F01",
-      "severity": "high",
-      "category": "consistency",
-      "file": "proposal.md",
-      "title": "Type-only import exception undermines the boundary",
-      "detail": "Allowing core to take type-only imports from any module conflicts with the stated goal of keeping Git/FS/CLI/vendor concerns out of core. Core could still be typed against `src/bin/*`, adapter modules, or DB-specific types, which would leak local-runtime semantics into the core contract. Tighten the rule so forbidden surfaces are also forbidden for type-only imports, or define a narrow shared-types exception that is explicitly boundary-safe.",
-      "origin_round": 2,
-      "latest_round": 2,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F01",
-      "severity": "high",
-      "category": "validation",
-      "file": "proposal.md",
-      "title": "Boundary status versus current implementation is undefined",
-      "detail": "The proposal creates a normative core dependency contract while also stating that Git/FS/CLI concerns currently leak into core, but it never says whether the architecture update should describe current state, target state, or target state with known exceptions. That would make the document immediately drift from the codebase and leave validation unable to tell whether a violation is expected. Fix by stating the boundary status model and how existing leaks are recorded or exempted until follow-up refactors land.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F02",
-      "severity": "high",
-      "category": "scope",
-      "file": "proposal.md",
-      "title": "\"Workflow core\" is not scoped precisely enough",
-      "detail": "The draft names example modules and concepts, but it never defines the authoritative surface the boundary governs: which modules count as core, whether the boundary is package-, directory-, or concept-based, and how mixed modules are handled. Designers cannot consistently apply or extend the boundary without that scope. Fix by defining the canonical core surface and clear inclusion/exclusion rules.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    }
-  ],
-  "round_summaries": [
-    {
-      "round": 1,
-      "total": 3,
-      "open": 3,
-      "new": 3,
-      "resolved": 0,
-      "overridden": 0,
-      "by_severity": {
-        "high": 2,
-        "medium": 1
-      }
-    },
-    {
-      "round": 2,
-      "total": 5,
-      "open": 3,
-      "new": 2,
-      "resolved": 2,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 2,
-        "high": 1
-      }
-    },
-    {
-      "round": 3,
-      "total": 6,
-      "open": 2,
-      "new": 0,
-      "resolved": 4,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 1,
-        "high": 1
-      }
-    },
-    {
-      "round": 4,
-      "total": 8,
-      "open": 2,
-      "new": 1,
-      "resolved": 6,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 1,
-        "high": 1
-      }
-    },
-    {
-      "round": 5,
-      "total": 11,
-      "open": 3,
-      "new": 2,
-      "resolved": 8,
-      "overridden": 0,
-      "by_severity": {
-        "high": 1,
-        "medium": 2
-      }
-    },
-    {
-      "round": 6,
-      "total": 13,
-      "open": 2,
-      "new": 2,
-      "resolved": 11,
-      "overridden": 0,
-      "by_severity": {
-        "high": 2
-      }
-    },
-    {
-      "round": 7,
-      "total": 14,
-      "open": 2,
-      "new": 1,
-      "resolved": 12,
-      "overridden": 0,
-      "by_severity": {
-        "high": 1,
-        "medium": 1
-      }
-    },
-    {
-      "round": 8,
-      "total": 16,
-      "open": 2,
-      "new": 2,
-      "resolved": 14,
-      "overridden": 0,
-      "by_severity": {
-        "high": 1,
-        "medium": 1
-      }
-    },
-    {
-      "round": 9,
-      "total": 18,
-      "open": 2,
-      "new": 2,
-      "resolved": 16,
-      "overridden": 0,
-      "by_severity": {
-        "high": 1,
-        "medium": 1
-      }
-    },
-    {
-      "round": 10,
-      "total": 18,
-      "open": 0,
-      "new": 0,
-      "resolved": 18,
-      "overridden": 0,
-      "by_severity": {}
-    }
-  ]
+	"feature_id": "core-dependency-boundary",
+	"phase": "proposal",
+	"current_round": 10,
+	"status": "all_resolved",
+	"max_finding_id": 3,
+	"findings": [
+		{
+			"id": "R9-F01",
+			"severity": "high",
+			"category": "scope",
+			"file": "proposal.md",
+			"title": "Persistence contract is simultaneously deferred and implied to be designed now",
+			"detail": "The proposal says this is a documentation-only change and repeatedly marks persistence as not yet a stable external-runtime contract, but it also says the design phase of this change will split `RunState` into core and local-adapter fields. At the same time, `src/types/contracts.ts` is fully allowlisted for core even though it currently contains those mixed persistence fields. Designers cannot tell whether they must define the field-level persistence contract in this proposal or only document that it remains unsupported. Fix by choosing one scope: either make the `RunState` split an explicit in-scope deliverable with field-level acceptance criteria, or defer it entirely and mark persistence-related exports in `src/types/contracts.ts` as transitional/non-core until a follow-up proposal defines the split.",
+			"origin_round": 9,
+			"latest_round": 9,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": "",
+			"resolved_round": 10
+		},
+		{
+			"id": "R9-F02",
+			"severity": "medium",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Internal core classification is not cleanly separated from externally supported contracts",
+			"detail": "The proposal classifies modules such as `workflow-machine.ts` as core to enable reuse, but later says external runtimes can reliably depend only on `state-machine.json` today. Without an explicit rule that 'core' is an internal architectural classification and does not by itself mean 'supported external API', the design handoff can overstate what external runtimes may import or depend on. Fix by adding a clear support-status mapping for each core/core-adjacent surface, or an explicit statement that module classification and external support status are separate concepts.",
+			"origin_round": 9,
+			"latest_round": 9,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": "",
+			"resolved_round": 10
+		},
+		{
+			"id": "R8-F01",
+			"severity": "high",
+			"category": "completeness",
+			"file": "proposal.md",
+			"title": "Required persistence contract remains underspecified",
+			"detail": "The proposal says run-state persistence is a required, currently supported external-runtime contract, but it also defers the key split inside `RunState` between core fields and local-adapter-only fields to the design phase. That leaves the only required adapter contract partially undefined, so design cannot state what external runtimes must persist versus may omit or replace. Either enumerate the normative persistence fields in this proposal, or move persistence into the deferred set until that contract is defined.",
+			"origin_round": 8,
+			"latest_round": 8,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R8-F02",
+			"severity": "medium",
+			"category": "validation",
+			"file": "proposal.md",
+			"title": "Known-violation tracking references are not actionable yet",
+			"detail": "The proposal requires a 'Known Boundary Violations' table with a tracking reference for each mixed module, but it does not identify the follow-up proposals/issues those references should point to or define an acceptable placeholder if they do not exist yet. That makes the documentation deliverable incomplete and likely to drift at handoff. Specify the required tracking artifacts now, or explicitly allow a defined placeholder/reference format until the follow-up work is created.",
+			"origin_round": 8,
+			"latest_round": 8,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R6-F02",
+			"severity": "high",
+			"category": "consistency",
+			"file": "proposal.md",
+			"title": "Authoritative external-runtime contract is still ambiguous",
+			"detail": "The proposal says external runtimes should rely on the `Workflow Core Contract Surface` inventory as canonical/interim canonical, but the existing section is explicitly non-normative, and the proposal does not explicitly state that this status will change. It also narrows supported external-runtime scope to exclude review orchestration until review transport is defined, while the current `Repository Scope` says all runtimes must implement review orchestration. This leaves design with conflicting sources of truth. Fix by explicitly amending the existing architecture sections so they distinguish target-state ownership from currently supported external-runtime contracts and identify one normative place for the contract surface.",
+			"origin_round": 6,
+			"latest_round": 7,
+			"status": "resolved",
+			"relation": "same",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R7-F01",
+			"severity": "medium",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "The core-adjacent allowlist misstates `src/types/contracts.ts` as type-only",
+			"detail": "The proposal describes `src/types/contracts.ts` as a pure type module, but the current codebase exports runtime values from it and value-imports them elsewhere. If design or enforcement work treats it as type-only, it will produce the wrong boundary rules. Fix by clarifying that value imports from this module are allowed, or by splitting runtime constants from type-only definitions before using this document as the boundary source of truth.",
+			"origin_round": 7,
+			"latest_round": 7,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R6-F01",
+			"severity": "high",
+			"category": "scope",
+			"file": "proposal.md",
+			"title": "Boundary scope excludes source trees that current core already depends on",
+			"detail": "The proposal defines the dependency boundary only as a classification of modules under `src/lib/`, but one of the proposed core modules (`schemas.ts`) already depends on `src/types/contracts.ts`, and the current architecture document treats `src/contracts/` as source-of-truth for workflow/build contracts. As written, the allowlist would make the declared core inventory immediately inconsistent while only `mixed` modules are tracked as violations. Fix by explicitly deciding how `src/types/*` and any relevant `src/contracts/*` modules relate to the boundary: include them in the boundary model, allowlist them as core-adjacent dependencies, or reclassify affected `src/lib` modules and record them as violations.",
+			"origin_round": 6,
+			"latest_round": 6,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R5-F01",
+			"severity": "high",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Core dependency allowlist is not precise enough to enforce",
+			"detail": "The proposal's main contract is the core boundary, but the allowed/forbidden dependency rules are still ambiguous. It allows 'standard JavaScript built-ins' while only forbidding some Node modules (`fs`/`path`/`os`) and references 'explicitly allowed third-party libraries' without fully enumerating them. That leaves unclear whether other Node built-ins or future package imports are allowed in core, which directly affects portability and any later lint/enforcement design. Fix by making the rule exhaustive: explicitly distinguish ECMAScript globals from Node built-in modules, forbid all non-core local imports unless listed, and enumerate the complete third-party allowlist.",
+			"origin_round": 5,
+			"latest_round": 5,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": "R4-F01",
+			"notes": ""
+		},
+		{
+			"id": "R5-F02",
+			"severity": "medium",
+			"category": "validation",
+			"file": "proposal.md",
+			"title": "Authoritative module inventory can drift without a maintenance rule",
+			"detail": "The proposal says the `src/lib/` inventory is 'authoritative' and lists every module 'as of this proposal', but it does not define how that inventory stays valid after adds/removes/renames. The default classification rule only covers new core modules, not whether all `src/lib/` changes must update the documented inventory or what counts as a validation failure when the list drifts. Fix by stating whether the inventory must always be kept in sync for any `src/lib/` change, or by reframing it as a snapshot plus separate normative classification rules.",
+			"origin_round": 5,
+			"latest_round": 5,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R5-F03",
+			"severity": "medium",
+			"category": "completeness",
+			"file": "proposal.md",
+			"title": "Near-term external runtime scope is still underspecified",
+			"detail": "The proposal presents this boundary as a contract external runtimes can rely on, but one of the core adapter seams, review transport, is explicitly deferred and non-canonical. That leaves unclear what external runtimes are actually expected to support before the follow-up proposal lands: full workflow execution, only state persistence/state-machine use, or some temporary local-only review path. Fix by explicitly bounding the supported external-runtime scenarios until the review transport contract is defined.",
+			"origin_round": 5,
+			"latest_round": 5,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R4-F01",
+			"severity": "medium",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Mixed-module handling remains ambiguous",
+			"detail": "The proposal lists several modules as 'mixed' known violations, but it does not define their interim usage rules. It is unclear whether new core code may import mixed modules, whether they should be treated as adapter-side internals, or whether external runtimes must treat them as unsupported transitional code. Add explicit interim rules for mixed modules so the boundary is actionable before follow-up refactors land.",
+			"origin_round": 4,
+			"latest_round": 5,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": "R3-F01",
+			"notes": ""
+		},
+		{
+			"id": "R4-F02",
+			"severity": "high",
+			"category": "consistency",
+			"file": "proposal.md",
+			"title": "Required review transport has no stable contract",
+			"detail": "The proposal says every runtime must implement review transport, but the Impact section also says that transport is not yet a canonical contract and external runtimes should not rely on the current subprocess-based mechanism. That leaves a required adapter boundary undefined enough that design cannot state what external runtimes are expected to implement. Either remove review transport from the required runtime categories in this proposal, or define the minimal canonical request/response/lifecycle contract here.",
+			"origin_round": 4,
+			"latest_round": 4,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R3-F01",
+			"severity": "high",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Core boundary definition is internally ambiguous",
+			"detail": "The proposal says the boundary is directory/module-based and that core consists of modules in `src/lib/`, but it also lists adapter and mixed modules that appear to live in the same directory. It is also unclear whether the listed core/adapter/mixed modules are exhaustive. That leaves the canonical core surface underdefined, which is the main thing downstream design would need to anchor on. Fix by defining the boundary as an explicit module classification within `src/lib/` and making the current inventory authoritative, or by stating exactly how any unlisted module is classified.",
+			"origin_round": 3,
+			"latest_round": 4,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": "R2-F02",
+			"notes": ""
+		},
+		{
+			"id": "R1-F03",
+			"severity": "medium",
+			"category": "completeness",
+			"file": "proposal.md",
+			"title": "Adapter contracts are too high-level for design handoff",
+			"detail": "The proposal assigns broad responsibilities to local and external adapters, but it does not identify the minimum core-side interfaces needed around persistence, run state, review transport, or process lifecycle. Since vendor-specific storage is forbidden in core, this leaves a key design seam open to interpretation. Fix by naming the required contract categories or explicitly deferring those interface definitions as out of scope.",
+			"origin_round": 1,
+			"latest_round": 3,
+			"status": "resolved",
+			"relation": "same",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R2-F02",
+			"severity": "medium",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "The claimed external contract surface is still too abstract",
+			"detail": "The impact section says external runtime authors gain a clear contract surface, but formal interfaces are deferred and `contracts.ts` is itself listed as a mixed-module violation. As written, the proposal defines categories but not the authoritative artifact or location external runtimes should depend on. Either identify the interim canonical contract surface in the docs or narrow the claim to a conceptual boundary until follow-up interface work lands.",
+			"origin_round": 2,
+			"latest_round": 3,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R2-F01",
+			"severity": "high",
+			"category": "consistency",
+			"file": "proposal.md",
+			"title": "Type-only import exception undermines the boundary",
+			"detail": "Allowing core to take type-only imports from any module conflicts with the stated goal of keeping Git/FS/CLI/vendor concerns out of core. Core could still be typed against `src/bin/*`, adapter modules, or DB-specific types, which would leak local-runtime semantics into the core contract. Tighten the rule so forbidden surfaces are also forbidden for type-only imports, or define a narrow shared-types exception that is explicitly boundary-safe.",
+			"origin_round": 2,
+			"latest_round": 2,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F01",
+			"severity": "high",
+			"category": "validation",
+			"file": "proposal.md",
+			"title": "Boundary status versus current implementation is undefined",
+			"detail": "The proposal creates a normative core dependency contract while also stating that Git/FS/CLI concerns currently leak into core, but it never says whether the architecture update should describe current state, target state, or target state with known exceptions. That would make the document immediately drift from the codebase and leave validation unable to tell whether a violation is expected. Fix by stating the boundary status model and how existing leaks are recorded or exempted until follow-up refactors land.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F02",
+			"severity": "high",
+			"category": "scope",
+			"file": "proposal.md",
+			"title": "\"Workflow core\" is not scoped precisely enough",
+			"detail": "The draft names example modules and concepts, but it never defines the authoritative surface the boundary governs: which modules count as core, whether the boundary is package-, directory-, or concept-based, and how mixed modules are handled. Designers cannot consistently apply or extend the boundary without that scope. Fix by defining the canonical core surface and clear inclusion/exclusion rules.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		}
+	],
+	"round_summaries": [
+		{
+			"round": 1,
+			"total": 3,
+			"open": 3,
+			"new": 3,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"high": 2,
+				"medium": 1
+			}
+		},
+		{
+			"round": 2,
+			"total": 5,
+			"open": 3,
+			"new": 2,
+			"resolved": 2,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 2,
+				"high": 1
+			}
+		},
+		{
+			"round": 3,
+			"total": 6,
+			"open": 2,
+			"new": 0,
+			"resolved": 4,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 1,
+				"high": 1
+			}
+		},
+		{
+			"round": 4,
+			"total": 8,
+			"open": 2,
+			"new": 1,
+			"resolved": 6,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 1,
+				"high": 1
+			}
+		},
+		{
+			"round": 5,
+			"total": 11,
+			"open": 3,
+			"new": 2,
+			"resolved": 8,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1,
+				"medium": 2
+			}
+		},
+		{
+			"round": 6,
+			"total": 13,
+			"open": 2,
+			"new": 2,
+			"resolved": 11,
+			"overridden": 0,
+			"by_severity": {
+				"high": 2
+			}
+		},
+		{
+			"round": 7,
+			"total": 14,
+			"open": 2,
+			"new": 1,
+			"resolved": 12,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1,
+				"medium": 1
+			}
+		},
+		{
+			"round": 8,
+			"total": 16,
+			"open": 2,
+			"new": 2,
+			"resolved": 14,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1,
+				"medium": 1
+			}
+		},
+		{
+			"round": 9,
+			"total": 18,
+			"open": 2,
+			"new": 2,
+			"resolved": 16,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1,
+				"medium": 1
+			}
+		},
+		{
+			"round": 10,
+			"total": 18,
+			"open": 0,
+			"new": 0,
+			"resolved": 18,
+			"overridden": 0,
+			"by_severity": {}
+		}
+	]
 }

--- a/openspec/changes/core-dependency-boundary/review-ledger-proposal.json.bak
+++ b/openspec/changes/core-dependency-boundary/review-ledger-proposal.json.bak
@@ -1,0 +1,370 @@
+{
+  "feature_id": "core-dependency-boundary",
+  "phase": "proposal",
+  "current_round": 9,
+  "status": "has_open_high",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R9-F01",
+      "severity": "high",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Persistence contract is simultaneously deferred and implied to be designed now",
+      "detail": "The proposal says this is a documentation-only change and repeatedly marks persistence as not yet a stable external-runtime contract, but it also says the design phase of this change will split `RunState` into core and local-adapter fields. At the same time, `src/types/contracts.ts` is fully allowlisted for core even though it currently contains those mixed persistence fields. Designers cannot tell whether they must define the field-level persistence contract in this proposal or only document that it remains unsupported. Fix by choosing one scope: either make the `RunState` split an explicit in-scope deliverable with field-level acceptance criteria, or defer it entirely and mark persistence-related exports in `src/types/contracts.ts` as transitional/non-core until a follow-up proposal defines the split.",
+      "origin_round": 9,
+      "latest_round": 9,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R9-F02",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Internal core classification is not cleanly separated from externally supported contracts",
+      "detail": "The proposal classifies modules such as `workflow-machine.ts` as core to enable reuse, but later says external runtimes can reliably depend only on `state-machine.json` today. Without an explicit rule that 'core' is an internal architectural classification and does not by itself mean 'supported external API', the design handoff can overstate what external runtimes may import or depend on. Fix by adding a clear support-status mapping for each core/core-adjacent surface, or an explicit statement that module classification and external support status are separate concepts.",
+      "origin_round": 9,
+      "latest_round": 9,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R8-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Required persistence contract remains underspecified",
+      "detail": "The proposal says run-state persistence is a required, currently supported external-runtime contract, but it also defers the key split inside `RunState` between core fields and local-adapter-only fields to the design phase. That leaves the only required adapter contract partially undefined, so design cannot state what external runtimes must persist versus may omit or replace. Either enumerate the normative persistence fields in this proposal, or move persistence into the deferred set until that contract is defined.",
+      "origin_round": 8,
+      "latest_round": 8,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R8-F02",
+      "severity": "medium",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "Known-violation tracking references are not actionable yet",
+      "detail": "The proposal requires a 'Known Boundary Violations' table with a tracking reference for each mixed module, but it does not identify the follow-up proposals/issues those references should point to or define an acceptable placeholder if they do not exist yet. That makes the documentation deliverable incomplete and likely to drift at handoff. Specify the required tracking artifacts now, or explicitly allow a defined placeholder/reference format until the follow-up work is created.",
+      "origin_round": 8,
+      "latest_round": 8,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R6-F02",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Authoritative external-runtime contract is still ambiguous",
+      "detail": "The proposal says external runtimes should rely on the `Workflow Core Contract Surface` inventory as canonical/interim canonical, but the existing section is explicitly non-normative, and the proposal does not explicitly state that this status will change. It also narrows supported external-runtime scope to exclude review orchestration until review transport is defined, while the current `Repository Scope` says all runtimes must implement review orchestration. This leaves design with conflicting sources of truth. Fix by explicitly amending the existing architecture sections so they distinguish target-state ownership from currently supported external-runtime contracts and identify one normative place for the contract surface.",
+      "origin_round": 6,
+      "latest_round": 7,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R7-F01",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "The core-adjacent allowlist misstates `src/types/contracts.ts` as type-only",
+      "detail": "The proposal describes `src/types/contracts.ts` as a pure type module, but the current codebase exports runtime values from it and value-imports them elsewhere. If design or enforcement work treats it as type-only, it will produce the wrong boundary rules. Fix by clarifying that value imports from this module are allowed, or by splitting runtime constants from type-only definitions before using this document as the boundary source of truth.",
+      "origin_round": 7,
+      "latest_round": 7,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R6-F01",
+      "severity": "high",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Boundary scope excludes source trees that current core already depends on",
+      "detail": "The proposal defines the dependency boundary only as a classification of modules under `src/lib/`, but one of the proposed core modules (`schemas.ts`) already depends on `src/types/contracts.ts`, and the current architecture document treats `src/contracts/` as source-of-truth for workflow/build contracts. As written, the allowlist would make the declared core inventory immediately inconsistent while only `mixed` modules are tracked as violations. Fix by explicitly deciding how `src/types/*` and any relevant `src/contracts/*` modules relate to the boundary: include them in the boundary model, allowlist them as core-adjacent dependencies, or reclassify affected `src/lib` modules and record them as violations.",
+      "origin_round": 6,
+      "latest_round": 6,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F01",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Core dependency allowlist is not precise enough to enforce",
+      "detail": "The proposal's main contract is the core boundary, but the allowed/forbidden dependency rules are still ambiguous. It allows 'standard JavaScript built-ins' while only forbidding some Node modules (`fs`/`path`/`os`) and references 'explicitly allowed third-party libraries' without fully enumerating them. That leaves unclear whether other Node built-ins or future package imports are allowed in core, which directly affects portability and any later lint/enforcement design. Fix by making the rule exhaustive: explicitly distinguish ECMAScript globals from Node built-in modules, forbid all non-core local imports unless listed, and enumerate the complete third-party allowlist.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R4-F01",
+      "notes": ""
+    },
+    {
+      "id": "R5-F02",
+      "severity": "medium",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "Authoritative module inventory can drift without a maintenance rule",
+      "detail": "The proposal says the `src/lib/` inventory is 'authoritative' and lists every module 'as of this proposal', but it does not define how that inventory stays valid after adds/removes/renames. The default classification rule only covers new core modules, not whether all `src/lib/` changes must update the documented inventory or what counts as a validation failure when the list drifts. Fix by stating whether the inventory must always be kept in sync for any `src/lib/` change, or by reframing it as a snapshot plus separate normative classification rules.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F03",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Near-term external runtime scope is still underspecified",
+      "detail": "The proposal presents this boundary as a contract external runtimes can rely on, but one of the core adapter seams, review transport, is explicitly deferred and non-canonical. That leaves unclear what external runtimes are actually expected to support before the follow-up proposal lands: full workflow execution, only state persistence/state-machine use, or some temporary local-only review path. Fix by explicitly bounding the supported external-runtime scenarios until the review transport contract is defined.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F01",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Mixed-module handling remains ambiguous",
+      "detail": "The proposal lists several modules as 'mixed' known violations, but it does not define their interim usage rules. It is unclear whether new core code may import mixed modules, whether they should be treated as adapter-side internals, or whether external runtimes must treat them as unsupported transitional code. Add explicit interim rules for mixed modules so the boundary is actionable before follow-up refactors land.",
+      "origin_round": 4,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R3-F01",
+      "notes": ""
+    },
+    {
+      "id": "R4-F02",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Required review transport has no stable contract",
+      "detail": "The proposal says every runtime must implement review transport, but the Impact section also says that transport is not yet a canonical contract and external runtimes should not rely on the current subprocess-based mechanism. That leaves a required adapter boundary undefined enough that design cannot state what external runtimes are expected to implement. Either remove review transport from the required runtime categories in this proposal, or define the minimal canonical request/response/lifecycle contract here.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R3-F01",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Core boundary definition is internally ambiguous",
+      "detail": "The proposal says the boundary is directory/module-based and that core consists of modules in `src/lib/`, but it also lists adapter and mixed modules that appear to live in the same directory. It is also unclear whether the listed core/adapter/mixed modules are exhaustive. That leaves the canonical core surface underdefined, which is the main thing downstream design would need to anchor on. Fix by defining the boundary as an explicit module classification within `src/lib/` and making the current inventory authoritative, or by stating exactly how any unlisted module is classified.",
+      "origin_round": 3,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R2-F02",
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Adapter contracts are too high-level for design handoff",
+      "detail": "The proposal assigns broad responsibilities to local and external adapters, but it does not identify the minimum core-side interfaces needed around persistence, run state, review transport, or process lifecycle. Since vendor-specific storage is forbidden in core, this leaves a key design seam open to interpretation. Fix by naming the required contract categories or explicitly deferring those interface definitions as out of scope.",
+      "origin_round": 1,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F02",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "The claimed external contract surface is still too abstract",
+      "detail": "The impact section says external runtime authors gain a clear contract surface, but formal interfaces are deferred and `contracts.ts` is itself listed as a mixed-module violation. As written, the proposal defines categories but not the authoritative artifact or location external runtimes should depend on. Either identify the interim canonical contract surface in the docs or narrow the claim to a conceptual boundary until follow-up interface work lands.",
+      "origin_round": 2,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Type-only import exception undermines the boundary",
+      "detail": "Allowing core to take type-only imports from any module conflicts with the stated goal of keeping Git/FS/CLI/vendor concerns out of core. Core could still be typed against `src/bin/*`, adapter modules, or DB-specific types, which would leak local-runtime semantics into the core contract. Tighten the rule so forbidden surfaces are also forbidden for type-only imports, or define a narrow shared-types exception that is explicitly boundary-safe.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "Boundary status versus current implementation is undefined",
+      "detail": "The proposal creates a normative core dependency contract while also stating that Git/FS/CLI concerns currently leak into core, but it never says whether the architecture update should describe current state, target state, or target state with known exceptions. That would make the document immediately drift from the codebase and leave validation unable to tell whether a violation is expected. Fix by stating the boundary status model and how existing leaks are recorded or exempted until follow-up refactors land.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "\"Workflow core\" is not scoped precisely enough",
+      "detail": "The draft names example modules and concepts, but it never defines the authoritative surface the boundary governs: which modules count as core, whether the boundary is package-, directory-, or concept-based, and how mixed modules are handled. Designers cannot consistently apply or extend the boundary without that scope. Fix by defining the canonical core surface and clear inclusion/exclusion rules.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 3,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 5,
+      "open": 3,
+      "new": 2,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 1
+      }
+    },
+    {
+      "round": 3,
+      "total": 6,
+      "open": 2,
+      "new": 0,
+      "resolved": 4,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "high": 1
+      }
+    },
+    {
+      "round": 4,
+      "total": 8,
+      "open": 2,
+      "new": 1,
+      "resolved": 6,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "high": 1
+      }
+    },
+    {
+      "round": 5,
+      "total": 11,
+      "open": 3,
+      "new": 2,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 2
+      }
+    },
+    {
+      "round": 6,
+      "total": 13,
+      "open": 2,
+      "new": 2,
+      "resolved": 11,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2
+      }
+    },
+    {
+      "round": 7,
+      "total": 14,
+      "open": 2,
+      "new": 1,
+      "resolved": 12,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      }
+    },
+    {
+      "round": 8,
+      "total": 16,
+      "open": 2,
+      "new": 2,
+      "resolved": 14,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      }
+    },
+    {
+      "round": 9,
+      "total": 18,
+      "open": 2,
+      "new": 2,
+      "resolved": 16,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/core-dependency-boundary/review-ledger.json
+++ b/openspec/changes/core-dependency-boundary/review-ledger.json
@@ -1,72 +1,72 @@
 {
-  "feature_id": "core-dependency-boundary",
-  "phase": "impl",
-  "current_round": 3,
-  "status": "all_resolved",
-  "max_finding_id": 1,
-  "findings": [
-    {
-      "id": "R1-F01",
-      "severity": "medium",
-      "category": "correctness",
-      "file": "docs/architecture.md",
-      "title": "Persistence contract row still points at the local runtime instead of the documented source of truth",
-      "detail": "The proposal explicitly says the amended \"Workflow Core Contract Surface\" section should clarify that the run-state contract’s normative source is `RunState` in `src/types/contracts.ts`, with external-runtime support deferred because that type still mixes core and local-adapter fields. The updated table still lists `specflow-run` as the source location, which keeps the persistence contract anchored to the bundled local implementation rather than the documented contract surface. Update that row to reference `src/types/contracts.ts` and treat `specflow-run` as the current local implementation, not the contract source.",
-      "origin_round": 1,
-      "latest_round": 2,
-      "status": "resolved",
-      "relation": "same",
-      "supersedes": null,
-      "notes": "",
-      "resolved_round": 3
-    },
-    {
-      "id": "R2-F01",
-      "severity": "medium",
-      "category": "correctness",
-      "file": "docs/architecture.md",
-      "title": "Persistence section uses a non-existent `RunState` field name",
-      "detail": "The persistence bullet says `RunState` contains core-contract fields `phase`, `history`, `agents`, and `status`, but the actual interface in `src/types/contracts.ts` uses `current_phase`, not `phase`. Because this section explicitly cites `RunState` as the current source of truth, the field list should be corrected (or made clearly illustrative) to avoid documenting a contract field that does not exist.",
-      "origin_round": 2,
-      "latest_round": 2,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": "",
-      "resolved_round": 3
-    }
-  ],
-  "round_summaries": [
-    {
-      "round": 1,
-      "total": 1,
-      "open": 1,
-      "new": 1,
-      "resolved": 0,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 1
-      }
-    },
-    {
-      "round": 2,
-      "total": 2,
-      "open": 2,
-      "new": 1,
-      "resolved": 0,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 2
-      }
-    },
-    {
-      "round": 3,
-      "total": 2,
-      "open": 0,
-      "new": 0,
-      "resolved": 2,
-      "overridden": 0,
-      "by_severity": {}
-    }
-  ]
+	"feature_id": "core-dependency-boundary",
+	"phase": "impl",
+	"current_round": 3,
+	"status": "all_resolved",
+	"max_finding_id": 1,
+	"findings": [
+		{
+			"id": "R1-F01",
+			"severity": "medium",
+			"category": "correctness",
+			"file": "docs/architecture.md",
+			"title": "Persistence contract row still points at the local runtime instead of the documented source of truth",
+			"detail": "The proposal explicitly says the amended \"Workflow Core Contract Surface\" section should clarify that the run-state contract’s normative source is `RunState` in `src/types/contracts.ts`, with external-runtime support deferred because that type still mixes core and local-adapter fields. The updated table still lists `specflow-run` as the source location, which keeps the persistence contract anchored to the bundled local implementation rather than the documented contract surface. Update that row to reference `src/types/contracts.ts` and treat `specflow-run` as the current local implementation, not the contract source.",
+			"origin_round": 1,
+			"latest_round": 2,
+			"status": "resolved",
+			"relation": "same",
+			"supersedes": null,
+			"notes": "",
+			"resolved_round": 3
+		},
+		{
+			"id": "R2-F01",
+			"severity": "medium",
+			"category": "correctness",
+			"file": "docs/architecture.md",
+			"title": "Persistence section uses a non-existent `RunState` field name",
+			"detail": "The persistence bullet says `RunState` contains core-contract fields `phase`, `history`, `agents`, and `status`, but the actual interface in `src/types/contracts.ts` uses `current_phase`, not `phase`. Because this section explicitly cites `RunState` as the current source of truth, the field list should be corrected (or made clearly illustrative) to avoid documenting a contract field that does not exist.",
+			"origin_round": 2,
+			"latest_round": 2,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": "",
+			"resolved_round": 3
+		}
+	],
+	"round_summaries": [
+		{
+			"round": 1,
+			"total": 1,
+			"open": 1,
+			"new": 1,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 1
+			}
+		},
+		{
+			"round": 2,
+			"total": 2,
+			"open": 2,
+			"new": 1,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 2
+			}
+		},
+		{
+			"round": 3,
+			"total": 2,
+			"open": 0,
+			"new": 0,
+			"resolved": 2,
+			"overridden": 0,
+			"by_severity": {}
+		}
+	]
 }

--- a/openspec/changes/core-dependency-boundary/review-ledger.json
+++ b/openspec/changes/core-dependency-boundary/review-ledger.json
@@ -1,0 +1,72 @@
+{
+  "feature_id": "core-dependency-boundary",
+  "phase": "impl",
+  "current_round": 3,
+  "status": "all_resolved",
+  "max_finding_id": 1,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "docs/architecture.md",
+      "title": "Persistence contract row still points at the local runtime instead of the documented source of truth",
+      "detail": "The proposal explicitly says the amended \"Workflow Core Contract Surface\" section should clarify that the run-state contract’s normative source is `RunState` in `src/types/contracts.ts`, with external-runtime support deferred because that type still mixes core and local-adapter fields. The updated table still lists `specflow-run` as the source location, which keeps the persistence contract anchored to the bundled local implementation rather than the documented contract surface. Update that row to reference `src/types/contracts.ts` and treat `specflow-run` as the current local implementation, not the contract source.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "docs/architecture.md",
+      "title": "Persistence section uses a non-existent `RunState` field name",
+      "detail": "The persistence bullet says `RunState` contains core-contract fields `phase`, `history`, `agents`, and `status`, but the actual interface in `src/types/contracts.ts` uses `current_phase`, not `phase`. Because this section explicitly cites `RunState` as the current source of truth, the field list should be corrected (or made clearly illustrative) to avoid documenting a contract field that does not exist.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 1,
+      "open": 1,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 2,
+      "open": 2,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 2,
+      "open": 0,
+      "new": 0,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/core-dependency-boundary/review-ledger.json.bak
+++ b/openspec/changes/core-dependency-boundary/review-ledger.json.bak
@@ -1,0 +1,61 @@
+{
+  "feature_id": "core-dependency-boundary",
+  "phase": "impl",
+  "current_round": 2,
+  "status": "in_progress",
+  "max_finding_id": 1,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "docs/architecture.md",
+      "title": "Persistence contract row still points at the local runtime instead of the documented source of truth",
+      "detail": "The proposal explicitly says the amended \"Workflow Core Contract Surface\" section should clarify that the run-state contract’s normative source is `RunState` in `src/types/contracts.ts`, with external-runtime support deferred because that type still mixes core and local-adapter fields. The updated table still lists `specflow-run` as the source location, which keeps the persistence contract anchored to the bundled local implementation rather than the documented contract surface. Update that row to reference `src/types/contracts.ts` and treat `specflow-run` as the current local implementation, not the contract source.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "open",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "docs/architecture.md",
+      "title": "Persistence section uses a non-existent `RunState` field name",
+      "detail": "The persistence bullet says `RunState` contains core-contract fields `phase`, `history`, `agents`, and `status`, but the actual interface in `src/types/contracts.ts` uses `current_phase`, not `phase`. Because this section explicitly cites `RunState` as the current source of truth, the field list should be corrected (or made clearly illustrative) to avoid documenting a contract field that does not exist.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 1,
+      "open": 1,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 2,
+      "open": 2,
+      "new": 1,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/core-dependency-boundary/specs/core-dependency-boundary/spec.md
+++ b/openspec/changes/core-dependency-boundary/specs/core-dependency-boundary/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Core dependency boundary section exists in docs/architecture.md
+The `docs/architecture.md` SHALL contain a "Core Dependency Boundary" section below the existing "Repository Scope" section that defines the internal module classification and dependency rules for workflow core.
+
+#### Scenario: Core Dependency Boundary section is present
+- **WHEN** a contributor reads `docs/architecture.md`
+- **THEN** a "Core Dependency Boundary" section exists containing subsections for module classification, allowed dependencies, forbidden dependencies, boundary status model, and adapter contract categories
+
+### Requirement: Authoritative module inventory classifies every src/lib module
+The "Core Dependency Boundary" section SHALL contain an authoritative inventory that classifies every module in `src/lib/` as exactly one of core, adapter, or mixed.
+
+#### Scenario: Module inventory is exhaustive
+- **WHEN** a contributor checks the module inventory
+- **THEN** every file in `src/lib/` is listed and classified as core, adapter, or mixed
+- **THEN** a default classification rule states that unlisted new modules default to adapter
+
+### Requirement: Core allowed dependencies are exhaustively enumerated
+The section SHALL define an exhaustive allowlist for core module dependencies distinguishing ECMAScript globals from Node.js built-ins.
+
+#### Scenario: Core dependency allowlist is complete
+- **WHEN** a contributor checks the allowed dependencies
+- **THEN** the list includes other core modules, core-adjacent modules (`src/types/contracts.ts`), ECMAScript globals, and a complete third-party allowlist (currently only `xstate`)
+- **THEN** Node.js built-in modules are explicitly forbidden
+
+### Requirement: Core forbidden dependencies are explicitly listed
+The section SHALL enumerate all categories of forbidden dependencies for core modules.
+
+#### Scenario: Forbidden dependencies cover all adapter concerns
+- **WHEN** a contributor checks the forbidden dependencies
+- **THEN** the list includes all Node.js built-in modules, `src/bin/*` entry-points, adapter and mixed modules, slash command surface, and DB vendor specifics
+
+### Requirement: Known boundary violations are tracked
+The section SHALL contain a "Known Boundary Violations" table documenting mixed modules with their violation description and tracking reference.
+
+#### Scenario: Violation table uses defined tracking format
+- **WHEN** a contributor checks the violations table
+- **THEN** each entry has module name, violation description, and tracking reference in `<repo>#<issue>` or `TBD` format
+
+### Requirement: Mixed-module interim rules are defined
+The section SHALL define interim usage rules for mixed modules.
+
+#### Scenario: Mixed-module rules prevent new coupling
+- **WHEN** a contributor writes new core code
+- **THEN** the rules state that core modules must not import mixed modules
+- **THEN** mixed modules are treated as adapter-side code for boundary enforcement
+
+### Requirement: Adapter contract categories are classified by requirement level
+The section SHALL list adapter contract categories with their requirement level (deferred-required vs. local-runtime-only).
+
+#### Scenario: Categories distinguish required from local-only
+- **WHEN** a contributor checks the adapter categories
+- **THEN** persistence and review transport are classified as deferred-required
+- **THEN** process lifecycle, path resolution, directory layout, and CLI surface are classified as local-runtime-only
+
+### Requirement: Classification vs support status distinction is documented
+The section SHALL explicitly state that core module classification is an internal architectural boundary and not an external API guarantee.
+
+#### Scenario: External runtimes directed to contract surfaces
+- **WHEN** an external runtime author reads the section
+- **THEN** the documentation states that external runtimes should depend on documented contract surfaces (rendered artifacts) not internal module APIs
+
+### Requirement: Inventory maintenance rule is defined
+The section SHALL define a rule requiring the module inventory to be updated when `src/lib/` modules are added, removed, or renamed.
+
+#### Scenario: Maintenance rule is actionable
+- **WHEN** a contributor adds a new module to `src/lib/`
+- **THEN** the inventory maintenance rule requires updating the inventory in the same PR

--- a/openspec/changes/core-dependency-boundary/specs/repo-responsibility/spec.md
+++ b/openspec/changes/core-dependency-boundary/specs/repo-responsibility/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Workflow Core Contract Surface inventory annotated with support status
+The existing "Workflow Core Contract Surface" section SHALL be amended to distinguish between target-state ownership and currently supported external-runtime contracts by annotating each contract surface with its support status.
+
+#### Scenario: Contract surfaces have support status annotations
+- **WHEN** a contributor reads the "Workflow Core Contract Surface" section
+- **THEN** state machine is annotated as supported for external runtimes
+- **THEN** persistence (run-state JSON) is annotated as not yet supported for external runtimes
+- **THEN** review transport is annotated as not yet supported for external runtimes
+
+### Requirement: Repository Scope distinguishes target state from current support
+The existing "Repository Scope" section SHALL clarify that the statement about all runtimes implementing review orchestration describes the target state, not the current supported scope for external runtimes.
+
+#### Scenario: Target vs current distinction is explicit
+- **WHEN** a contributor reads the Repository Scope section alongside the Core Dependency Boundary section
+- **THEN** it is clear that review orchestration is a target-state responsibility, not currently supported for external runtimes

--- a/openspec/changes/core-dependency-boundary/tasks.md
+++ b/openspec/changes/core-dependency-boundary/tasks.md
@@ -1,0 +1,32 @@
+## 1. Core Dependency Boundary Section
+
+- [x] 1.1 Add "Core Dependency Boundary" heading after the existing "Workflow Core Contract Surface" subsection in `docs/architecture.md`
+- [x] 1.2 Add the authoritative module inventory table classifying every `src/lib/` module as core, adapter, or mixed
+- [x] 1.3 Add the "Core Allowed Dependencies" subsection with the exhaustive allowlist, explicitly stating that `src/types/contracts.ts` is the only core-adjacent local module and that both value and type imports from it are allowed
+- [x] 1.4 Add an explicit rule that type-only imports follow the same source restrictions as value imports, including that type-only imports from adapter modules, `src/bin/*`, `src/contracts/*`, or DB-specific packages remain forbidden
+- [x] 1.5 Add an explicit note in the allowlist guidance that `src/contracts/*` is not core-adjacent and remains outside the core boundary allowlist
+- [x] 1.6 Add the "Core Forbidden Dependencies" subsection (all Node.js built-ins, `src/bin/*`, adapter/mixed modules, slash command surface, DB vendor specifics)
+- [x] 1.7 Add the "Boundary Status Model" subsection describing the target state versus current mixed-module known violations and clarifying that existing violations are tracked rather than treated as present-day errors
+- [x] 1.8 Add an explicit statement in the status model that new boundary violations must not be introduced
+- [x] 1.9 Add the "Known Boundary Violations" table with module, violation description, and tracking reference columns for `review-ledger.ts`, `review-runtime.ts`, `contracts.ts`, `proposal-source.ts`
+- [x] 1.10 Add explicit table guidance that every tracking reference must use the exact `<repo>#<issue-number>` or `TBD — to be filed before next release` format
+- [x] 1.11 Add the "Mixed-Module Interim Rules" subsection defining the four interim rules
+- [x] 1.12 Add the "Default Classification Rule" and "Inventory Maintenance Rule" subsections
+- [x] 1.13 Add the "Dependency Decision Heuristic" subsection with concrete borderline examples
+- [x] 1.14 Add an explicit sentence tying heuristic-based dependency placement back to the "Repository Scope" ownership model
+- [x] 1.15 Add the "Classification vs. Support Status" statement
+
+## 2. Adapter Contract Categories
+
+- [x] 2.1 Add the "Adapter Contract Categories" subsection with deferred-required (persistence, review transport) and local-runtime-only (process lifecycle, path resolution, directory layout, CLI surface) categories
+- [x] 2.2 Add explicit caveat for persistence: `RunState` in `src/types/contracts.ts` mixes core-contract fields (`phase`, `history`, `agents`, `status`) with local-adapter fields (`repo_path`, `worktree_path`, `last_summary_path`); field-level split deferred to follow-up proposal; external runtimes cannot reliably determine which fields to persist
+- [x] 2.3 Add explicit caveat for review transport: current subprocess-based codex invocation is a local-adapter implementation detail; canonical request/response payload schema and lifecycle protocol deferred to follow-up proposal; external runtimes must not depend on current mechanism
+- [x] 2.4 Add note that formal TypeScript adapter interfaces and automated enforcement are deferred to follow-up proposals
+- [x] 2.5 Add the "Local Adapter Responsibility" description enumerating concrete owned concerns: Git/FS access (`git.ts`, `fs.ts`, `paths.ts`), OpenSpec directory traversal, CLI argument parsing (`src/bin/*`), process orchestration (`process.ts`), file-based run-state persistence
+- [x] 2.6 Add the "External Runtime Adapter Responsibility" description: external runtimes own their own storage, transport, and CLI surface; they conform to core contracts only; currently only state machine schema is supported for external runtimes
+
+## 3. Existing Section Amendments
+
+- [x] 3.1 Add "External Runtime Support" column to the existing "Workflow Core Contract Surface" table with support status annotations per surface
+- [x] 3.2 Add a clarifying note to the "Repository Scope" section distinguishing target-state ownership from currently supported external-runtime scope
+- [x] 3.3 Add an explicit cross-reference from the relevant "Repository Scope" guidance to the new dependency decision heuristic so the Repository Scope section also points readers back to the boundary definitions


### PR DESCRIPTION
## Summary
- Add "Core Dependency Boundary" section to `docs/architecture.md` defining authoritative module classification (core/adapter/mixed) for all `src/lib/` modules
- Define exhaustive dependency allowlist (ECMAScript globals, `xstate`, core-adjacent `src/types/contracts.ts`) and forbidden list (all Node.js built-ins, adapters, `src/bin/*`, DB vendors)
- Document known boundary violations for 4 mixed modules with tracking references
- Add adapter contract categories (deferred-required: persistence, review transport; local-only: process lifecycle, path resolution, directory layout, CLI surface)
- Annotate existing "Workflow Core Contract Surface" table with external runtime support status

## Issue
Closes https://github.com/skr19930617/specflow/issues/91