### PR TITLE
feat: define reusable agent context template and repo setup generator (#104)

### DIFF
--- a/assets/template/CLAUDE.md
+++ b/assets/template/CLAUDE.md
@@ -1,3 +1,4 @@
+<!-- specflow:managed:start -->
 ## Contract Discipline
 
 - Prefer explicit, enforceable contracts over implicit behavior.
@@ -6,3 +7,12 @@
 - Do not add special-case behavior unless it is explicitly part of the contract.
 - If a contract changes, update the corresponding tests in the same change.
 - Contract validation is required, not optional.
+- After making changes, run the repository's defined verification steps for the affected scope.
+- This includes formatting, linting, type checking, tests, and build steps whenever the repository defines them and they are relevant to the change.
+- Do not consider a change complete until the relevant verification steps pass.
+- Prefer repository-defined commands and workflows over ad hoc validation.
+<!-- specflow:managed:end -->
+
+## MANUAL ADDITIONS
+
+<!-- Add project-specific guidance here. Content outside the managed block is preserved by specflow. -->

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/approval-summary.md
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/approval-summary.md
@@ -1,0 +1,113 @@
+# Approval Summary: define-reusable-agent-context-template-and-repo-setup-generator
+
+**Generated**: 2026-04-11T07:30:08Z
+**Branch**: define-reusable-agent-context-template-and-repo-setup-generator
+**Status**: ⚠️ 4 unresolved high (2 design, 2 impl — see notes below)
+
+## What Changed
+
+```
+ assets/template/CLAUDE.md              |   8 +-
+ src/bin/specflow-init.ts               | 173 ++++++++++++++++++++++-------
+ src/contracts/command-bodies.ts        |  27 +++--
+ src/lib/schemas.ts                     |  21 +++-
+ src/tests/generation.test.ts           |   5 +-
+ src/tests/release-distribution.test.ts |   5 +-
+ src/tests/utility-cli.test.ts          | 192 +++++++++++++++++++++++++++++++--
+ src/types/contracts.ts                 |   3 +-
+ 8 files changed, 367 insertions(+), 67 deletions(-)
+```
+
+Additionally, 5 new library modules (untracked, will be staged at commit):
+- `src/lib/profile-schema.ts` (395 lines)
+- `src/lib/agent-context-template.ts` (239 lines)
+- `src/lib/ecosystem-detector.ts` (425 lines)
+- `src/lib/profile-diff.ts` (186 lines)
+- `src/lib/claude-renderer.ts` (379 lines)
+
+## Files Touched
+
+Modified:
+- assets/template/CLAUDE.md
+- src/bin/specflow-init.ts
+- src/contracts/command-bodies.ts
+- src/lib/schemas.ts
+- src/tests/generation.test.ts
+- src/tests/release-distribution.test.ts
+- src/tests/utility-cli.test.ts
+- src/types/contracts.ts
+
+New:
+- src/lib/profile-schema.ts
+- src/lib/agent-context-template.ts
+- src/lib/ecosystem-detector.ts
+- src/lib/profile-diff.ts
+- src/lib/claude-renderer.ts
+
+## Review Loop Summary
+
+### Design Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 2     |
+| Resolved high      | 0     |
+| Unresolved high    | 2     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+Note: Design findings (five-layer core model, migration flow) were addressed in design.md/tasks.md updates by the auto-fix loop, but ledger was not updated due to Codex API issues.
+
+### Impl Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 2     |
+| Resolved high      | 0     |
+| Unresolved high    | 2     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+Note: Impl F1 (profile read error handling) was fixed — now calls `die()` instead of logging a warning. F2 (new modules not in diff) refers to untracked files that will be included in the commit.
+
+## Proposal Coverage
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | Context layering model defines five distinct layers with ownership and conflict resolution | Yes | src/lib/agent-context-template.ts |
+| 2 | Profile schema defines a closed, versioned JSON contract | Yes | src/lib/profile-schema.ts, src/lib/schemas.ts, src/types/contracts.ts |
+| 3 | Surface architecture separates core model from surface-specific adapters | Yes | src/lib/agent-context-template.ts, src/lib/claude-renderer.ts |
+| 4 | CLAUDE.md uses marker-based managed/unmanaged boundary | Yes | src/lib/claude-renderer.ts, assets/template/CLAUDE.md |
+| 5 | Profile validation is enforced at every read entry point | Yes | src/lib/profile-schema.ts, src/bin/specflow-init.ts |
+| 6 | Setup command analyzes repository and generates structured profile | Yes | src/lib/ecosystem-detector.ts, src/contracts/command-bodies.ts |
+| 7 | Setup rerun performs deterministic diff-and-resolve | Yes | src/lib/profile-diff.ts, src/contracts/command-bodies.ts |
+| 8 | Setup detects out-of-scope repositories and aborts | Yes | src/lib/ecosystem-detector.ts |
+| 9 | Setup owns profile schema migration | Yes | src/lib/profile-schema.ts |
+| 10 | specflow-init --update triggers adapter rendering when profile exists | Yes | src/bin/specflow-init.ts |
+| 11 | specflow-init --update skips rendering when no profile exists | Yes | src/bin/specflow-init.ts |
+
+**Coverage Rate**: 11/11 (100%)
+
+## Remaining Risks
+
+1. **From Design Ledger (unresolved):**
+   - R1-F01: Five-layer core model not mapped to implementation artifact (severity: high) — *Addressed: `agent-context-template.ts` created*
+   - R1-F02: Profile migration flow conflicts with validate-on-read design (severity: high) — *Addressed: `loadProfileForSetup()` and `readProfileStrict()` implemented*
+   - R1-F03: Legacy CLAUDE.md confirmation flow not designed through write paths (severity: medium) — *Addressed: renderer returns `RenderResult` with `writeDisposition`*
+
+2. **From Impl Ledger (unresolved):**
+   - R1-F01: Invalid profile reads downgraded to warnings (severity: high) — *Fixed: now calls `die()`*
+   - R1-F02: New modules not in reviewed diff (severity: high) — *Will be staged at commit*
+   - R1-F03: No tests for new profile-driven update behavior (severity: medium) — *3 new tests added by autofix*
+   - R1-F04: Repository CLAUDE.md rewritten outside migration contract (severity: medium) — *Template correctly updated; repo CLAUDE.md unchanged*
+
+3. **Untested new files:**
+   - ⚠️ New file not mentioned in review: src/lib/agent-context-template.ts
+   - ⚠️ New file not mentioned in review: src/lib/ecosystem-detector.ts
+   - ⚠️ New file not mentioned in review: src/lib/profile-diff.ts
+
+## Human Checkpoints
+
+- [ ] Verify `src/lib/ecosystem-detector.ts` correctly detects this repository's ecosystem (TypeScript/npm)
+- [ ] Run `specflow.setup` on a test repository to validate the full flow (detect → profile → render)
+- [ ] Confirm legacy CLAUDE.md migration preserves all existing unmanaged content when markers are missing
+- [ ] Verify `specflow-init --update` aborts cleanly when profile has a newer schemaVersion
+- [ ] Check that `.specflow/profile.json` is not accidentally gitignored in initialized projects

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/current-phase.md
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/current-phase.md
@@ -1,0 +1,15 @@
+# Current Phase: define-reusable-agent-context-template-and-repo-setup-generator
+
+- Phase: impl-review
+- Round: 1
+- Status: has_open_high
+- Open High Findings: 2 件 — "Invalid profile reads are downgraded to warnings instead of aborting", "The diff references new profile/renderer modules but does not actually ship them"
+- Actionable Findings: 4
+- Accepted Risks: none
+- Latest Changes:
+  - 0dfc9f1 update package-lock metadata
+  - 717100f fix ci formatting drift
+  - 838d034 align specflow with openspec spec phase
+  - 5a7a2ca fix: format review ledger JSON files for biome
+  - cc0f6e7 docs: define core dependency boundary (#91)
+- Next Recommended Action: /specflow.fix_apply

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/design.md
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/design.md
@@ -1,0 +1,190 @@
+## Context
+
+specflow の `CLAUDE.md` template は Contract Discipline を含む project guideline として機能するが、agent context の層が分離されていない。現在の setup コマンド（`specflow.setup`）は CLAUDE.md の対話的穴埋めを行うだけで、構造化された profile データを持たない。
+
+現在の構造:
+- `assets/template/CLAUDE.md` — 静的テキスト（Contract Discipline のみ）
+- `src/contracts/templates.ts` — `TemplateAssetContract` で template を宣言
+- `src/contracts/command-bodies.ts` — `specflow.setup` の command body（対話ステップ 5つ）
+- `src/bin/specflow-init.ts` — template 更新と `--update` フローを提供
+- `src/lib/schemas.ts` — 各種 runtime schema validator（profile schema は未定義）
+- `src/lib/template-files.ts` — dotfile aliasing（packaging 用）
+
+制約:
+- Contract-driven architecture に従う（新しいアーティファクトは contract として宣言）
+- 既存の `specflow-init` / `specflow-install` フローを大きく変更しない
+- `src/lib/schemas.ts` の既存バリデーションパターンに揃える
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface-neutral な context layering model と adapter-facing core contract を実装可能な形で設計する
+- `.specflow/profile.json` の生成・version-aware load・検証・diffing ロジックを `src/lib/` に追加する
+- Claude adapter（CLAUDE.md renderer）を managed/unmanaged マーカーベースで実装し、legacy migration は caller-confirmed write にする
+- `specflow.setup` command body をエコシステム検出 → profile 生成フローに書き換える
+- 既存の template contract / install plan に最小限の変更で統合する
+
+**Non-Goals:**
+- Monorepo / polyglot 対応
+- Claude 以外の surface adapter 実装（設計上の拡張ポイントは設ける）
+- `specflow-init` / `specflow-install` の大規模リファクタ
+- 非対話（non-TTY）モードの実装（v1 は対話専用）
+
+## Decisions
+
+### D1: Profile schema を `src/lib/schemas.ts` に追加する
+
+**選択:** 既存の `schemas.ts` にある `validateSchemaValue()` パターンで profile validator を実装する。
+
+**理由:** 他の runtime schema（`run-state`, `review-*-result` 等）と同じ検証パターンを使うことで、コードの一貫性を保ち、新しい依存を追加しない。JSON Schema ライブラリ（ajv 等）を導入する選択肢もあったが、既存パターンに合わせる方が保守コストが低い。
+
+**代替案:** Zod や ajv による外部 schema validation → 新規依存が増え、既存パターンから逸脱する。
+
+### D2: Ecosystem 検出ロジックを `src/lib/ecosystem-detector.ts` として新規追加する
+
+**選択:** 新しいモジュール `src/lib/ecosystem-detector.ts` を作成し、proposal で定義された検出マトリクスを実装する。
+
+**理由:** `src/contracts/command-bodies.ts` の setup body はコマンドの「何をすべきか」を記述する場所であり、検出ロジックの実装場所ではない。既存の `specflow-analyze` CLI（`src/bin/specflow-analyze.ts`）が類似の解析を行っているが、その出力形式は profile schema と一致しない。新しいモジュールとして分離し、setup command body から呼び出す形にする。
+
+**代替案:** `specflow-analyze` を拡張する → 出力形式の互換性維持が複雑になり、既存ユーザーへの影響が大きい。
+
+### D2a: Five-layer core contract を `src/lib/agent-context-template.ts` として新規追加する
+
+**選択:** `src/lib/agent-context-template.ts` を surface-neutral core artifact として追加し、5 layer の canonical definition をここに集約する。この module 自体を新しい `agent-context-template` capability の実装契約とし、adapter や runtime injector はこの export surface を import して利用する。module は `AgentContextLayerId`、各 layer の ownership / persistence metadata、namespace identifier、precedence utility（Layer 1 > Layer 3 > Layer 2 > Layer 4 > Layer 5）、および adapter-facing `AgentContextTemplateInput` / `ResolvedAgentContextEnvelope` interface を export する。Claude renderer を含む各 surface adapter と runtime injector はこの interface に依存し、layer rule を独自実装しない。
+
+v1 の layer-to-artifact mapping は次で固定する:
+- Layer 1 (`global-invariants`) は `agent-context-template.ts` 内の immutable core definition として保持する
+- Layer 2 (`project-profile`) は `ProfileSchema` として `.specflow/profile.json` から読み込む
+- Layer 3 (`phase-contract`) は `src/contracts/command-bodies.ts` など command contract 側が `AgentContextTemplateInput.phaseContract` に供給する
+- Layer 4 (`runtime-task-instance`) は run-state / 一時ファイルの payload を `AgentContextTemplateInput.runtimeTask` として供給する
+- Layer 5 (`evidence-context`) は review/apply runtime の payload を `AgentContextTemplateInput.evidenceContext` として供給する
+- `resolveAgentContextEnvelope()` が namespace separation と precedence rule を適用した canonical envelope を返し、surface adapter はそこから必要な layer だけを投影する
+- `ResolvedAgentContextEnvelope` は常に 5 layer すべての namespace を保持する。v1 の Claude adapter が markdown 化するのは Layer 1-2 だけだが、Layer 3-5 も core contract 上は first-class input として確定し、将来 surface ごとに再定義しない
+
+**理由:** proposal の `agent-context-template` capability を implementation artifact に落とすには、特定 surface から独立した core module が必要。これにより Layer 3-5 を v1 で CLAUDE.md に直接 serialize しなくても、namespace separation と conflict priority をこの変更で formalize できる。将来 Cursor などの新 surface を追加しても core contract を再定義せずに済む。
+
+**代替案:** layer 定義を Claude renderer 内に埋め込む → future surface ごとに precedence / namespace rule が重複し、core capability が不完全になる。
+
+### D3: Claude renderer を `src/lib/claude-renderer.ts` として新規追加する
+
+**選択:** profile.json → CLAUDE.md の rendering ロジックを独立モジュールとして実装する。マーカーベースの managed/unmanaged パーサー、profile → markdown マッパー、`agent-context-template.ts` の adapter-facing interface を入力とする render planner を含む。v1 の Claude adapter は `ResolvedAgentContextEnvelope` から Layer 1-2 を markdown 化し、Layer 3-5 は同じ core contract を通じて既存の command prompt / run-state 注入経路で消費する。
+
+**理由:** Adapter pattern の core/adapter 境界を明確にする。将来の surface adapter 追加時に renderer interface を参照できるようにする。rendering ロジックは command body に埋め込まず、reusable なモジュールとして切り出す。
+
+### D4: Template contract に `template-claude-md-v2` を追加し、既存 `template-claude-md` を置き換える
+
+**選択:** 新しい template contract を追加する。v2 template には managed マーカーと profile 参照 slot を含む。`specflow-init` は v2 template を使用する。
+
+**理由:** 既存の `assets/template/CLAUDE.md` は Contract Discipline のみのフラットテキスト。マーカー付きの新しい template が必要。contract ID を変えることで、install plan の asset mapping が明確になる。
+
+**代替案:** 既存 contract を in-place 更新する → migration 時の差分検出が曖昧になる。
+
+### D5: Setup command body を全面書き換えする
+
+**選択:** `src/contracts/command-bodies.ts` の `specflow.setup` エントリを、エコシステム検出 → profile 生成 → adapter rendering のフローに書き換える。
+
+**理由:** 既存の 5 ステップ（Analyze → Tech Stack 確認 → Commands 確認 → Code Style 確認 → CLAUDE.md 更新）は CLAUDE.md 直接編集前提であり、profile 分離アーキテクチャと互換性がない。新しいフローは: Scope 判定 → Ecosystem 検出 → Profile raw load / migration / diff resolve → Schema validation → Adapter render plan → caller-confirmed write。
+
+### D6: `.specflow/profile.json` を `.gitignore` から除外する
+
+**選択:** `src/lib/project-gitignore.ts` の gitignore 生成ロジックを確認し、`.specflow/profile.json` が ignore されないことを保証する。既存の `.specflow/config.env` と `.specflow/runs/` は引き続き ignore する。
+
+**理由:** Profile はチーム共有の committed artifact。config.env（ローカル設定）や runs/（揮発性）とは性質が異なる。
+
+### D7: Profile validation を全読み取りエントリポイントに適用する
+
+**選択:** `src/lib/schemas.ts` に追加する profile validator を、setup rerun、`specflow-init --update`、Claude renderer の全てで共有する。全 entrypoint は「その entrypoint が実際に消費する current schema object」に対して validation を実行し、invalid profile はどのエントリポイントでも処理を中断する。version 判定のための最小 `schemaVersion` sniff は validation 前に許容する。setup では raw payload 全体を current schema で即 validate するのではなく、sniff/migration 後の current object を validate 対象にする。
+
+**理由:** Profile は複数のコマンドから読み取られる shared artifact。validation が一箇所でも欠けると、invalid な profile から CLAUDE.md が生成されるリスクがある。
+
+### D7a: setup は version-aware loader、その他 reader は strict loader を使い分ける
+
+**選択:** `src/lib/profile-schema.ts` は 2 つの load path を持つ。`loadProfileForSetup()` は raw JSON read → 最小 object guard → `schemaVersion` sniff → current より古ければ migrate → current schema validate の順で処理する。`readProfileStrict()` は raw JSON read → 最小 object guard → `schemaVersion` sniff → older/newer mismatch なら remediation 付きで strict-abort → current schema validate の順で処理し、`specflow-init --update`、renderer、将来の非-setup reader で共有する。validate-on-read の例外はこの `schemaVersion` sniff と setup migration 前の最小 object guard だけで、setup も migration 後の current object には必ず validation を通す。
+
+**理由:** proposal の「全読み取り元で validation」を維持しつつ、setup にだけ migration responsibility を持たせるため。古い profile を current-schema validation 前に救済できる一方、通常 reader は version mismatch を strict abort して template/profile drift を隠さない。
+
+**代替案:** 全 reader で自動 migration を行う → shared artifact が暗黙に書き換わり、`specflow-init --update` と renderer の責務境界が曖昧になる。
+
+### D7b: Legacy `CLAUDE.md` migration の確認は caller が所有する
+
+**選択:** `src/lib/claude-renderer.ts` は file write を行わず、`RenderResult` を返す pure module にする。result は `nextContent` に加えて `warning`、`diffPreview`、`writeDisposition`（`safe-write` / `confirmation-required` / `abort`）を持ち、marker-less `CLAUDE.md` では `legacy-migration` + `confirmation-required` result を返す。`specflow.setup` と `src/bin/specflow-init.ts` は renderer が返した warning / diffPreview をそのまま表示し、ユーザーが accept した場合のみ `CLAUDE.md` を書き換える。reject 時はファイルを変更しない。
+
+**理由:** setup と `--update` はどちらも profile/template 変更後に自動 render へ進むため、confirmation を明示的に flow に組み込まないと silent rewrite が起こりうる。diff 生成は renderer に集中させつつ、実際の write decision は対話フロー側に残すのが責務分離として最も明確。
+
+**代替案:** renderer が直接書き込む → legacy migration の warning / diff / confirmation 要件を満たせない。
+
+### D7c: `CLAUDE.md` の write path は renderer disposition を必ず尊重する
+
+**選択:** `specflow.setup` と `specflow-init --update` は renderer の `writeDisposition` を見て分岐する。`safe-write` のみ自動で書き込み可能、`confirmation-required` は warning + diff を表示して明示 accept/reject を得た場合のみ書き込み、`abort` は write せず終了する。reject、または confirmation を得られないケースでは file write にフォールバックしない。caller は renderer result を解釈するが、migration diff の生成規則自体は renderer 側に集中させる。
+
+**理由:** legacy migration の確認要件は renderer 実装だけでは完結せず、実際の write path に適用されて初めて silent rewrite リスクを除去できる。setup と `--update` の両方で同じ gate を使うことで、profile 更新起点・template 更新起点のどちらでも動作が一致する。
+
+**代替案:** setup だけ confirmation を持ち `--update` は自動書き込みする → template 更新時に手動編集済み `CLAUDE.md` を破壊するリスクが残る。
+
+## File Change Plan
+
+### New files
+
+| File | Responsibility |
+|------|----------------|
+| `src/lib/profile-schema.ts` | Profile TypeScript 型定義、schema version 定数、version-aware / strict load path、profile 読み書きユーティリティ |
+| `src/lib/agent-context-template.ts` | Five-layer core contract（layer 定義、namespace、precedence、adapter-facing interface、resolved envelope helper） |
+| `src/lib/ecosystem-detector.ts` | エコシステム検出ロジック（proposal の検出マトリクス実装） |
+| `src/lib/claude-renderer.ts` | Profile → CLAUDE.md render planning（マーカーベース managed/unmanaged、warning/diff/`writeDisposition` を返す） |
+| `src/lib/profile-diff.ts` | Profile の field-level diff と対話的 resolve ロジック |
+| `assets/template/CLAUDE.md` | v2 template（managed マーカー + profile 参照 slot）— 既存ファイルを上書き |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/lib/schemas.ts` | `profile` schema validator の追加 |
+| `src/contracts/templates.ts` | `template-claude-md` contract の sourcePath 更新（v2 template を参照） |
+| `src/contracts/command-bodies.ts` | `specflow.setup` の全 sections を書き換え（setup-only migration、renderer warning/diff の表示、render disposition handling、legacy write confirmation を含む） |
+| `src/bin/specflow-init.ts` | `--update` フローを strict profile read + renderer warning/diff の表示 + render disposition handling + legacy write confirmation に更新 |
+| `src/lib/project-gitignore.ts` | `.specflow/profile.json` が ignore されないことを確認（必要に応じて除外ルール追加） |
+
+### Unchanged files
+
+| File | Reason |
+|------|--------|
+| `src/contracts/commands.ts` | setup command の contract メタデータ（id, description）は変更不要 |
+| `src/contracts/install.ts` | install plan は template contract 参照で間接的に更新される |
+| `src/lib/template-files.ts` | 新規 dotfile alias は不要（profile.json は template ではない） |
+
+## Risks / Trade-offs
+
+### [Risk] Setup command body が大きくなりすぎる
+→ **Mitigation:** 検出・validation・rendering ロジックを `src/lib/` に分離し、command body はフロー制御のみを記述する。
+
+### [Risk] 既存 CLAUDE.md カスタマイズの破損
+→ **Mitigation:** Legacy migration は非破壊（マーカーなしの場合は既存全体を unmanaged として保全）。renderer は warning と diffPreview を返し、setup / `specflow-init --update` がユーザー確認を得るまで write しない。マーカー異常時は render を中断する。
+
+### [Risk] Profile schema の将来的な拡張が困難
+→ **Mitigation:** `schemaVersion` による monotonic versioning。`commands` と `directories` は closed object で拡張は version bump が必要だが、top-level の optional array フィールドは追加しやすい構造。
+
+### [Risk] setup 用 migration path と strict reader の挙動が乖離する
+→ **Mitigation:** version sniff / migrate / validate の順序を `profile-schema.ts` に集約し、setup は `loadProfileForSetup()`、その他 reader は `readProfileStrict()` を使う。古い profile の rerun と older/newer version mismatch をテストで固定する。
+
+### [Risk] `specflow-analyze` との機能重複
+→ **Mitigation:** `ecosystem-detector.ts` は profile 生成に特化した軽量モジュール。`specflow-analyze` は汎用解析ツールとして残し、setup は ecosystem-detector を使う。将来的に specflow-analyze が ecosystem-detector を内部利用する統合は可能。
+
+### [Trade-off] 非対話モードの欠如
+v1 は対話専用。CI/CD や自動化環境では setup を実行できない。ただし profile.json はコミットされる shared artifact なので、チームの誰かが一度 setup を実行すれば他のメンバーは git pull で取得できる。
+
+## Migration Plan
+
+1. **Core contract 追加:** `src/lib/agent-context-template.ts` で 5 layer / namespace / precedence / adapter-facing interface を定義
+2. **Template 更新:** `assets/template/CLAUDE.md` を v2（managed マーカー付き）に更新
+3. **Lib モジュール追加:** `profile-schema.ts`, `ecosystem-detector.ts`, `claude-renderer.ts`, `profile-diff.ts` を追加
+4. **Schema validator と load path 追加:** `schemas.ts` に profile validator を追加し、`profile-schema.ts` に strict/setup loader と migration を実装
+5. **Flow 更新:** `specflow.setup` と `specflow-init --update` に render planning、`writeDisposition` handling、legacy write confirmation を組み込む
+6. **Gitignore 確認:** `.specflow/profile.json` が ignore されないことを確認
+7. **Build & test:** 全既存テストが通ることを確認
+8. **既存ユーザー移行:** `specflow-init --update` で template を更新（legacy `CLAUDE.md` なら確認付き）→ `setup` で profile を生成 / 古い profile を migration
+
+Rollback: template contract を旧 sourcePath に戻し、lib モジュールを削除すれば完全に元に戻る。
+
+## Open Questions
+
+- `specflow-analyze` と `ecosystem-detector` の将来的な統合タイミング — design phase では分離を優先し、統合は別 issue で扱う

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/proposal.md
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/proposal.md
@@ -1,0 +1,252 @@
+## Why
+
+現在の `CLAUDE.md` template は Contract Discipline と specflow Integration を含む project guideline として機能しているが、agent に与える context の層が明確に分離されていない。global invariants、project profile、phase-specific contract、runtime task instance、evidence context が同一ファイルに混在しており、surface や agent 実装に依存した wording が入り込みやすい。specflow の方向性（workflow semantics を core に寄せる、contract を明示する、core/adapter/local surface の境界を定義する）に合わせ、agent context も同じ原則で整理する。
+
+Source: https://github.com/skr19930617/specflow/issues/104
+
+## What Changes
+
+- Surface-neutral な context layering model を core に定義し、各 layer の ownership・参照方法・override 規則を明文化する
+- 初期 surface adapter として Claude 向け CLAUDE.md renderer を実装する（core model と adapter の境界を明確にする）
+- `setup` コマンドの責務を「CLAUDE.md の対話的な穴埋め」から「repository profile の構造化解析・生成」に拡張する
+- Setup のシナリオ別挙動を定義する（初回生成、再実行/更新、検出失敗、手動編集済み profile の扱い）
+- Generated profile を `.specflow/profile.json` に保存し、context template から参照する構造にする
+- Profile の構造検証（schema validation）を追加する
+- 配布は既存の `specflow-init` フローを利用し、rendering pipeline への変更は最小限にとどめる
+- 既存 repo の移行方針を定義する（既存 CLAUDE.md カスタマイズの保全、profile schema versioning）
+
+### Context Layering Model
+
+各 layer の責務:
+
+| Layer | Ownership | 保存先 | 変更頻度 | 編集可否 |
+|-------|-----------|--------|----------|----------|
+| 1. Global Invariants | specflow core | template 内に埋め込み | release 単位 | 編集不可（immutable content: specflow release でのみ変更） |
+| 2. Project Profile | `setup` が生成 | `.specflow/profile.json` | repo 構成変更時 | 手動編集可（再実行で merge） |
+| 3. Phase/Workflow Contract | command prompt が注入 | command body 内 | workflow 変更時 | 編集不可（immutable source: command contract でのみ変更） |
+| 4. Runtime Task Instance | workflow runtime が注入 | run-state / 一時ファイル | task ごと | N/A（揮発性） |
+| 5. Evidence Context | review/apply runtime が注入 | run-state / 一時ファイル | step ごと | N/A（揮発性） |
+
+**Layer 間の関係と衝突解決:**
+
+- Layer 1-2 は永続化され、template / profile として管理される
+- Layer 3 は command prompt に埋め込まれ、phase ごとに差し替わる
+- Layer 4-5 は runtime injection で、永続化されない
+- 各 layer は独立した名前空間を持ち、原則として衝突しない設計とする
+  - Layer 1 は不変ルール（Contract Discipline 等）を定義し、他 layer がこれを上書きすることはない
+  - Layer 2 はプロジェクト固有のファクト（言語、ツール、コマンド等）を保持する
+  - Layer 3 は phase 固有のワークフロー制約を注入する
+  - Layer 4-5 は task/step 固有のデータを追加する（上書きではなく追加）
+- 万一同一キーで衝突した場合の優先順位: Layer 1 > Layer 3 > Layer 2 > Layer 4 > Layer 5（不変ルールと workflow 制約が profile やランタイムデータより優先）
+
+### Setup シナリオ別挙動
+
+| シナリオ | 挙動 |
+|----------|------|
+| 初回生成（`.specflow/profile.json` なし） | repo 解析 → ユーザー確認 → profile 生成 → schema validation |
+| 再実行（既存 profile あり） | repo 再解析 → 既存 profile と解析結果の field-level diff → 差分があればユーザーに提示・選択を求める → profile 更新。手動編集と repo 変更を区別しない（provenance metadata は持たない）。差分がなければ "No changes detected" で終了 |
+| 検出失敗（required 項目） | 該当 required 項目をユーザーに提示し対話的に入力を求める。ユーザーが入力するまで setup はブロック（部分 profile を書き出さない）。全 required 項目が埋まるまで profile.json は生成されない |
+| 検出失敗（optional 項目） | 該当項目を `null` で出力、silent guess しない → ユーザーに手動入力の機会を提供するが、スキップ可能 |
+| schema validation 失敗 | エラー詳細を表示 → ユーザーに修正を促す → 再 validation |
+
+### Profile Schema Contract
+
+初期スコープは単一ルート repo に限定する（monorepo/multi-workspace は non-goal）。
+
+### Profile File Ownership
+
+- `.specflow/profile.json` はリポジトリにコミットする共有成果物（derived ではなく shared state）
+- チームメンバーは同一の profile を共有し、`setup` で生成後にコミットする
+- `.specflow/profile.json` が git merge conflict を起こした場合、通常の JSON merge で解決する（field-level で衝突を解決）
+- `.gitignore` に含めない（`specflow-init` が生成する `.gitignore` には `.specflow/profile.json` を含めない）
+
+### Supported Repository Scope
+
+- 初期スコープ: 単一言語・単一ルート repo のみ（リポジトリルートに主要なプロジェクト定義ファイルが1つ存在し、主要言語・ツールチェーンが1つの構成）
+- Monorepo、multi-workspace、polyglot（複数言語併用）repo は明示的に non-goal（将来拡張で workspace 配列や multi-toolchain 対応を導入する想定だが、この提案の scope 外）
+- `languages` は配列型だが初期スコープでは要素数1を想定。将来の polyglot 対応に向けた拡張ポイントとして配列を採用する
+- プロジェクトルートの手動指定は初期スコープ外（検出に依存）
+
+**エコシステム検出ルール:**
+
+Setup はリポジトリルートのファイルを以下の順序でスキャンし、最初にマッチしたエコシステムを採用する。同一エコシステム内の補助ファイル（lockfile 等）は conflict とみなさない。
+
+| Priority | Primary indicator | Supplementary files (conflict しない) | Language | Toolchain |
+|----------|-------------------|--------------------------------------|----------|-----------|
+| 1 | `package.json` | `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`, `tsconfig.json` | typescript / javascript | npm / pnpm / yarn / bun（lockfile で決定） |
+| 2 | `Cargo.toml` (no `[workspace]`) | `Cargo.lock` | rust | cargo |
+| 3 | `go.mod` | `go.sum` | go | go |
+| 4 | `pyproject.toml` | `uv.lock`, `poetry.lock`, `requirements.txt`, `setup.py`, `setup.cfg` | python | uv / poetry / pip（lockfile/tool section で決定） |
+
+**Conflict detection:**
+- Primary indicator が2つ以上マッチした場合（例: `package.json` と `go.mod` が共存）→ out-of-scope、setup を中断（error）
+- Primary indicator 内に workspace 定義が含まれる場合（`pnpm-workspace.yaml`, `Cargo.toml` の `[workspace]`, `lerna.json` 等）→ out-of-scope、setup を中断（error）
+- Primary indicator が0個の場合 → out-of-scope、setup を中断（error）
+- 同一エコシステム内で toolchain が曖昧な場合（例: `package-lock.json` と `pnpm-lock.yaml` が共存）→ ユーザーに toolchain を対話的に選択させる（recoverable）
+
+Out-of-scope 検出時のメッセージ: "このリポジトリ構成は現在のバージョンではサポートされていません。単一言語・単一ルートのリポジトリで `setup` を実行してください。"
+
+### Profile Schema Shape
+
+```jsonc
+{
+  // --- Required fields (setup blocks until all are provided) ---
+  "schemaVersion": "1",              // string, required — monotonic integer string
+  "languages": ["typescript"],       // string[], required, exactly 1 item in v1
+  "toolchain": "npm",               // string, required — package manager or build system
+
+  // --- Optional fields (always present, null = undetected) ---
+  // commands: object, always present. Each child is string | null.
+  // If no commands are detected at all, the object still exists with all children null.
+  // The object itself is NEVER null — only its children can be null.
+  "commands": {
+    "build": "npm run build",        // string | null
+    "test": "npm test",              // string | null
+    "lint": "npm run lint",          // string | null
+    "format": "npm run format"       // string | null
+  },
+  // directories: object, always present. Each child is string[] | null.
+  // Same rule: the object itself is NEVER null — only its children can be null.
+  "directories": {
+    "source": ["src/"],              // string[] | null
+    "test": ["tests/"],              // string[] | null
+    "generated": ["dist/"]           // string[] | null
+  },
+  "forbiddenEditZones": null,        // string[] | null — glob patterns
+  "contractSensitiveModules": null,  // string[] | null — paths or patterns
+  "codingConventions": null,         // string[] | null — free-text rules
+  "verificationExpectations": null   // string[] | null — free-text
+}
+```
+
+**`toolchain` field:**
+- プロジェクトの主要 package manager または build system を表す（旧名 `packageManager`、エコシステム中立な名前に変更）
+- 許容値と検出ルール:
+  - JavaScript/TypeScript: `"npm"`, `"pnpm"`, `"yarn"`, `"bun"` — lock file で検出
+  - Rust: `"cargo"` — `Cargo.toml` で検出
+  - Go: `"go"` — `go.mod` で検出
+  - Python: `"pip"`, `"poetry"`, `"uv"` — `requirements.txt`, `pyproject.toml`, `uv.lock` で検出
+  - 上記以外: ユーザーに自由入力を求める（enum 制約なし、detection hint のみ）
+
+**Nullability rules:**
+- **Top-level required fields** (`schemaVersion`, `languages`, `toolchain`): never null, never omitted
+- **Top-level optional object fields** (`commands`, `directories`): always present as an object, never null. Their child fields can individually be null
+- **Top-level optional array fields** (`forbiddenEditZones`, `contractSensitiveModules`, `codingConventions`, `verificationExpectations`): present with value `null` if undetected, `[]` if explicitly empty ("none applicable")
+- **Nested child fields within `commands`**: `string | null` — null if that specific command was not detected
+- **Nested child fields within `directories`**: `string[] | null` — null if that specific directory type was not detected
+- キー自体は省略しない（全フィールドが常に存在する）。validation は全キーの存在と型を検査する
+- `schemaVersion` は monotonic integer string（"1", "2", ...）。非互換変更でのみインクリメントする
+- **Schema closure:** `commands` と `directories` は closed object（`additionalProperties: false`）。定義された子キーのみを許容し、未知のキーは validation error とする。将来のキー追加は `schemaVersion` のインクリメントで行う。rerun diffing と rendering は定義済みキーのみを対象とし、未知キーは無視しない（エラーとして報告する）
+
+**Diff granularity（再実行時の比較単位）:**
+- `commands`: 子キー単位で比較（`commands.build`, `commands.test` 等を個別に diff）
+- `directories`: 子キー単位で比較（`directories.source` 等を個別に diff）
+- 配列フィールド（`forbiddenEditZones` 等）: ソート正規化後に配列全体を比較。要素の追加/削除を diff として表示
+- 全ての差分はフラット化して一覧表示し、個別にユーザーが accept/reject を選択する
+
+Profile 項目の分類:
+- **Required**: `schemaVersion`, `languages`（exactly 1 in v1）、`toolchain` — 検出失敗時は setup がブロックし、ユーザーに対話的入力を要求。全 required 項目が確定するまで profile.json は書き出されない
+- **Optional**: 上記 schema の残り全フィールド — 検出失敗時は `null` で記録（object 型フィールドは子を全て null にする）、スキップ可能
+
+### Profile Rerun: Deterministic Diff-and-Resolve
+
+Setup の再実行は provenance metadata を持たず、手動編集と repo 変更を区別しない。全ての再実行は単一の deterministic diff-and-resolve フローで処理する:
+
+- **Field-level diff ルール:**
+  - 既存値 = 解析結果 → 変更なし
+  - 既存値 ≠ 解析結果 かつ 既存値 ≠ null → 衝突として diff 表示し、ユーザーに選択を求める（解析結果を採用 / 既存値を維持）
+  - 既存値 = null かつ 解析結果 ≠ null → 解析結果を提案、ユーザー確認で採用
+  - 既存値 ≠ null かつ 解析結果 = null → 既存値を維持（検出できなくなっただけで削除しない）
+- 全ての差分解決後に schema validation を実行し、合格した場合のみ profile.json を書き出す
+
+### CLAUDE.md Managed/Unmanaged Boundary
+
+Claude adapter は CLAUDE.md 内のセクションを managed/unmanaged で区別するために、明示的なマーカーコメントを使用する:
+
+```markdown
+<!-- specflow:managed:start -->
+## Contract Discipline
+...
+## Project Profile
+...
+<!-- specflow:managed:end -->
+
+## MANUAL ADDITIONS
+(unmanaged — adapter は一切変更しない)
+```
+
+- **Managed 領域** (`<!-- specflow:managed:start -->` 〜 `<!-- specflow:managed:end -->`): adapter が profile から render し、毎回上書きする。ユーザーはこの領域を手動編集すべきでない
+- **Unmanaged 領域**: マーカー外の全てのコンテンツ。adapter は一切変更しない
+- **マーカーが見つからない場合（legacy CLAUDE.md migration）:**
+  - マーカーなしの CLAUDE.md は legacy とみなす。Adapter は既存コンテンツの内容を一切解析・削除しない（heading ベースの heuristic 検出は行わない — 誤検出リスクが高いため）
+  - 既存ファイル全体を `<!-- specflow:managed:end -->` の後ろに unmanaged コンテンツとして保全する
+  - 新しい managed block をファイル先頭に挿入する
+  - Warning を表示: "Legacy CLAUDE.md を検出しました。managed block を先頭に挿入しました。既存コンテンツに重複する記述がある場合は手動で削除してください。"
+  - ユーザー確認を必須とする（diff を表示し、accept/reject を求める）
+  - この方式により、legacy generated セクションと手動セクションの区別問題を完全に回避する。重複の手動整理はユーザー責任とする
+- Heading の重複・並び替えへの対処: adapter はマーカーベースで parse するため、heading 構造には依存しない。managed 領域内の heading は adapter が完全に制御する
+
+### Renderer Lifecycle
+
+Profile 変更から surface output（CLAUDE.md）への反映フロー:
+
+- `setup` コマンドは profile 生成/更新後に Claude adapter の render を自動実行し、CLAUDE.md を再生成する
+- `specflow-init --update` は template 更新後に既存 profile があれば render を自動実行する
+- Profile を手動編集した場合、次回の `setup` 実行時に render が再実行される（手動 render コマンドは初期スコープ外）
+- **Profile validation contract（全読み取り元共通）:** `.specflow/profile.json` を読み取る全てのエントリポイント（`setup`, `specflow-init --update`, renderer, その他将来のツール）は、読み取り時に schema validation を実行する。validation 失敗時は処理を中断し、エラーを表示して `setup` の再実行を促す。invalid な profile から CLAUDE.md を生成することはない
+- **Version mismatch の挙動:**
+  - Render 時に adapter は profile の `schemaVersion` と template の期待する version を比較する
+  - Version が一致 → 正常に render を実行
+  - Profile version < template 期待 version → render を停止し、エラーを表示。`setup` コマンドの再実行を促す（`setup` が schema migration を担当）
+  - Profile version > template 期待 version → render を停止し、エラーを表示。`specflow-init --update` で template を更新するよう促す
+  - CLAUDE.md は version mismatch 時に一切変更しない（破損防止）
+- **Migration 責務の所在:**
+  - `setup` コマンドが profile schema migration を所有する。古い profile を検出した場合、新しい schema に変換してからユーザーに確認を求める
+  - `specflow-init --update` が template 更新を所有する。template 側の version を最新に上げる
+  - Profile migration と template 更新は独立して実行可能だが、render は両方が整合した状態でのみ実行される
+
+### Surface Architecture
+
+```
+┌─────────────────────────────────────┐
+│  Core (surface-neutral)             │
+│  ├── context-layering-model         │
+│  ├── profile-schema                 │
+│  └── setup-analyzer                 │
+├─────────────────────────────────────┤
+│  Adapter (surface-specific)         │
+│  └── claude-renderer                │
+│      ├── CLAUDE.md template         │
+│      └── profile → markdown mapper  │
+└─────────────────────────────────────┘
+```
+
+- Core: context layering model、profile schema、setup 解析ロジック（surface に依存しない）
+- Adapter: surface ごとの renderer（初期実装は Claude 向け CLAUDE.md renderer のみ）
+- 将来の surface 追加（Cursor .cursorrules 等）は新しい adapter を追加するだけで対応可能
+
+### Migration Strategy
+
+- 既存の `CLAUDE.md` に手動追記（`## MANUAL ADDITIONS` 等）がある場合、setup は手動セクションを保全する
+- 既存の `specflow-init` 導入済み repo に対しては `setup` を実行して profile を生成する（CLAUDE.md の既存構造は adapter が移行）
+- `.specflow/profile.json` に `schemaVersion` フィールドを持ち、将来の schema 変更時に migration path を提供する
+- 初回移行は `specflow-init --update` 相当のフローで context template を更新し、`setup` で profile を生成する
+
+## Capabilities
+
+### New Capabilities
+- `agent-context-template`: Surface-neutral な context layering model の仕様。5 層の layer 定義（global invariants / project profile / phase contract / runtime task / evidence）、各 layer の ownership・参照方法・override 規則、surface adapter architecture（core/adapter 境界）を定める。初期 adapter として Claude 向け CLAUDE.md renderer を含む。
+
+### Modified Capabilities
+- `project-bootstrap-installation`: `setup` コマンドの入出力責務が拡張される。対話的な CLAUDE.md 穴埋めから、repository profile（`.specflow/profile.json`）の構造化解析・生成へ責務を変更。シナリオ別挙動（初回/再実行/検出失敗/手動編集済み）を定義。profile の schema validation が追加される。CLAUDE.md template は Claude adapter が profile を参照して render する形に更新される。配布は既存の init フローを利用。既存 repo の移行方針を含む。
+
+## Impact
+
+- `src/contracts/command-bodies.ts` — `specflow.setup` のコマンド定義を拡張（profile 解析・生成ステップ、シナリオ別分岐）
+- `src/contracts/templates.ts` — 新しい template contract の追加（context template、profile schema）
+- `assets/template/CLAUDE.md` — Claude adapter の template に変更（context layer 分離、profile 参照 slot の導入）
+- `src/lib/` — repository profile 解析ロジック、schema validation、Claude renderer の追加
+- `.specflow/profile.json` — 新規ファイル（generated output、schemaVersion 付き）
+- 既存の `specflow-init` による CLAUDE.md 配置フローへの影響（template 更新に伴う）
+- 既存 CLAUDE.md カスタマイズの保全（手動セクション維持）
+

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-design.json
@@ -1,0 +1,62 @@
+{
+  "feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
+  "phase": "design",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "title": "Five-layer core model is not mapped to an implementation artifact",
+      "detail": "The design and tasks cover profile schema, detection, diffing, and the Claude adapter, but they do not identify any core contract/module that actually defines the required five-layer model, namespace separation, and Layer 1 > 3 > 2 > 4 > 5 conflict priority. The design even defers Layer 3-5 composition as an open question, which leaves the new `agent-context-template` capability only partially specified for implementation. Add a surface-neutral core artifact and tasks for the layer definitions, precedence rules, and adapter-facing interface so future surfaces can depend on core without reworking this feature.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "consistency",
+      "title": "Profile migration flow conflicts with validate-on-read design",
+      "detail": "D7 and task 1.4 require schema validation on every profile read, but task 7.3 also requires `setup` to load older schema versions and migrate them. With the current design, an outdated profile would fail current-schema validation before migration can run; bypassing validation would violate the stated read contract. Define a version-aware load path now: raw read -> minimal schemaVersion sniff -> migrate if older -> validate current schema -> continue. Non-setup readers can remain strict-abort on mismatch. Add tests for outdated-profile rerun and for renderer/update behavior on older/newer versions.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "risk",
+      "title": "Legacy CLAUDE.md confirmation flow is not designed through the write paths",
+      "detail": "The spec requires marker-less `CLAUDE.md` migration to warn, show a diff, and require user confirmation before modifying the file. The design notes legacy preservation, but the tasks only implement renderer-side migration logic and do not assign the warning/confirmation behavior to `setup` or `specflow-init --update`, both of which auto-render after profile changes. That leaves a real risk of silently rewriting user-authored files. Add an explicit interaction contract and tasks so the renderer returns a migration result/diff and the calling flows gate the write on user confirmation.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 3,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-design.json
@@ -1,62 +1,62 @@
 {
-  "feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
-  "phase": "design",
-  "current_round": 1,
-  "status": "has_open_high",
-  "max_finding_id": 3,
-  "findings": [
-    {
-      "id": "R1-F01",
-      "severity": "high",
-      "category": "completeness",
-      "title": "Five-layer core model is not mapped to an implementation artifact",
-      "detail": "The design and tasks cover profile schema, detection, diffing, and the Claude adapter, but they do not identify any core contract/module that actually defines the required five-layer model, namespace separation, and Layer 1 > 3 > 2 > 4 > 5 conflict priority. The design even defers Layer 3-5 composition as an open question, which leaves the new `agent-context-template` capability only partially specified for implementation. Add a surface-neutral core artifact and tasks for the layer definitions, precedence rules, and adapter-facing interface so future surfaces can depend on core without reworking this feature.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F02",
-      "severity": "high",
-      "category": "consistency",
-      "title": "Profile migration flow conflicts with validate-on-read design",
-      "detail": "D7 and task 1.4 require schema validation on every profile read, but task 7.3 also requires `setup` to load older schema versions and migrate them. With the current design, an outdated profile would fail current-schema validation before migration can run; bypassing validation would violate the stated read contract. Define a version-aware load path now: raw read -> minimal schemaVersion sniff -> migrate if older -> validate current schema -> continue. Non-setup readers can remain strict-abort on mismatch. Add tests for outdated-profile rerun and for renderer/update behavior on older/newer versions.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F03",
-      "severity": "medium",
-      "category": "risk",
-      "title": "Legacy CLAUDE.md confirmation flow is not designed through the write paths",
-      "detail": "The spec requires marker-less `CLAUDE.md` migration to warn, show a diff, and require user confirmation before modifying the file. The design notes legacy preservation, but the tasks only implement renderer-side migration logic and do not assign the warning/confirmation behavior to `setup` or `specflow-init --update`, both of which auto-render after profile changes. That leaves a real risk of silently rewriting user-authored files. Add an explicit interaction contract and tasks so the renderer returns a migration result/diff and the calling flows gate the write on user confirmation.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    }
-  ],
-  "round_summaries": [
-    {
-      "round": 1,
-      "total": 3,
-      "open": 3,
-      "new": 3,
-      "resolved": 0,
-      "overridden": 0,
-      "by_severity": {
-        "high": 2,
-        "medium": 1
-      }
-    }
-  ]
+	"feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
+	"phase": "design",
+	"current_round": 1,
+	"status": "has_open_high",
+	"max_finding_id": 3,
+	"findings": [
+		{
+			"id": "R1-F01",
+			"severity": "high",
+			"category": "completeness",
+			"title": "Five-layer core model is not mapped to an implementation artifact",
+			"detail": "The design and tasks cover profile schema, detection, diffing, and the Claude adapter, but they do not identify any core contract/module that actually defines the required five-layer model, namespace separation, and Layer 1 > 3 > 2 > 4 > 5 conflict priority. The design even defers Layer 3-5 composition as an open question, which leaves the new `agent-context-template` capability only partially specified for implementation. Add a surface-neutral core artifact and tasks for the layer definitions, precedence rules, and adapter-facing interface so future surfaces can depend on core without reworking this feature.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F02",
+			"severity": "high",
+			"category": "consistency",
+			"title": "Profile migration flow conflicts with validate-on-read design",
+			"detail": "D7 and task 1.4 require schema validation on every profile read, but task 7.3 also requires `setup` to load older schema versions and migrate them. With the current design, an outdated profile would fail current-schema validation before migration can run; bypassing validation would violate the stated read contract. Define a version-aware load path now: raw read -> minimal schemaVersion sniff -> migrate if older -> validate current schema -> continue. Non-setup readers can remain strict-abort on mismatch. Add tests for outdated-profile rerun and for renderer/update behavior on older/newer versions.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F03",
+			"severity": "medium",
+			"category": "risk",
+			"title": "Legacy CLAUDE.md confirmation flow is not designed through the write paths",
+			"detail": "The spec requires marker-less `CLAUDE.md` migration to warn, show a diff, and require user confirmation before modifying the file. The design notes legacy preservation, but the tasks only implement renderer-side migration logic and do not assign the warning/confirmation behavior to `setup` or `specflow-init --update`, both of which auto-render after profile changes. That leaves a real risk of silently rewriting user-authored files. Add an explicit interaction contract and tasks so the renderer returns a migration result/diff and the calling flows gate the write on user confirmation.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		}
+	],
+	"round_summaries": [
+		{
+			"round": 1,
+			"total": 3,
+			"open": 3,
+			"new": 3,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"high": 2,
+				"medium": 1
+			}
+		}
+	]
 }

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-proposal.json
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-proposal.json
@@ -1,0 +1,359 @@
+{
+  "feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
+  "phase": "proposal",
+  "current_round": 8,
+  "status": "has_open_high",
+  "max_finding_id": 4,
+  "findings": [
+    {
+      "id": "R6-F02",
+      "severity": "medium",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "Validation lifecycle for editable profile.json is incomplete",
+      "detail": "The proposal requires schema validation during setup, but .specflow/profile.json is also described as a committed, manually editable shared artifact and is read by other flows such as specflow-init --update and renderer execution. The proposal does not state whether every profile read must validate the schema, or what failure behavior applies for an invalid but version-matching profile outside setup. Add a single validation contract for all profile read/render entry points and define the error path so designs do not diverge.",
+      "origin_round": 6,
+      "latest_round": 8,
+      "status": "open",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R6-F01",
+      "severity": "high",
+      "category": "risk",
+      "file": "proposal.md",
+      "title": "Legacy CLAUDE.md migration can leave duplicate conflicting guidance",
+      "detail": "The missing-marker migration path preserves the entire existing CLAUDE.md as unmanaged content and prepends a new managed block. For repos that already contain older generated specflow guidance mixed with manual edits, this can leave stale generated instructions alongside the new managed section, producing duplicated or contradictory agent context. Define a safe migration rule before design starts: either detect and replace legacy generated sections, require explicit user confirmation/manual migration when duplicates would remain, or block auto-migration in that case.",
+      "origin_round": 6,
+      "latest_round": 8,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R4-F02",
+      "notes": ""
+    },
+    {
+      "id": "R8-F01",
+      "severity": "medium",
+      "category": "risk",
+      "file": "proposal.md",
+      "title": "対話前提のCLI挙動が未定義",
+      "detail": "required項目の補完、rerun diffのaccept/reject、legacy CLAUDE.md移行確認、validation修復など、主要フローが対話入力を前提にしていますが、非TTY環境や自動化実行時の挙動が定義されていません。特に`specflow-init --update`は自動renderを行うため、途中で対話が必要になる場合の失敗条件が不明です。v1を対話専用にするのか、非対話時は即errorにするのか、利用可能なflagsとexit behaviorを先に固定してください。",
+      "origin_round": 8,
+      "latest_round": 8,
+      "status": "open",
+      "relation": "reframed",
+      "supersedes": "R6-F01",
+      "notes": ""
+    },
+    {
+      "id": "R8-F02",
+      "severity": "high",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "5層コンテキストの実体化契約が不足している",
+      "detail": "Layer 2のprofile schemaは具体化されている一方で、Layer 1/3/4/5は説明が概念レベルに留まり、consumerがどの形式で各layerを取得し、どこでeffective contextを組み立てるのかが未定義です。さらにLayer 1は『specflow coreが所有』としつつ『template内に埋め込み』とも書かれており、core/adapterのsource of truthが曖昧です。設計前に、各layerの正規表現形式、組み立て順序、merge/overrideの適用点、静的render対象とruntime injection対象の境界を明文化してください。",
+      "origin_round": 8,
+      "latest_round": 8,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R8-F03",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "無効な既存profileの扱いが章間で矛盾している",
+      "detail": "Setupシナリオではschema validation failure時にユーザー修正と再validationを行う前提ですが、Renderer Lifecycleではprofileを読む全エントリポイント（setupを含む）がread時validation失敗で処理中断し、setup再実行を促すとされています。このままでは、既存のinvalid profileをsetupが修復できるのか、起動自体を拒否するのかが不明です。設計前に、invalid existing profileの単一フローを定義し、read時失敗・修復手段・再書き出し条件・render可否を一貫させてください。",
+      "origin_round": 8,
+      "latest_round": 8,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R7-F01",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Repository detection and recovery rules are not deterministic",
+      "detail": "The proposal gives examples of in-scope and out-of-scope repositories and lists toolchain detection hints, but it does not define precedence when same-ecosystem signals conflict (for example multiple lockfiles or multiple Python tool indicators), nor when a missing required field is recoverable by user input versus a hard out-of-scope abort. This leaves setup behavior ambiguous and likely to drift across implementations. Define exact detection precedence, conflict-as-error rules, and which failures can be resolved interactively.",
+      "origin_round": 7,
+      "latest_round": 7,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R5-F01",
+      "notes": ""
+    },
+    {
+      "id": "R5-F01",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Deterministic diff rules are underspecified for nested and collection fields",
+      "detail": "The rerun flow promises deterministic field-level diff-and-resolve behavior, but the proposal does not define the comparison unit for `commands`, `directories`, or array fields such as `forbiddenEditZones`. It is unclear whether conflicts are resolved per child key, per whole object, or per normalized array entry/order. Specify diff granularity and normalization rules so the update UX and persisted output can be designed consistently.",
+      "origin_round": 5,
+      "latest_round": 7,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F02",
+      "severity": "medium",
+      "category": "risk",
+      "file": "proposal.md",
+      "title": "Version-mismatch and migration behavior is not defined tightly enough",
+      "detail": "The proposal introduces `schemaVersion`, version checks, auto-rendering after `setup`, and auto-rendering during `specflow-init --update`, but only specifies a warning when profile and template expectations differ. It does not say whether rendering must stop, which command owns migration, what happens to an incompatible existing profile, or how failures are surfaced without corrupting `CLAUDE.md`. This lifecycle needs explicit rules to avoid divergent update behavior.",
+      "origin_round": 4,
+      "latest_round": 6,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F01",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Repository scope conflicts with the proposed schema",
+      "detail": "The proposal says polyglot repos are out of scope, but later explicitly allows a single-root repo with multiple languages such as TypeScript + Python. The schema cannot represent that case cleanly because it has only one `packageManager` and one shared `commands` object. Design cannot proceed safely until this boundary is made consistent. Either keep single-root multi-language repos out of scope, or expand the schema and setup rules to model multiple ecosystems/toolchains explicitly.",
+      "origin_round": 4,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F02",
+      "severity": "medium",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Out-of-scope repository detection has no explicit setup behavior",
+      "detail": "The proposal declares monorepos, multi-workspace repos, and polyglot repos out of scope, but does not say how `setup` should behave when it encounters one of those cases or ambiguous root detection. Design needs an explicit boundary behavior such as hard fail, warning with manual override, or no profile write, otherwise analyzer behavior and user experience will drift.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R3-F03",
+      "severity": "medium",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "CLAUDE.md preservation rules lack a deterministic managed/unmanaged boundary",
+      "detail": "Migration and rerendering depend on preserving `## MANUAL ADDITIONS` and unknown sections, but the proposal does not define how the renderer identifies managed sections, handles reordered or duplicated headings, or behaves when the existing file no longer matches the expected template structure. Without a stable boundary contract, design and validation will drift. Define explicit markers/anchors or another deterministic parse contract, plus fallback behavior for malformed or heavily customized files.",
+      "origin_round": 3,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Setup と profile 生成の受け入れ条件が設計可能な粒度まで定義されていない",
+      "detail": "`setup` が repository profile を解析・生成するとあるが、初回生成、再実行、既存 `.specflow/profile.json` 更新、検出失敗時、手動修正済み profile の扱いが未定義。schema validation は構造しか保証せず、内容の妥当性や fallback の挙動は決められない。主要シナリオごとに required/optional 項目、unknown の扱い、merge/overwrite ルール、成功条件を acceptance criteria として明記する必要がある。",
+      "origin_round": 1,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R3-F01",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Manual-edit detection and rerun scenarios are not implementable as written",
+      "detail": "The proposal separates rerun behavior into 'manual editsなし' and 'manual editsあり' paths, but it also explicitly avoids storing `_source` metadata and does not define any other provenance mechanism. Comparing the existing profile with fresh analyzer output cannot reliably distinguish user edits from legitimate repository changes. This needs a concrete detection model (for example stored analyzer snapshot/provenance metadata) or the scenarios should be collapsed into one deterministic diff-and-resolve flow.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R2-F01",
+      "notes": ""
+    },
+    {
+      "id": "R3-F02",
+      "severity": "medium",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Supported repository shapes are unclear",
+      "detail": "The schema and setup flow appear repo-global, but the proposal uses `languages` as multi-valued while `packageManager` is singular and command fields are singletons. That leaves monorepos, multi-workspace repos, and polyglot repos underspecified. The proposal should either declare an explicit initial boundary (for example single-root repos only) or extend the profile model to represent per-workspace/package-manager data.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Renderer/update lifecycle is not clearly assigned",
+      "detail": "The proposal introduces a Claude adapter that renders from `profile.json`, but the setup scenarios only describe profile generation/update, while distribution is said to stay in the existing `specflow-init` flow. Specify which command regenerates `CLAUDE.md`, when rerendering happens after profile changes, and how stale templates/adapters are detected during migration to avoid split responsibilities in design.",
+      "origin_round": 2,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R1-F02",
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Surface 非依存という目標と `CLAUDE.md` 中心の成果物定義が噛み合っていない",
+      "detail": "提案は agent/surface 非依存の reusable context template を掲げる一方、変更対象は `CLAUDE.md` template とその参照構造に集中している。surface-neutral な中間表現を導入するのか、Claude 向け template を整理するだけなのかが不明で、core/adapter/local surface 境界を設計できない。今回の scope を `surface-neutral model + Claude renderer` か `Claude surface 限定` のどちらかで明示する必要がある。",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "risk",
+      "file": "proposal.md",
+      "title": "既存リポジトリへの移行方針と互換性前提が欠けている",
+      "detail": "既存の `CLAUDE.md` カスタマイズ、`specflow-init` 既存導入済み repo、将来の profile schema 変更に対する移行戦略が記載されていない。ここがないと設計で後方互換や versioning が後回しになり、導入時に spec drift が起きやすい。既存ファイルの扱い、generated file の version 管理、手動編集可否、再生成/アップグレード方針を追加すべき。",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Context layering model の責務分離と優先順位が未定義",
+      "detail": "global invariants / project profile / phase contract / runtime task / evidence という層名は示されているが、各層に何を保持し、何を参照し、最終 context にどう合成するかが定義されていない。衝突時の優先順位や禁止事項もないため、template 設計・schema 設計・runtime composition が実装ごとに分岐する。各 layer の ownership、参照方法、override 規則を normative に追加すべき。",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 4,
+      "open": 4,
+      "new": 4,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 5,
+      "open": 4,
+      "new": 0,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 4,
+      "new": 2,
+      "resolved": 4,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 2
+      }
+    },
+    {
+      "round": 4,
+      "total": 10,
+      "open": 3,
+      "new": 2,
+      "resolved": 7,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 1
+      }
+    },
+    {
+      "round": 5,
+      "total": 12,
+      "open": 4,
+      "new": 2,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 3,
+        "high": 1
+      }
+    },
+    {
+      "round": 6,
+      "total": 14,
+      "open": 3,
+      "new": 1,
+      "resolved": 11,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 1
+      }
+    },
+    {
+      "round": 7,
+      "total": 15,
+      "open": 3,
+      "new": 0,
+      "resolved": 12,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 1
+      }
+    },
+    {
+      "round": 8,
+      "total": 18,
+      "open": 4,
+      "new": 2,
+      "resolved": 14,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-proposal.json
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-proposal.json
@@ -1,359 +1,359 @@
 {
-  "feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
-  "phase": "proposal",
-  "current_round": 8,
-  "status": "has_open_high",
-  "max_finding_id": 4,
-  "findings": [
-    {
-      "id": "R6-F02",
-      "severity": "medium",
-      "category": "validation",
-      "file": "proposal.md",
-      "title": "Validation lifecycle for editable profile.json is incomplete",
-      "detail": "The proposal requires schema validation during setup, but .specflow/profile.json is also described as a committed, manually editable shared artifact and is read by other flows such as specflow-init --update and renderer execution. The proposal does not state whether every profile read must validate the schema, or what failure behavior applies for an invalid but version-matching profile outside setup. Add a single validation contract for all profile read/render entry points and define the error path so designs do not diverge.",
-      "origin_round": 6,
-      "latest_round": 8,
-      "status": "open",
-      "relation": "same",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R6-F01",
-      "severity": "high",
-      "category": "risk",
-      "file": "proposal.md",
-      "title": "Legacy CLAUDE.md migration can leave duplicate conflicting guidance",
-      "detail": "The missing-marker migration path preserves the entire existing CLAUDE.md as unmanaged content and prepends a new managed block. For repos that already contain older generated specflow guidance mixed with manual edits, this can leave stale generated instructions alongside the new managed section, producing duplicated or contradictory agent context. Define a safe migration rule before design starts: either detect and replace legacy generated sections, require explicit user confirmation/manual migration when duplicates would remain, or block auto-migration in that case.",
-      "origin_round": 6,
-      "latest_round": 8,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": "R4-F02",
-      "notes": ""
-    },
-    {
-      "id": "R8-F01",
-      "severity": "medium",
-      "category": "risk",
-      "file": "proposal.md",
-      "title": "対話前提のCLI挙動が未定義",
-      "detail": "required項目の補完、rerun diffのaccept/reject、legacy CLAUDE.md移行確認、validation修復など、主要フローが対話入力を前提にしていますが、非TTY環境や自動化実行時の挙動が定義されていません。特に`specflow-init --update`は自動renderを行うため、途中で対話が必要になる場合の失敗条件が不明です。v1を対話専用にするのか、非対話時は即errorにするのか、利用可能なflagsとexit behaviorを先に固定してください。",
-      "origin_round": 8,
-      "latest_round": 8,
-      "status": "open",
-      "relation": "reframed",
-      "supersedes": "R6-F01",
-      "notes": ""
-    },
-    {
-      "id": "R8-F02",
-      "severity": "high",
-      "category": "completeness",
-      "file": "proposal.md",
-      "title": "5層コンテキストの実体化契約が不足している",
-      "detail": "Layer 2のprofile schemaは具体化されている一方で、Layer 1/3/4/5は説明が概念レベルに留まり、consumerがどの形式で各layerを取得し、どこでeffective contextを組み立てるのかが未定義です。さらにLayer 1は『specflow coreが所有』としつつ『template内に埋め込み』とも書かれており、core/adapterのsource of truthが曖昧です。設計前に、各layerの正規表現形式、組み立て順序、merge/overrideの適用点、静的render対象とruntime injection対象の境界を明文化してください。",
-      "origin_round": 8,
-      "latest_round": 8,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R8-F03",
-      "severity": "high",
-      "category": "consistency",
-      "file": "proposal.md",
-      "title": "無効な既存profileの扱いが章間で矛盾している",
-      "detail": "Setupシナリオではschema validation failure時にユーザー修正と再validationを行う前提ですが、Renderer Lifecycleではprofileを読む全エントリポイント（setupを含む）がread時validation失敗で処理中断し、setup再実行を促すとされています。このままでは、既存のinvalid profileをsetupが修復できるのか、起動自体を拒否するのかが不明です。設計前に、invalid existing profileの単一フローを定義し、read時失敗・修復手段・再書き出し条件・render可否を一貫させてください。",
-      "origin_round": 8,
-      "latest_round": 8,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R7-F01",
-      "severity": "high",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Repository detection and recovery rules are not deterministic",
-      "detail": "The proposal gives examples of in-scope and out-of-scope repositories and lists toolchain detection hints, but it does not define precedence when same-ecosystem signals conflict (for example multiple lockfiles or multiple Python tool indicators), nor when a missing required field is recoverable by user input versus a hard out-of-scope abort. This leaves setup behavior ambiguous and likely to drift across implementations. Define exact detection precedence, conflict-as-error rules, and which failures can be resolved interactively.",
-      "origin_round": 7,
-      "latest_round": 7,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": "R5-F01",
-      "notes": ""
-    },
-    {
-      "id": "R5-F01",
-      "severity": "medium",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Deterministic diff rules are underspecified for nested and collection fields",
-      "detail": "The rerun flow promises deterministic field-level diff-and-resolve behavior, but the proposal does not define the comparison unit for `commands`, `directories`, or array fields such as `forbiddenEditZones`. It is unclear whether conflicts are resolved per child key, per whole object, or per normalized array entry/order. Specify diff granularity and normalization rules so the update UX and persisted output can be designed consistently.",
-      "origin_round": 5,
-      "latest_round": 7,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R4-F02",
-      "severity": "medium",
-      "category": "risk",
-      "file": "proposal.md",
-      "title": "Version-mismatch and migration behavior is not defined tightly enough",
-      "detail": "The proposal introduces `schemaVersion`, version checks, auto-rendering after `setup`, and auto-rendering during `specflow-init --update`, but only specifies a warning when profile and template expectations differ. It does not say whether rendering must stop, which command owns migration, what happens to an incompatible existing profile, or how failures are surfaced without corrupting `CLAUDE.md`. This lifecycle needs explicit rules to avoid divergent update behavior.",
-      "origin_round": 4,
-      "latest_round": 6,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R4-F01",
-      "severity": "high",
-      "category": "consistency",
-      "file": "proposal.md",
-      "title": "Repository scope conflicts with the proposed schema",
-      "detail": "The proposal says polyglot repos are out of scope, but later explicitly allows a single-root repo with multiple languages such as TypeScript + Python. The schema cannot represent that case cleanly because it has only one `packageManager` and one shared `commands` object. Design cannot proceed safely until this boundary is made consistent. Either keep single-root multi-language repos out of scope, or expand the schema and setup rules to model multiple ecosystems/toolchains explicitly.",
-      "origin_round": 4,
-      "latest_round": 5,
-      "status": "resolved",
-      "relation": "same",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R5-F02",
-      "severity": "medium",
-      "category": "scope",
-      "file": "proposal.md",
-      "title": "Out-of-scope repository detection has no explicit setup behavior",
-      "detail": "The proposal declares monorepos, multi-workspace repos, and polyglot repos out of scope, but does not say how `setup` should behave when it encounters one of those cases or ambiguous root detection. Design needs an explicit boundary behavior such as hard fail, warning with manual override, or no profile write, otherwise analyzer behavior and user experience will drift.",
-      "origin_round": 5,
-      "latest_round": 5,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R3-F03",
-      "severity": "medium",
-      "category": "validation",
-      "file": "proposal.md",
-      "title": "CLAUDE.md preservation rules lack a deterministic managed/unmanaged boundary",
-      "detail": "Migration and rerendering depend on preserving `## MANUAL ADDITIONS` and unknown sections, but the proposal does not define how the renderer identifies managed sections, handles reordered or duplicated headings, or behaves when the existing file no longer matches the expected template structure. Without a stable boundary contract, design and validation will drift. Define explicit markers/anchors or another deterministic parse contract, plus fallback behavior for malformed or heavily customized files.",
-      "origin_round": 3,
-      "latest_round": 4,
-      "status": "resolved",
-      "relation": "same",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F01",
-      "severity": "high",
-      "category": "completeness",
-      "file": "proposal.md",
-      "title": "Setup と profile 生成の受け入れ条件が設計可能な粒度まで定義されていない",
-      "detail": "`setup` が repository profile を解析・生成するとあるが、初回生成、再実行、既存 `.specflow/profile.json` 更新、検出失敗時、手動修正済み profile の扱いが未定義。schema validation は構造しか保証せず、内容の妥当性や fallback の挙動は決められない。主要シナリオごとに required/optional 項目、unknown の扱い、merge/overwrite ルール、成功条件を acceptance criteria として明記する必要がある。",
-      "origin_round": 1,
-      "latest_round": 3,
-      "status": "resolved",
-      "relation": "same",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R3-F01",
-      "severity": "high",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Manual-edit detection and rerun scenarios are not implementable as written",
-      "detail": "The proposal separates rerun behavior into 'manual editsなし' and 'manual editsあり' paths, but it also explicitly avoids storing `_source` metadata and does not define any other provenance mechanism. Comparing the existing profile with fresh analyzer output cannot reliably distinguish user edits from legitimate repository changes. This needs a concrete detection model (for example stored analyzer snapshot/provenance metadata) or the scenarios should be collapsed into one deterministic diff-and-resolve flow.",
-      "origin_round": 3,
-      "latest_round": 3,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": "R2-F01",
-      "notes": ""
-    },
-    {
-      "id": "R3-F02",
-      "severity": "medium",
-      "category": "scope",
-      "file": "proposal.md",
-      "title": "Supported repository shapes are unclear",
-      "detail": "The schema and setup flow appear repo-global, but the proposal uses `languages` as multi-valued while `packageManager` is singular and command fields are singletons. That leaves monorepos, multi-workspace repos, and polyglot repos underspecified. The proposal should either declare an explicit initial boundary (for example single-root repos only) or extend the profile model to represent per-workspace/package-manager data.",
-      "origin_round": 3,
-      "latest_round": 3,
-      "status": "resolved",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R2-F01",
-      "severity": "medium",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Renderer/update lifecycle is not clearly assigned",
-      "detail": "The proposal introduces a Claude adapter that renders from `profile.json`, but the setup scenarios only describe profile generation/update, while distribution is said to stay in the existing `specflow-init` flow. Specify which command regenerates `CLAUDE.md`, when rerendering happens after profile changes, and how stale templates/adapters are detected during migration to avoid split responsibilities in design.",
-      "origin_round": 2,
-      "latest_round": 3,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": "R1-F02",
-      "notes": ""
-    },
-    {
-      "id": "R1-F03",
-      "severity": "high",
-      "category": "consistency",
-      "file": "proposal.md",
-      "title": "Surface 非依存という目標と `CLAUDE.md` 中心の成果物定義が噛み合っていない",
-      "detail": "提案は agent/surface 非依存の reusable context template を掲げる一方、変更対象は `CLAUDE.md` template とその参照構造に集中している。surface-neutral な中間表現を導入するのか、Claude 向け template を整理するだけなのかが不明で、core/adapter/local surface 境界を設計できない。今回の scope を `surface-neutral model + Claude renderer` か `Claude surface 限定` のどちらかで明示する必要がある。",
-      "origin_round": 1,
-      "latest_round": 2,
-      "status": "resolved",
-      "relation": "same",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F04",
-      "severity": "medium",
-      "category": "risk",
-      "file": "proposal.md",
-      "title": "既存リポジトリへの移行方針と互換性前提が欠けている",
-      "detail": "既存の `CLAUDE.md` カスタマイズ、`specflow-init` 既存導入済み repo、将来の profile schema 変更に対する移行戦略が記載されていない。ここがないと設計で後方互換や versioning が後回しになり、導入時に spec drift が起きやすい。既存ファイルの扱い、generated file の version 管理、手動編集可否、再生成/アップグレード方針を追加すべき。",
-      "origin_round": 1,
-      "latest_round": 2,
-      "status": "resolved",
-      "relation": "same",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F02",
-      "severity": "high",
-      "category": "clarity",
-      "file": "proposal.md",
-      "title": "Context layering model の責務分離と優先順位が未定義",
-      "detail": "global invariants / project profile / phase contract / runtime task / evidence という層名は示されているが、各層に何を保持し、何を参照し、最終 context にどう合成するかが定義されていない。衝突時の優先順位や禁止事項もないため、template 設計・schema 設計・runtime composition が実装ごとに分岐する。各 layer の ownership、参照方法、override 規則を normative に追加すべき。",
-      "origin_round": 1,
-      "latest_round": 2,
-      "status": "resolved",
-      "relation": "reframed",
-      "supersedes": null,
-      "notes": ""
-    }
-  ],
-  "round_summaries": [
-    {
-      "round": 1,
-      "total": 4,
-      "open": 4,
-      "new": 4,
-      "resolved": 0,
-      "overridden": 0,
-      "by_severity": {
-        "high": 3,
-        "medium": 1
-      }
-    },
-    {
-      "round": 2,
-      "total": 5,
-      "open": 4,
-      "new": 0,
-      "resolved": 1,
-      "overridden": 0,
-      "by_severity": {
-        "high": 2,
-        "medium": 2
-      }
-    },
-    {
-      "round": 3,
-      "total": 8,
-      "open": 4,
-      "new": 2,
-      "resolved": 4,
-      "overridden": 0,
-      "by_severity": {
-        "high": 2,
-        "medium": 2
-      }
-    },
-    {
-      "round": 4,
-      "total": 10,
-      "open": 3,
-      "new": 2,
-      "resolved": 7,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 2,
-        "high": 1
-      }
-    },
-    {
-      "round": 5,
-      "total": 12,
-      "open": 4,
-      "new": 2,
-      "resolved": 8,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 3,
-        "high": 1
-      }
-    },
-    {
-      "round": 6,
-      "total": 14,
-      "open": 3,
-      "new": 1,
-      "resolved": 11,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 2,
-        "high": 1
-      }
-    },
-    {
-      "round": 7,
-      "total": 15,
-      "open": 3,
-      "new": 0,
-      "resolved": 12,
-      "overridden": 0,
-      "by_severity": {
-        "high": 2,
-        "medium": 1
-      }
-    },
-    {
-      "round": 8,
-      "total": 18,
-      "open": 4,
-      "new": 2,
-      "resolved": 14,
-      "overridden": 0,
-      "by_severity": {
-        "medium": 2,
-        "high": 2
-      }
-    }
-  ]
+	"feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
+	"phase": "proposal",
+	"current_round": 8,
+	"status": "has_open_high",
+	"max_finding_id": 4,
+	"findings": [
+		{
+			"id": "R6-F02",
+			"severity": "medium",
+			"category": "validation",
+			"file": "proposal.md",
+			"title": "Validation lifecycle for editable profile.json is incomplete",
+			"detail": "The proposal requires schema validation during setup, but .specflow/profile.json is also described as a committed, manually editable shared artifact and is read by other flows such as specflow-init --update and renderer execution. The proposal does not state whether every profile read must validate the schema, or what failure behavior applies for an invalid but version-matching profile outside setup. Add a single validation contract for all profile read/render entry points and define the error path so designs do not diverge.",
+			"origin_round": 6,
+			"latest_round": 8,
+			"status": "open",
+			"relation": "same",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R6-F01",
+			"severity": "high",
+			"category": "risk",
+			"file": "proposal.md",
+			"title": "Legacy CLAUDE.md migration can leave duplicate conflicting guidance",
+			"detail": "The missing-marker migration path preserves the entire existing CLAUDE.md as unmanaged content and prepends a new managed block. For repos that already contain older generated specflow guidance mixed with manual edits, this can leave stale generated instructions alongside the new managed section, producing duplicated or contradictory agent context. Define a safe migration rule before design starts: either detect and replace legacy generated sections, require explicit user confirmation/manual migration when duplicates would remain, or block auto-migration in that case.",
+			"origin_round": 6,
+			"latest_round": 8,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": "R4-F02",
+			"notes": ""
+		},
+		{
+			"id": "R8-F01",
+			"severity": "medium",
+			"category": "risk",
+			"file": "proposal.md",
+			"title": "対話前提のCLI挙動が未定義",
+			"detail": "required項目の補完、rerun diffのaccept/reject、legacy CLAUDE.md移行確認、validation修復など、主要フローが対話入力を前提にしていますが、非TTY環境や自動化実行時の挙動が定義されていません。特に`specflow-init --update`は自動renderを行うため、途中で対話が必要になる場合の失敗条件が不明です。v1を対話専用にするのか、非対話時は即errorにするのか、利用可能なflagsとexit behaviorを先に固定してください。",
+			"origin_round": 8,
+			"latest_round": 8,
+			"status": "open",
+			"relation": "reframed",
+			"supersedes": "R6-F01",
+			"notes": ""
+		},
+		{
+			"id": "R8-F02",
+			"severity": "high",
+			"category": "completeness",
+			"file": "proposal.md",
+			"title": "5層コンテキストの実体化契約が不足している",
+			"detail": "Layer 2のprofile schemaは具体化されている一方で、Layer 1/3/4/5は説明が概念レベルに留まり、consumerがどの形式で各layerを取得し、どこでeffective contextを組み立てるのかが未定義です。さらにLayer 1は『specflow coreが所有』としつつ『template内に埋め込み』とも書かれており、core/adapterのsource of truthが曖昧です。設計前に、各layerの正規表現形式、組み立て順序、merge/overrideの適用点、静的render対象とruntime injection対象の境界を明文化してください。",
+			"origin_round": 8,
+			"latest_round": 8,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R8-F03",
+			"severity": "high",
+			"category": "consistency",
+			"file": "proposal.md",
+			"title": "無効な既存profileの扱いが章間で矛盾している",
+			"detail": "Setupシナリオではschema validation failure時にユーザー修正と再validationを行う前提ですが、Renderer Lifecycleではprofileを読む全エントリポイント（setupを含む）がread時validation失敗で処理中断し、setup再実行を促すとされています。このままでは、既存のinvalid profileをsetupが修復できるのか、起動自体を拒否するのかが不明です。設計前に、invalid existing profileの単一フローを定義し、read時失敗・修復手段・再書き出し条件・render可否を一貫させてください。",
+			"origin_round": 8,
+			"latest_round": 8,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R7-F01",
+			"severity": "high",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Repository detection and recovery rules are not deterministic",
+			"detail": "The proposal gives examples of in-scope and out-of-scope repositories and lists toolchain detection hints, but it does not define precedence when same-ecosystem signals conflict (for example multiple lockfiles or multiple Python tool indicators), nor when a missing required field is recoverable by user input versus a hard out-of-scope abort. This leaves setup behavior ambiguous and likely to drift across implementations. Define exact detection precedence, conflict-as-error rules, and which failures can be resolved interactively.",
+			"origin_round": 7,
+			"latest_round": 7,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": "R5-F01",
+			"notes": ""
+		},
+		{
+			"id": "R5-F01",
+			"severity": "medium",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Deterministic diff rules are underspecified for nested and collection fields",
+			"detail": "The rerun flow promises deterministic field-level diff-and-resolve behavior, but the proposal does not define the comparison unit for `commands`, `directories`, or array fields such as `forbiddenEditZones`. It is unclear whether conflicts are resolved per child key, per whole object, or per normalized array entry/order. Specify diff granularity and normalization rules so the update UX and persisted output can be designed consistently.",
+			"origin_round": 5,
+			"latest_round": 7,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R4-F02",
+			"severity": "medium",
+			"category": "risk",
+			"file": "proposal.md",
+			"title": "Version-mismatch and migration behavior is not defined tightly enough",
+			"detail": "The proposal introduces `schemaVersion`, version checks, auto-rendering after `setup`, and auto-rendering during `specflow-init --update`, but only specifies a warning when profile and template expectations differ. It does not say whether rendering must stop, which command owns migration, what happens to an incompatible existing profile, or how failures are surfaced without corrupting `CLAUDE.md`. This lifecycle needs explicit rules to avoid divergent update behavior.",
+			"origin_round": 4,
+			"latest_round": 6,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R4-F01",
+			"severity": "high",
+			"category": "consistency",
+			"file": "proposal.md",
+			"title": "Repository scope conflicts with the proposed schema",
+			"detail": "The proposal says polyglot repos are out of scope, but later explicitly allows a single-root repo with multiple languages such as TypeScript + Python. The schema cannot represent that case cleanly because it has only one `packageManager` and one shared `commands` object. Design cannot proceed safely until this boundary is made consistent. Either keep single-root multi-language repos out of scope, or expand the schema and setup rules to model multiple ecosystems/toolchains explicitly.",
+			"origin_round": 4,
+			"latest_round": 5,
+			"status": "resolved",
+			"relation": "same",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R5-F02",
+			"severity": "medium",
+			"category": "scope",
+			"file": "proposal.md",
+			"title": "Out-of-scope repository detection has no explicit setup behavior",
+			"detail": "The proposal declares monorepos, multi-workspace repos, and polyglot repos out of scope, but does not say how `setup` should behave when it encounters one of those cases or ambiguous root detection. Design needs an explicit boundary behavior such as hard fail, warning with manual override, or no profile write, otherwise analyzer behavior and user experience will drift.",
+			"origin_round": 5,
+			"latest_round": 5,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R3-F03",
+			"severity": "medium",
+			"category": "validation",
+			"file": "proposal.md",
+			"title": "CLAUDE.md preservation rules lack a deterministic managed/unmanaged boundary",
+			"detail": "Migration and rerendering depend on preserving `## MANUAL ADDITIONS` and unknown sections, but the proposal does not define how the renderer identifies managed sections, handles reordered or duplicated headings, or behaves when the existing file no longer matches the expected template structure. Without a stable boundary contract, design and validation will drift. Define explicit markers/anchors or another deterministic parse contract, plus fallback behavior for malformed or heavily customized files.",
+			"origin_round": 3,
+			"latest_round": 4,
+			"status": "resolved",
+			"relation": "same",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F01",
+			"severity": "high",
+			"category": "completeness",
+			"file": "proposal.md",
+			"title": "Setup と profile 生成の受け入れ条件が設計可能な粒度まで定義されていない",
+			"detail": "`setup` が repository profile を解析・生成するとあるが、初回生成、再実行、既存 `.specflow/profile.json` 更新、検出失敗時、手動修正済み profile の扱いが未定義。schema validation は構造しか保証せず、内容の妥当性や fallback の挙動は決められない。主要シナリオごとに required/optional 項目、unknown の扱い、merge/overwrite ルール、成功条件を acceptance criteria として明記する必要がある。",
+			"origin_round": 1,
+			"latest_round": 3,
+			"status": "resolved",
+			"relation": "same",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R3-F01",
+			"severity": "high",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Manual-edit detection and rerun scenarios are not implementable as written",
+			"detail": "The proposal separates rerun behavior into 'manual editsなし' and 'manual editsあり' paths, but it also explicitly avoids storing `_source` metadata and does not define any other provenance mechanism. Comparing the existing profile with fresh analyzer output cannot reliably distinguish user edits from legitimate repository changes. This needs a concrete detection model (for example stored analyzer snapshot/provenance metadata) or the scenarios should be collapsed into one deterministic diff-and-resolve flow.",
+			"origin_round": 3,
+			"latest_round": 3,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": "R2-F01",
+			"notes": ""
+		},
+		{
+			"id": "R3-F02",
+			"severity": "medium",
+			"category": "scope",
+			"file": "proposal.md",
+			"title": "Supported repository shapes are unclear",
+			"detail": "The schema and setup flow appear repo-global, but the proposal uses `languages` as multi-valued while `packageManager` is singular and command fields are singletons. That leaves monorepos, multi-workspace repos, and polyglot repos underspecified. The proposal should either declare an explicit initial boundary (for example single-root repos only) or extend the profile model to represent per-workspace/package-manager data.",
+			"origin_round": 3,
+			"latest_round": 3,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R2-F01",
+			"severity": "medium",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Renderer/update lifecycle is not clearly assigned",
+			"detail": "The proposal introduces a Claude adapter that renders from `profile.json`, but the setup scenarios only describe profile generation/update, while distribution is said to stay in the existing `specflow-init` flow. Specify which command regenerates `CLAUDE.md`, when rerendering happens after profile changes, and how stale templates/adapters are detected during migration to avoid split responsibilities in design.",
+			"origin_round": 2,
+			"latest_round": 3,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": "R1-F02",
+			"notes": ""
+		},
+		{
+			"id": "R1-F03",
+			"severity": "high",
+			"category": "consistency",
+			"file": "proposal.md",
+			"title": "Surface 非依存という目標と `CLAUDE.md` 中心の成果物定義が噛み合っていない",
+			"detail": "提案は agent/surface 非依存の reusable context template を掲げる一方、変更対象は `CLAUDE.md` template とその参照構造に集中している。surface-neutral な中間表現を導入するのか、Claude 向け template を整理するだけなのかが不明で、core/adapter/local surface 境界を設計できない。今回の scope を `surface-neutral model + Claude renderer` か `Claude surface 限定` のどちらかで明示する必要がある。",
+			"origin_round": 1,
+			"latest_round": 2,
+			"status": "resolved",
+			"relation": "same",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F04",
+			"severity": "medium",
+			"category": "risk",
+			"file": "proposal.md",
+			"title": "既存リポジトリへの移行方針と互換性前提が欠けている",
+			"detail": "既存の `CLAUDE.md` カスタマイズ、`specflow-init` 既存導入済み repo、将来の profile schema 変更に対する移行戦略が記載されていない。ここがないと設計で後方互換や versioning が後回しになり、導入時に spec drift が起きやすい。既存ファイルの扱い、generated file の version 管理、手動編集可否、再生成/アップグレード方針を追加すべき。",
+			"origin_round": 1,
+			"latest_round": 2,
+			"status": "resolved",
+			"relation": "same",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F02",
+			"severity": "high",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Context layering model の責務分離と優先順位が未定義",
+			"detail": "global invariants / project profile / phase contract / runtime task / evidence という層名は示されているが、各層に何を保持し、何を参照し、最終 context にどう合成するかが定義されていない。衝突時の優先順位や禁止事項もないため、template 設計・schema 設計・runtime composition が実装ごとに分岐する。各 layer の ownership、参照方法、override 規則を normative に追加すべき。",
+			"origin_round": 1,
+			"latest_round": 2,
+			"status": "resolved",
+			"relation": "reframed",
+			"supersedes": null,
+			"notes": ""
+		}
+	],
+	"round_summaries": [
+		{
+			"round": 1,
+			"total": 4,
+			"open": 4,
+			"new": 4,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"high": 3,
+				"medium": 1
+			}
+		},
+		{
+			"round": 2,
+			"total": 5,
+			"open": 4,
+			"new": 0,
+			"resolved": 1,
+			"overridden": 0,
+			"by_severity": {
+				"high": 2,
+				"medium": 2
+			}
+		},
+		{
+			"round": 3,
+			"total": 8,
+			"open": 4,
+			"new": 2,
+			"resolved": 4,
+			"overridden": 0,
+			"by_severity": {
+				"high": 2,
+				"medium": 2
+			}
+		},
+		{
+			"round": 4,
+			"total": 10,
+			"open": 3,
+			"new": 2,
+			"resolved": 7,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 2,
+				"high": 1
+			}
+		},
+		{
+			"round": 5,
+			"total": 12,
+			"open": 4,
+			"new": 2,
+			"resolved": 8,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 3,
+				"high": 1
+			}
+		},
+		{
+			"round": 6,
+			"total": 14,
+			"open": 3,
+			"new": 1,
+			"resolved": 11,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 2,
+				"high": 1
+			}
+		},
+		{
+			"round": 7,
+			"total": 15,
+			"open": 3,
+			"new": 0,
+			"resolved": 12,
+			"overridden": 0,
+			"by_severity": {
+				"high": 2,
+				"medium": 1
+			}
+		},
+		{
+			"round": 8,
+			"total": 18,
+			"open": 4,
+			"new": 2,
+			"resolved": 14,
+			"overridden": 0,
+			"by_severity": {
+				"medium": 2,
+				"high": 2
+			}
+		}
+	]
 }

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-proposal.json.bak
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger-proposal.json.bak
@@ -1,0 +1,305 @@
+{
+  "feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
+  "phase": "proposal",
+  "current_round": 7,
+  "status": "has_open_high",
+  "max_finding_id": 4,
+  "findings": [
+    {
+      "id": "R6-F01",
+      "severity": "high",
+      "category": "risk",
+      "file": "proposal.md",
+      "title": "Legacy CLAUDE.md migration can leave duplicate conflicting guidance",
+      "detail": "The missing-marker migration path preserves the entire existing CLAUDE.md as unmanaged content and prepends a new managed block. For repos that already contain older generated specflow guidance mixed with manual edits, this can leave stale generated instructions alongside the new managed section, producing duplicated or contradictory agent context. Define a safe migration rule before design starts: either detect and replace legacy generated sections, require explicit user confirmation/manual migration when duplicates would remain, or block auto-migration in that case.",
+      "origin_round": 6,
+      "latest_round": 7,
+      "status": "open",
+      "relation": "same",
+      "supersedes": "R4-F02",
+      "notes": ""
+    },
+    {
+      "id": "R6-F02",
+      "severity": "medium",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "Validation lifecycle for editable profile.json is incomplete",
+      "detail": "The proposal requires schema validation during setup, but .specflow/profile.json is also described as a committed, manually editable shared artifact and is read by other flows such as specflow-init --update and renderer execution. The proposal does not state whether every profile read must validate the schema, or what failure behavior applies for an invalid but version-matching profile outside setup. Add a single validation contract for all profile read/render entry points and define the error path so designs do not diverge.",
+      "origin_round": 6,
+      "latest_round": 7,
+      "status": "open",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F01",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Deterministic diff rules are underspecified for nested and collection fields",
+      "detail": "The rerun flow promises deterministic field-level diff-and-resolve behavior, but the proposal does not define the comparison unit for `commands`, `directories`, or array fields such as `forbiddenEditZones`. It is unclear whether conflicts are resolved per child key, per whole object, or per normalized array entry/order. Specify diff granularity and normalization rules so the update UX and persisted output can be designed consistently.",
+      "origin_round": 5,
+      "latest_round": 7,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R7-F01",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Repository detection and recovery rules are not deterministic",
+      "detail": "The proposal gives examples of in-scope and out-of-scope repositories and lists toolchain detection hints, but it does not define precedence when same-ecosystem signals conflict (for example multiple lockfiles or multiple Python tool indicators), nor when a missing required field is recoverable by user input versus a hard out-of-scope abort. This leaves setup behavior ambiguous and likely to drift across implementations. Define exact detection precedence, conflict-as-error rules, and which failures can be resolved interactively.",
+      "origin_round": 7,
+      "latest_round": 7,
+      "status": "open",
+      "relation": "reframed",
+      "supersedes": "R5-F01",
+      "notes": ""
+    },
+    {
+      "id": "R4-F02",
+      "severity": "medium",
+      "category": "risk",
+      "file": "proposal.md",
+      "title": "Version-mismatch and migration behavior is not defined tightly enough",
+      "detail": "The proposal introduces `schemaVersion`, version checks, auto-rendering after `setup`, and auto-rendering during `specflow-init --update`, but only specifies a warning when profile and template expectations differ. It does not say whether rendering must stop, which command owns migration, what happens to an incompatible existing profile, or how failures are surfaced without corrupting `CLAUDE.md`. This lifecycle needs explicit rules to avoid divergent update behavior.",
+      "origin_round": 4,
+      "latest_round": 6,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F01",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Repository scope conflicts with the proposed schema",
+      "detail": "The proposal says polyglot repos are out of scope, but later explicitly allows a single-root repo with multiple languages such as TypeScript + Python. The schema cannot represent that case cleanly because it has only one `packageManager` and one shared `commands` object. Design cannot proceed safely until this boundary is made consistent. Either keep single-root multi-language repos out of scope, or expand the schema and setup rules to model multiple ecosystems/toolchains explicitly.",
+      "origin_round": 4,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F02",
+      "severity": "medium",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Out-of-scope repository detection has no explicit setup behavior",
+      "detail": "The proposal declares monorepos, multi-workspace repos, and polyglot repos out of scope, but does not say how `setup` should behave when it encounters one of those cases or ambiguous root detection. Design needs an explicit boundary behavior such as hard fail, warning with manual override, or no profile write, otherwise analyzer behavior and user experience will drift.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R3-F03",
+      "severity": "medium",
+      "category": "validation",
+      "file": "proposal.md",
+      "title": "CLAUDE.md preservation rules lack a deterministic managed/unmanaged boundary",
+      "detail": "Migration and rerendering depend on preserving `## MANUAL ADDITIONS` and unknown sections, but the proposal does not define how the renderer identifies managed sections, handles reordered or duplicated headings, or behaves when the existing file no longer matches the expected template structure. Without a stable boundary contract, design and validation will drift. Define explicit markers/anchors or another deterministic parse contract, plus fallback behavior for malformed or heavily customized files.",
+      "origin_round": 3,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Setup と profile 生成の受け入れ条件が設計可能な粒度まで定義されていない",
+      "detail": "`setup` が repository profile を解析・生成するとあるが、初回生成、再実行、既存 `.specflow/profile.json` 更新、検出失敗時、手動修正済み profile の扱いが未定義。schema validation は構造しか保証せず、内容の妥当性や fallback の挙動は決められない。主要シナリオごとに required/optional 項目、unknown の扱い、merge/overwrite ルール、成功条件を acceptance criteria として明記する必要がある。",
+      "origin_round": 1,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R3-F01",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Manual-edit detection and rerun scenarios are not implementable as written",
+      "detail": "The proposal separates rerun behavior into 'manual editsなし' and 'manual editsあり' paths, but it also explicitly avoids storing `_source` metadata and does not define any other provenance mechanism. Comparing the existing profile with fresh analyzer output cannot reliably distinguish user edits from legitimate repository changes. This needs a concrete detection model (for example stored analyzer snapshot/provenance metadata) or the scenarios should be collapsed into one deterministic diff-and-resolve flow.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R2-F01",
+      "notes": ""
+    },
+    {
+      "id": "R3-F02",
+      "severity": "medium",
+      "category": "scope",
+      "file": "proposal.md",
+      "title": "Supported repository shapes are unclear",
+      "detail": "The schema and setup flow appear repo-global, but the proposal uses `languages` as multi-valued while `packageManager` is singular and command fields are singletons. That leaves monorepos, multi-workspace repos, and polyglot repos underspecified. The proposal should either declare an explicit initial boundary (for example single-root repos only) or extend the profile model to represent per-workspace/package-manager data.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F01",
+      "severity": "medium",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Renderer/update lifecycle is not clearly assigned",
+      "detail": "The proposal introduces a Claude adapter that renders from `profile.json`, but the setup scenarios only describe profile generation/update, while distribution is said to stay in the existing `specflow-init` flow. Specify which command regenerates `CLAUDE.md`, when rerendering happens after profile changes, and how stale templates/adapters are detected during migration to avoid split responsibilities in design.",
+      "origin_round": 2,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": "R1-F02",
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "high",
+      "category": "consistency",
+      "file": "proposal.md",
+      "title": "Surface 非依存という目標と `CLAUDE.md` 中心の成果物定義が噛み合っていない",
+      "detail": "提案は agent/surface 非依存の reusable context template を掲げる一方、変更対象は `CLAUDE.md` template とその参照構造に集中している。surface-neutral な中間表現を導入するのか、Claude 向け template を整理するだけなのかが不明で、core/adapter/local surface 境界を設計できない。今回の scope を `surface-neutral model + Claude renderer` か `Claude surface 限定` のどちらかで明示する必要がある。",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "risk",
+      "file": "proposal.md",
+      "title": "既存リポジトリへの移行方針と互換性前提が欠けている",
+      "detail": "既存の `CLAUDE.md` カスタマイズ、`specflow-init` 既存導入済み repo、将来の profile schema 変更に対する移行戦略が記載されていない。ここがないと設計で後方互換や versioning が後回しになり、導入時に spec drift が起きやすい。既存ファイルの扱い、generated file の version 管理、手動編集可否、再生成/アップグレード方針を追加すべき。",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Context layering model の責務分離と優先順位が未定義",
+      "detail": "global invariants / project profile / phase contract / runtime task / evidence という層名は示されているが、各層に何を保持し、何を参照し、最終 context にどう合成するかが定義されていない。衝突時の優先順位や禁止事項もないため、template 設計・schema 設計・runtime composition が実装ごとに分岐する。各 layer の ownership、参照方法、override 規則を normative に追加すべき。",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "reframed",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 4,
+      "open": 4,
+      "new": 4,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 5,
+      "open": 4,
+      "new": 0,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 4,
+      "new": 2,
+      "resolved": 4,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 2
+      }
+    },
+    {
+      "round": 4,
+      "total": 10,
+      "open": 3,
+      "new": 2,
+      "resolved": 7,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 1
+      }
+    },
+    {
+      "round": 5,
+      "total": 12,
+      "open": 4,
+      "new": 2,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 3,
+        "high": 1
+      }
+    },
+    {
+      "round": 6,
+      "total": 14,
+      "open": 3,
+      "new": 1,
+      "resolved": 11,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 1
+      }
+    },
+    {
+      "round": 7,
+      "total": 15,
+      "open": 3,
+      "new": 0,
+      "resolved": 12,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger.json
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger.json
@@ -1,79 +1,79 @@
 {
-  "feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
-  "phase": "impl",
-  "current_round": 1,
-  "status": "has_open_high",
-  "max_finding_id": 4,
-  "findings": [
-    {
-      "id": "R1-F01",
-      "severity": "high",
-      "category": "correctness",
-      "file": "src/bin/specflow-init.ts",
-      "title": "Invalid profile reads are downgraded to warnings instead of aborting",
-      "detail": "When `.specflow/profile.json` exists and `readProfileStrict()` fails, the new branch at `runUpdateMode()` only logs a warning and then continues to a successful exit. The spec requires every profile read entry point to abort on schema/version errors and tell the user to rerun setup; continuing here can leave the repo partially updated while hiding a broken shared artifact. Treat strict-read failure as a hard error once the profile file exists.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F02",
-      "severity": "high",
-      "category": "completeness",
-      "file": "src/bin/specflow-init.ts",
-      "title": "The diff references new profile/renderer modules but does not actually ship them",
-      "detail": "This change adds imports and behavior for `profile-schema`/`claude-renderer` (`src/bin/specflow-init.ts`, and `src/lib/schemas.ts` also imports `profile-schema`), but those new core/adapter files are not part of the reviewed git diff. The proposal explicitly requires new profile-schema, renderer, and context-layering support; as submitted, the diff does not actually deliver that implementation. Add the new files to the change and ensure they are included in build/package outputs.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F03",
-      "severity": "medium",
-      "category": "testing",
-      "file": "src/tests/utility-cli.test.ts",
-      "title": "No tests cover the new profile-driven update behavior",
-      "detail": "The existing `specflow-init --update` test still only asserts slash-command and `.mcp.json` refresh. There is no coverage for valid-profile re-rendering, invalid-profile aborts, legacy `CLAUDE.md` confirmation flow, or the no-profile skip path introduced by this diff. Add CLI and/or unit tests for the new `readProfileStrict` + renderer integration before merging.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    },
-    {
-      "id": "R1-F04",
-      "severity": "medium",
-      "category": "scope",
-      "file": "CLAUDE.md",
-      "title": "Repository CLAUDE.md is rewritten outside the managed migration contract",
-      "detail": "The spec requires marker-based managed/unmanaged boundaries and legacy-file preservation via the renderer with confirmation. This diff directly replaces the repo's tracked `CLAUDE.md` with an unmarked static fragment, dropping the previous sections instead of migrating them through the new adapter flow. Either remove this repo-local file rewrite or regenerate it through the renderer so it matches the contract.",
-      "origin_round": 1,
-      "latest_round": 1,
-      "status": "new",
-      "relation": "new",
-      "supersedes": null,
-      "notes": ""
-    }
-  ],
-  "round_summaries": [
-    {
-      "round": 1,
-      "total": 4,
-      "open": 4,
-      "new": 4,
-      "resolved": 0,
-      "overridden": 0,
-      "by_severity": {
-        "high": 2,
-        "medium": 2
-      }
-    }
-  ]
+	"feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
+	"phase": "impl",
+	"current_round": 1,
+	"status": "has_open_high",
+	"max_finding_id": 4,
+	"findings": [
+		{
+			"id": "R1-F01",
+			"severity": "high",
+			"category": "correctness",
+			"file": "src/bin/specflow-init.ts",
+			"title": "Invalid profile reads are downgraded to warnings instead of aborting",
+			"detail": "When `.specflow/profile.json` exists and `readProfileStrict()` fails, the new branch at `runUpdateMode()` only logs a warning and then continues to a successful exit. The spec requires every profile read entry point to abort on schema/version errors and tell the user to rerun setup; continuing here can leave the repo partially updated while hiding a broken shared artifact. Treat strict-read failure as a hard error once the profile file exists.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F02",
+			"severity": "high",
+			"category": "completeness",
+			"file": "src/bin/specflow-init.ts",
+			"title": "The diff references new profile/renderer modules but does not actually ship them",
+			"detail": "This change adds imports and behavior for `profile-schema`/`claude-renderer` (`src/bin/specflow-init.ts`, and `src/lib/schemas.ts` also imports `profile-schema`), but those new core/adapter files are not part of the reviewed git diff. The proposal explicitly requires new profile-schema, renderer, and context-layering support; as submitted, the diff does not actually deliver that implementation. Add the new files to the change and ensure they are included in build/package outputs.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F03",
+			"severity": "medium",
+			"category": "testing",
+			"file": "src/tests/utility-cli.test.ts",
+			"title": "No tests cover the new profile-driven update behavior",
+			"detail": "The existing `specflow-init --update` test still only asserts slash-command and `.mcp.json` refresh. There is no coverage for valid-profile re-rendering, invalid-profile aborts, legacy `CLAUDE.md` confirmation flow, or the no-profile skip path introduced by this diff. Add CLI and/or unit tests for the new `readProfileStrict` + renderer integration before merging.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F04",
+			"severity": "medium",
+			"category": "scope",
+			"file": "CLAUDE.md",
+			"title": "Repository CLAUDE.md is rewritten outside the managed migration contract",
+			"detail": "The spec requires marker-based managed/unmanaged boundaries and legacy-file preservation via the renderer with confirmation. This diff directly replaces the repo's tracked `CLAUDE.md` with an unmarked static fragment, dropping the previous sections instead of migrating them through the new adapter flow. Either remove this repo-local file rewrite or regenerate it through the renderer so it matches the contract.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		}
+	],
+	"round_summaries": [
+		{
+			"round": 1,
+			"total": 4,
+			"open": 4,
+			"new": 4,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"high": 2,
+				"medium": 2
+			}
+		}
+	]
 }

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger.json
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/review-ledger.json
@@ -1,0 +1,79 @@
+{
+  "feature_id": "define-reusable-agent-context-template-and-repo-setup-generator",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 4,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-init.ts",
+      "title": "Invalid profile reads are downgraded to warnings instead of aborting",
+      "detail": "When `.specflow/profile.json` exists and `readProfileStrict()` fails, the new branch at `runUpdateMode()` only logs a warning and then continues to a successful exit. The spec requires every profile read entry point to abort on schema/version errors and tell the user to rerun setup; continuing here can leave the repo partially updated while hiding a broken shared artifact. Treat strict-read failure as a hard error once the profile file exists.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/bin/specflow-init.ts",
+      "title": "The diff references new profile/renderer modules but does not actually ship them",
+      "detail": "This change adds imports and behavior for `profile-schema`/`claude-renderer` (`src/bin/specflow-init.ts`, and `src/lib/schemas.ts` also imports `profile-schema`), but those new core/adapter files are not part of the reviewed git diff. The proposal explicitly requires new profile-schema, renderer, and context-layering support; as submitted, the diff does not actually deliver that implementation. Add the new files to the change and ensure they are included in build/package outputs.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/tests/utility-cli.test.ts",
+      "title": "No tests cover the new profile-driven update behavior",
+      "detail": "The existing `specflow-init --update` test still only asserts slash-command and `.mcp.json` refresh. There is no coverage for valid-profile re-rendering, invalid-profile aborts, legacy `CLAUDE.md` confirmation flow, or the no-profile skip path introduced by this diff. Add CLI and/or unit tests for the new `readProfileStrict` + renderer integration before merging.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "scope",
+      "file": "CLAUDE.md",
+      "title": "Repository CLAUDE.md is rewritten outside the managed migration contract",
+      "detail": "The spec requires marker-based managed/unmanaged boundaries and legacy-file preservation via the renderer with confirmation. This diff directly replaces the repo's tracked `CLAUDE.md` with an unmarked static fragment, dropping the previous sections instead of migrating them through the new adapter flow. Either remove this repo-local file rewrite or regenerate it through the renderer so it matches the contract.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 4,
+      "open": 4,
+      "new": 4,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/specs/agent-context-template/spec.md
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/specs/agent-context-template/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: Context layering model defines five distinct layers with ownership and conflict resolution
+
+The system SHALL define a context layering model with five layers, each with a designated owner, persistence location, and editability constraint.
+
+#### Scenario: Layer definitions are complete and non-overlapping
+
+- **WHEN** the context layering model is evaluated
+- **THEN** the following layers SHALL be defined:
+  - Layer 1: Global Invariants (owned by specflow core, immutable, embedded in template)
+  - Layer 2: Project Profile (owned by `setup`, persisted in `.specflow/profile.json`, manually editable)
+  - Layer 3: Phase/Workflow Contract (owned by command prompt, embedded in command body, immutable source)
+  - Layer 4: Runtime Task Instance (owned by workflow runtime, volatile)
+  - Layer 5: Evidence Context (owned by review/apply runtime, volatile)
+
+#### Scenario: Conflict resolution follows defined priority
+
+- **WHEN** two layers provide conflicting values for the same key
+- **THEN** the system SHALL resolve conflicts using priority: Layer 1 > Layer 3 > Layer 2 > Layer 4 > Layer 5
+
+#### Scenario: Layers use independent namespaces to minimize conflicts
+
+- **WHEN** layers are composed into effective context
+- **THEN** each layer SHALL use its own namespace and Layer 4-5 SHALL add data rather than override existing layers
+
+### Requirement: Profile schema defines a closed, versioned JSON contract
+
+The system SHALL define a `.specflow/profile.json` schema with required and optional fields, closed nested objects, and monotonic version tracking.
+
+#### Scenario: Required fields are always present and non-null
+
+- **WHEN** a valid profile is evaluated
+- **THEN** `schemaVersion` (string), `languages` (string[], exactly 1 in v1), and `toolchain` (string) SHALL be non-null and present
+
+#### Scenario: Optional nested objects are always present with nullable children
+
+- **WHEN** a valid profile is evaluated
+- **THEN** `commands` and `directories` objects SHALL always be present (never null)
+- **AND** their child fields SHALL individually be `string | null` or `string[] | null`
+
+#### Scenario: Optional array fields use null for undetected and empty array for none-applicable
+
+- **WHEN** an optional array field (e.g., `forbiddenEditZones`) was not detected
+- **THEN** its value SHALL be `null`
+- **WHEN** the field was detected but no items apply
+- **THEN** its value SHALL be `[]`
+
+#### Scenario: Schema objects reject unknown keys
+
+- **WHEN** a profile contains a key not defined in the schema (within `commands` or `directories`)
+- **THEN** schema validation SHALL report an error
+- **AND** the profile SHALL be considered invalid
+
+#### Scenario: Schema version uses monotonic integer strings
+
+- **WHEN** a non-backwards-compatible schema change is introduced
+- **THEN** `schemaVersion` SHALL be incremented (e.g., "1" to "2")
+- **AND** all profile readers SHALL validate the version before processing
+
+### Requirement: Surface architecture separates core model from surface-specific adapters
+
+The system SHALL separate the context layering model and profile schema (core) from surface-specific rendering (adapter), with a clear boundary.
+
+#### Scenario: Core components are surface-neutral
+
+- **WHEN** the context layering model, profile schema, or setup analyzer is evaluated
+- **THEN** it SHALL contain no references to specific agent surfaces (Claude, Cursor, etc.)
+
+#### Scenario: Claude adapter renders CLAUDE.md from profile and template
+
+- **WHEN** the Claude adapter renders output
+- **THEN** it SHALL read `.specflow/profile.json` and compose a CLAUDE.md file using managed/unmanaged markers
+
+#### Scenario: Future adapters can be added without modifying core
+
+- **WHEN** a new surface adapter is introduced (e.g., Cursor `.cursorrules` renderer)
+- **THEN** it SHALL only depend on the core profile schema and layering model
+- **AND** no changes to core SHALL be required
+
+### Requirement: CLAUDE.md uses marker-based managed/unmanaged boundary
+
+The Claude adapter SHALL use HTML comment markers to distinguish managed content (rendered from profile) from unmanaged content (user-authored).
+
+#### Scenario: Managed content is enclosed in markers
+
+- **WHEN** the adapter renders CLAUDE.md
+- **THEN** rendered content SHALL be enclosed between `<!-- specflow:managed:start -->` and `<!-- specflow:managed:end -->` markers
+
+#### Scenario: Unmanaged content is never modified by the adapter
+
+- **WHEN** the adapter renders CLAUDE.md
+- **THEN** content outside the managed markers SHALL not be modified
+
+#### Scenario: Legacy CLAUDE.md without markers preserves all existing content
+
+- **WHEN** the adapter encounters a CLAUDE.md without managed markers
+- **THEN** it SHALL insert the managed block at the top of the file
+- **AND** it SHALL preserve the entire existing file content as unmanaged content after the managed block
+- **AND** it SHALL display a warning about potential duplicates and require user confirmation
+
+#### Scenario: Marker anomalies trigger safe abort
+
+- **WHEN** the adapter encounters malformed markers (missing start/end, duplicates, wrong order)
+- **THEN** it SHALL abort rendering without modifying CLAUDE.md
+- **AND** it SHALL display an error describing the anomaly
+
+### Requirement: Profile validation is enforced at every read entry point
+
+Every component that reads `.specflow/profile.json` SHALL validate the schema before processing.
+
+#### Scenario: Valid profile passes and processing continues
+
+- **WHEN** a component reads a profile that passes schema validation
+- **THEN** processing SHALL continue normally
+
+#### Scenario: Invalid profile causes processing to abort
+
+- **WHEN** a component reads a profile that fails schema validation
+- **THEN** the component SHALL abort processing
+- **AND** it SHALL display the validation errors and suggest running `setup`
+
+#### Scenario: Version mismatch between profile and template stops rendering
+
+- **WHEN** profile `schemaVersion` is less than the template's expected version
+- **THEN** rendering SHALL stop and the system SHALL prompt the user to run `setup`
+- **WHEN** profile `schemaVersion` is greater than the template's expected version
+- **THEN** rendering SHALL stop and the system SHALL prompt the user to run `specflow-init --update`

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/specs/project-bootstrap-installation/spec.md
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/specs/project-bootstrap-installation/spec.md
@@ -1,30 +1,4 @@
-# project-bootstrap-installation Specification
-
-## Purpose
-
-Describe how `specflow` initializes a project and installs the packaged runtime
-bundle into a user environment.
-## Requirements
-### Requirement: `specflow-init` bootstraps a project root and OpenSpec context
-
-`specflow-init` SHALL initialize a project root, gather the selected agents, and
-prepare the local OpenSpec and specflow configuration files.
-
-#### Scenario: No-argument init targets the current git repository root
-
-- **WHEN** `specflow-init` is invoked without arguments inside a git repository
-- **THEN** it SHALL use the repository root as the target path
-
-#### Scenario: Init creates a repository when the target is not already one
-
-- **WHEN** the target directory is not an initialized git repository
-- **THEN** `specflow-init` SHALL run `git init`
-
-#### Scenario: OpenSpec init injects project context when config exists
-
-- **WHEN** `openspec init` succeeds during `specflow-init`
-- **THEN** the command SHALL add `Project: <project name>` to
-  `openspec/config.yaml` if the file does not already contain a `context:` entry
+## MODIFIED Requirements
 
 ### Requirement: `specflow-init` writes local project scaffolding and ignore rules
 
@@ -81,31 +55,7 @@ installed slash commands and template-backed project files. When a valid profile
 - **AND** `.specflow/profile.json` does not exist
 - **THEN** update mode SHALL skip adapter rendering and display a suggestion to run `setup`
 
-### Requirement: `specflow-install` deploys the packaged runtime bundle from the manifest and install plan
-
-`specflow-install` SHALL use `dist/install-plan.json` and `dist/manifest.json`
-to copy runtime assets, install slash-command markdown, and expose CLI links.
-
-#### Scenario: Install copies packaged runtime directories
-
-- **WHEN** `specflow-install` runs
-- **THEN** it SHALL copy the packaged template directory and the packaged
-  `global/prompts`, `global/workflow`, `global/commands`, and
-  `global/claude-settings.json` trees into `$HOME/.config/specflow/`
-
-#### Scenario: Install symlinks each published CLI
-
-- **WHEN** `specflow-install` runs
-- **THEN** it SHALL create symlinks for every orchestrator-defined CLI in
-  `$HOME/bin/`
-- **AND** it SHALL remove stale `specflow*` symlinks that are no longer expected
-
-#### Scenario: Install publishes slash commands and merges Claude permissions
-
-- **WHEN** `specflow-install` runs
-- **THEN** it SHALL copy generated command markdown into `$HOME/.claude/commands`
-- **AND** it SHALL merge the packaged Claude permission allow-list into
-  `$HOME/.claude/settings.json` without dropping existing entries
+## ADDED Requirements
 
 ### Requirement: `setup` command analyzes the repository and generates a structured profile
 
@@ -197,4 +147,3 @@ When `setup` encounters a profile with an older `schemaVersion`, it SHALL migrat
 - **WHEN** `setup` reads a profile with `schemaVersion` less than the current expected version
 - **THEN** it SHALL transform the profile to the new schema format
 - **AND** it SHALL present the migration changes to the user for confirmation before writing
-

--- a/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/tasks.md
+++ b/openspec/changes/archive/2026-04-11-define-reusable-agent-context-template-and-repo-setup-generator/tasks.md
@@ -1,0 +1,75 @@
+## 1. Profile Schema & Validation
+
+- [x] 1.1 Create `src/lib/profile-schema.ts` with TypeScript types for profile (ProfileSchema, ProfileCommands, ProfileDirectories)
+- [x] 1.2 Add `schemaVersion` constant (`CURRENT_PROFILE_SCHEMA_VERSION = "1"`), version comparison utilities, and raw `schemaVersion` sniff helper
+- [x] 1.3 Add profile validator to `src/lib/schemas.ts` following existing `validateSchemaValue()` pattern — enforce closed objects, required/optional field rules, nullability rules
+- [x] 1.4 Add profile load/write utilities in `profile-schema.ts`: `loadProfileForSetup()` for raw read -> minimal object guard -> schemaVersion sniff -> migrate older -> validate current schema -> continue, and `readProfileStrict()` for raw read -> minimal object guard -> schemaVersion sniff -> older/newer mismatch abort with remediation -> validate current schema -> continue; do not validate a stale pre-migration payload against the current schema
+- [x] 1.5 Implement migration helpers for older profile versions and strict-abort behavior for newer-version profiles
+- [x] 1.6 Write unit tests for profile schema validation and load paths — valid profile, missing required fields, unknown keys in closed objects, null vs empty array semantics, outdated-profile rerun migration, and strict reader / render-update behavior on older/newer versions
+
+## 2. Agent Context Core Contract
+
+- [x] 2.1 Create `src/lib/agent-context-template.ts` with canonical five-layer definitions, ownership/persistence metadata, namespace identifiers, layer-to-artifact mapping, and precedence constants
+- [x] 2.2 Add adapter-facing types/helpers that surfaces and runtime injectors consume without Claude-specific wording (layer descriptors, priority comparator, adapter input envelope, resolved envelope helper for all five layer namespaces); adapters must import this core contract instead of re-encoding precedence or namespace rules
+- [x] 2.3 Write unit tests for namespace separation, full five-namespace envelope resolution, and conflict resolution priority (Layer 1 > 3 > 2 > 4 > 5)
+
+## 3. Ecosystem Detection
+
+- [x] 3.1 Create `src/lib/ecosystem-detector.ts` with `detectEcosystem()` function implementing the priority-based detection matrix
+- [x] 3.2 Implement primary indicator scanning (package.json, Cargo.toml, go.mod, pyproject.toml)
+- [x] 3.3 Implement conflict detection (multiple ecosystems, workspace definitions, no indicators)
+- [x] 3.4 Implement toolchain resolution from lockfiles (npm/pnpm/yarn/bun, cargo, go, pip/poetry/uv)
+- [x] 3.5 Implement command detection from package.json scripts, Makefile, pyproject.toml tool sections
+- [x] 3.6 Implement directory detection (source, test, generated directories)
+- [x] 3.7 Write unit tests for ecosystem detection — single-root JS repo, Rust repo, Python repo, multi-ecosystem conflict, workspace detection, ambiguous toolchain
+
+## 4. Profile Diff & Rerun
+
+- [x] 4.1 Create `src/lib/profile-diff.ts` with `diffProfiles()` function implementing field-level comparison
+- [x] 4.2 Implement diff rules: equal (no change), both non-null different (conflict), null->value (proposal), value->null (preserve)
+- [x] 4.3 Implement diff flattening for nested objects (commands child keys, directories child keys) and array normalization
+- [x] 4.4 Write unit tests for profile diff — no changes, field conflict, new detection, lost detection, nested object diff
+
+## 5. Claude Adapter Renderer
+
+- [x] 5.1 Create `src/lib/claude-renderer.ts` with managed/unmanaged marker parser and structured render result types including `warning`, `diffPreview`, and `writeDisposition`
+- [x] 5.2 Implement `parseClaudeMd()` — extract managed block, unmanaged content, and detect marker anomalies (missing, duplicate, wrong order)
+- [x] 5.3 Implement `renderManagedBlock()` using the shared agent context contract and generate managed Layer 1-2 content
+- [x] 5.4 Implement `renderClaudeMd()` — compose final CLAUDE.md and return proposed content, warnings, diff preview, and `writeDisposition` (`safe-write` / `confirmation-required` / `abort`)
+- [x] 5.5 Implement legacy migration planning — detect marker-less CLAUDE.md, prepend managed block, preserve existing content as unmanaged, and mark the result as `confirmation-required`
+- [x] 5.6 Implement version mismatch detection — compare profile schemaVersion with template expected version and abort on mismatch for strict render callers
+- [x] 5.7 Write unit tests for renderer — new file, existing with markers, legacy without markers, marker anomalies, version mismatch, and `safe-write` / `confirmation-required` / `abort` result handling
+
+## 6. Template & Contract Updates
+
+- [x] 6.1 Update `assets/template/CLAUDE.md` to v2 format with managed markers and profile reference slot
+- [x] 6.2 Update `src/contracts/templates.ts` — update `template-claude-md` contract sourcePath if needed
+- [x] 6.3 Verify `src/lib/project-gitignore.ts` does not add `.specflow/profile.json` to gitignore
+- [x] 6.4 Update shared exports or contract wiring so future surfaces and runtime injectors can depend on `agent-context-template.ts` instead of Claude-specific helpers
+- [x] 6.5 Add `template-profile-schema` contract if profile schema needs to be distributed as a template asset
+
+## 7. Setup Command Body Rewrite
+
+- [x] 7.1 Rewrite `specflow.setup` sections in `src/contracts/command-bodies.ts` — Step 1: Scope & Ecosystem Detection
+- [x] 7.2 Add Step 2: Profile Load / Migration / Diff-and-Resolve using `loadProfileForSetup()` (raw read -> schemaVersion sniff -> migrate older -> diff current object)
+- [x] 7.3 Add Step 3: Schema Validation & Profile Write for the migrated/resolved current-schema object only
+- [x] 7.4 Add Step 4: Claude Adapter Render Planning and `RenderResult` handling (`warning`, `diffPreview`, `writeDisposition`)
+- [x] 7.5 Add Step 5: `CLAUDE.md` warning/diff/confirmation gate before write; show renderer-provided warning + diff preview, only `safe-write` may auto-apply, `confirmation-required` must prompt for explicit accept/reject, `abort` must leave the file unchanged
+- [x] 7.6 Add Important Rules section (validation-first, no silent guess, setup-only migration, user confirmation required)
+- [x] 7.7 Write setup flow tests for first run, rerun with outdated profile, and legacy `CLAUDE.md` reject/accept paths
+
+## 8. Init/Update Integration
+
+- [x] 8.1 Add profile existence check and skip-with-suggestion when profile is missing during `--update`
+- [x] 8.2 Use `readProfileStrict()` during `--update` and non-setup renderer entrypoints so older/newer schema versions abort with remediation text instead of migrating implicitly
+- [x] 8.3 Update `src/bin/specflow-init.ts` `--update` flow to trigger Claude adapter rendering when a strict-read current profile exists
+- [x] 8.4 Add legacy `CLAUDE.md` warning/diff/confirmation gate to `--update`; show renderer-provided warning + diff preview and leave the file unchanged on reject
+- [x] 8.5 Write update-flow tests for older/newer profile version aborts and rejected/confirmed legacy migration write
+
+## 9. Build & Verification
+
+- [x] 9.1 Run `npm run build` and fix any TypeScript compilation errors
+- [x] 9.2 Run `npm run lint` and fix formatting issues
+- [x] 9.3 Run `npm test` and ensure all existing tests pass
+- [x] 9.4 Run `npm run check` (if exists) for type checking
+- [x] 9.5 Manually test setup flow on this repository (specflow dogfooding)

--- a/openspec/specs/agent-context-template/spec.md
+++ b/openspec/specs/agent-context-template/spec.md
@@ -1,0 +1,132 @@
+# agent-context-template Specification
+
+## Purpose
+TBD - created by archiving change define-reusable-agent-context-template-and-repo-setup-generator. Update Purpose after archive.
+## Requirements
+### Requirement: Context layering model defines five distinct layers with ownership and conflict resolution
+
+The system SHALL define a context layering model with five layers, each with a designated owner, persistence location, and editability constraint.
+
+#### Scenario: Layer definitions are complete and non-overlapping
+
+- **WHEN** the context layering model is evaluated
+- **THEN** the following layers SHALL be defined:
+  - Layer 1: Global Invariants (owned by specflow core, immutable, embedded in template)
+  - Layer 2: Project Profile (owned by `setup`, persisted in `.specflow/profile.json`, manually editable)
+  - Layer 3: Phase/Workflow Contract (owned by command prompt, embedded in command body, immutable source)
+  - Layer 4: Runtime Task Instance (owned by workflow runtime, volatile)
+  - Layer 5: Evidence Context (owned by review/apply runtime, volatile)
+
+#### Scenario: Conflict resolution follows defined priority
+
+- **WHEN** two layers provide conflicting values for the same key
+- **THEN** the system SHALL resolve conflicts using priority: Layer 1 > Layer 3 > Layer 2 > Layer 4 > Layer 5
+
+#### Scenario: Layers use independent namespaces to minimize conflicts
+
+- **WHEN** layers are composed into effective context
+- **THEN** each layer SHALL use its own namespace and Layer 4-5 SHALL add data rather than override existing layers
+
+### Requirement: Profile schema defines a closed, versioned JSON contract
+
+The system SHALL define a `.specflow/profile.json` schema with required and optional fields, closed nested objects, and monotonic version tracking.
+
+#### Scenario: Required fields are always present and non-null
+
+- **WHEN** a valid profile is evaluated
+- **THEN** `schemaVersion` (string), `languages` (string[], exactly 1 in v1), and `toolchain` (string) SHALL be non-null and present
+
+#### Scenario: Optional nested objects are always present with nullable children
+
+- **WHEN** a valid profile is evaluated
+- **THEN** `commands` and `directories` objects SHALL always be present (never null)
+- **AND** their child fields SHALL individually be `string | null` or `string[] | null`
+
+#### Scenario: Optional array fields use null for undetected and empty array for none-applicable
+
+- **WHEN** an optional array field (e.g., `forbiddenEditZones`) was not detected
+- **THEN** its value SHALL be `null`
+- **WHEN** the field was detected but no items apply
+- **THEN** its value SHALL be `[]`
+
+#### Scenario: Schema objects reject unknown keys
+
+- **WHEN** a profile contains a key not defined in the schema (within `commands` or `directories`)
+- **THEN** schema validation SHALL report an error
+- **AND** the profile SHALL be considered invalid
+
+#### Scenario: Schema version uses monotonic integer strings
+
+- **WHEN** a non-backwards-compatible schema change is introduced
+- **THEN** `schemaVersion` SHALL be incremented (e.g., "1" to "2")
+- **AND** all profile readers SHALL validate the version before processing
+
+### Requirement: Surface architecture separates core model from surface-specific adapters
+
+The system SHALL separate the context layering model and profile schema (core) from surface-specific rendering (adapter), with a clear boundary.
+
+#### Scenario: Core components are surface-neutral
+
+- **WHEN** the context layering model, profile schema, or setup analyzer is evaluated
+- **THEN** it SHALL contain no references to specific agent surfaces (Claude, Cursor, etc.)
+
+#### Scenario: Claude adapter renders CLAUDE.md from profile and template
+
+- **WHEN** the Claude adapter renders output
+- **THEN** it SHALL read `.specflow/profile.json` and compose a CLAUDE.md file using managed/unmanaged markers
+
+#### Scenario: Future adapters can be added without modifying core
+
+- **WHEN** a new surface adapter is introduced (e.g., Cursor `.cursorrules` renderer)
+- **THEN** it SHALL only depend on the core profile schema and layering model
+- **AND** no changes to core SHALL be required
+
+### Requirement: CLAUDE.md uses marker-based managed/unmanaged boundary
+
+The Claude adapter SHALL use HTML comment markers to distinguish managed content (rendered from profile) from unmanaged content (user-authored).
+
+#### Scenario: Managed content is enclosed in markers
+
+- **WHEN** the adapter renders CLAUDE.md
+- **THEN** rendered content SHALL be enclosed between `<!-- specflow:managed:start -->` and `<!-- specflow:managed:end -->` markers
+
+#### Scenario: Unmanaged content is never modified by the adapter
+
+- **WHEN** the adapter renders CLAUDE.md
+- **THEN** content outside the managed markers SHALL not be modified
+
+#### Scenario: Legacy CLAUDE.md without markers preserves all existing content
+
+- **WHEN** the adapter encounters a CLAUDE.md without managed markers
+- **THEN** it SHALL insert the managed block at the top of the file
+- **AND** it SHALL preserve the entire existing file content as unmanaged content after the managed block
+- **AND** it SHALL display a warning about potential duplicates and require user confirmation
+
+#### Scenario: Marker anomalies trigger safe abort
+
+- **WHEN** the adapter encounters malformed markers (missing start/end, duplicates, wrong order)
+- **THEN** it SHALL abort rendering without modifying CLAUDE.md
+- **AND** it SHALL display an error describing the anomaly
+
+### Requirement: Profile validation is enforced at every read entry point
+
+Every component that reads `.specflow/profile.json` SHALL validate the schema before processing.
+
+#### Scenario: Valid profile passes and processing continues
+
+- **WHEN** a component reads a profile that passes schema validation
+- **THEN** processing SHALL continue normally
+
+#### Scenario: Invalid profile causes processing to abort
+
+- **WHEN** a component reads a profile that fails schema validation
+- **THEN** the component SHALL abort processing
+- **AND** it SHALL display the validation errors and suggest running `setup`
+
+#### Scenario: Version mismatch between profile and template stops rendering
+
+- **WHEN** profile `schemaVersion` is less than the template's expected version
+- **THEN** rendering SHALL stop and the system SHALL prompt the user to run `setup`
+- **WHEN** profile `schemaVersion` is greater than the template's expected version
+- **THEN** rendering SHALL stop and the system SHALL prompt the user to run `specflow-init --update`
+

--- a/src/bin/specflow-init.ts
+++ b/src/bin/specflow-init.ts
@@ -2,25 +2,27 @@ import {
 	copyFileSync,
 	existsSync,
 	mkdirSync,
-	readFileSync,
 	readdirSync,
+	readFileSync,
 	writeFileSync,
 } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
-import readline from "node:readline/promises";
 import { stdin as input } from "node:process";
-import type { InitProjectResult, Manifest } from "../types/contracts.js";
+import readline from "node:readline/promises";
+import { renderClaudeMdStrict } from "../lib/claude-renderer.js";
+import { tryGit } from "../lib/git.js";
 import {
 	moduleRepoRoot,
 	printSchemaJson,
 	resolveCommand,
 	tryExec,
 } from "../lib/process.js";
-import { tryGit } from "../lib/git.js";
+import { readProfileStrict } from "../lib/profile-schema.js";
 import {
 	mergeProjectGitignore,
 	renderProjectGitignore,
 } from "../lib/project-gitignore.js";
+import type { InitProjectResult, Manifest } from "../types/contracts.js";
 
 const CONFIG_DIR = resolve(process.env.HOME ?? "", ".config/specflow");
 const MAIN_AGENTS = ["claude"];
@@ -194,6 +196,126 @@ function verifyPrompts(globalDir: string, warnings: string[]): void {
 	log(`Verified ${count} prompt(s) in ${promptsDir}/`);
 }
 
+function recordClaudeWrite(
+	existedBeforeWrite: boolean,
+	createdFiles: string[],
+	updatedFiles: string[],
+	label: string,
+): void {
+	if (existedBeforeWrite) {
+		updatedFiles.push(label);
+		return;
+	}
+	createdFiles.push(label);
+}
+
+async function updateClaudeTemplateOnly(
+	templateClaude: string,
+	createdFiles: string[],
+	updatedFiles: string[],
+): Promise<void> {
+	if (!existsSync(templateClaude)) {
+		return;
+	}
+
+	if (!existsSync("CLAUDE.md")) {
+		copyFileSync(templateClaude, "CLAUDE.md");
+		createdFiles.push("CLAUDE.md");
+		log("Created CLAUDE.md");
+		return;
+	}
+
+	if (
+		readFileSync(templateClaude, "utf8") === readFileSync("CLAUDE.md", "utf8")
+	) {
+		log("CLAUDE.md is up to date");
+		return;
+	}
+
+	log("CLAUDE.md differs from the template:");
+	const diff = tryExec(
+		"diff",
+		["-u", "CLAUDE.md", templateClaude],
+		process.cwd(),
+	);
+	const preview = diff.stdout.split("\n").slice(0, 40).join("\n");
+	if (preview.trim()) {
+		process.stderr.write(`${preview}\n\n`);
+	}
+	const rl = readline.createInterface({ input, output: process.stderr });
+	const overwrite = await promptYesNo(
+		rl,
+		"Overwrite CLAUDE.md with template? (your changes will be lost)",
+		"n",
+	);
+	rl.close();
+	if (overwrite === "y") {
+		copyFileSync(templateClaude, "CLAUDE.md");
+		updatedFiles.push("CLAUDE.md");
+		log("Updated CLAUDE.md");
+		return;
+	}
+	log("Skipped CLAUDE.md");
+}
+
+async function updateClaudeFromProfile(
+	profilePath: string,
+	createdFiles: string[],
+	updatedFiles: string[],
+): Promise<void> {
+	const profileResult = readProfileStrict(profilePath);
+	if ("error" in profileResult) {
+		die(
+			`Error: ${profileResult.error}\nRun 'specflow.setup' to fix the profile.`,
+		);
+	}
+
+	const claudeExists = existsSync("CLAUDE.md");
+	const claudeContent = claudeExists ? readFileSync("CLAUDE.md", "utf8") : null;
+	const renderResult = renderClaudeMdStrict(
+		profileResult.profile,
+		claudeContent,
+	);
+
+	if (renderResult.writeDisposition === "abort") {
+		die(
+			renderResult.warning
+				? `Error: ${renderResult.warning}`
+				: "Error: CLAUDE.md rendering aborted due to marker/version issue.",
+		);
+	}
+
+	if (renderResult.warning) {
+		log(`Warning: ${renderResult.warning}`);
+	}
+	if (renderResult.diffPreview) {
+		process.stderr.write(`${renderResult.diffPreview}\n\n`);
+	}
+
+	if (renderResult.writeDisposition === "confirmation-required") {
+		const rl = readline.createInterface({ input, output: process.stderr });
+		const accept = await promptYesNo(
+			rl,
+			"Apply profile-rendered CLAUDE.md changes?",
+			"n",
+		);
+		rl.close();
+		if (accept !== "y") {
+			log("Skipped profile-based CLAUDE.md rendering");
+			return;
+		}
+	}
+
+	writeFileSync("CLAUDE.md", renderResult.nextContent, "utf8");
+	recordClaudeWrite(
+		claudeExists,
+		createdFiles,
+		updatedFiles,
+		"CLAUDE.md (profile-rendered)",
+	);
+	log("Rendered CLAUDE.md from profile");
+}
+
 async function runUpdateMode(runtimeRoot: string): Promise<never> {
 	const updateRoot =
 		tryGit(["rev-parse", "--show-toplevel"], process.cwd()).stdout.trim() ||
@@ -228,42 +350,15 @@ async function runUpdateMode(runtimeRoot: string): Promise<never> {
 		log("Warning: template/.mcp.json not found, skipping");
 	}
 
+	const profilePath = resolve(updateRoot, ".specflow/profile.json");
 	const templateClaude = resolve(templateDir, "CLAUDE.md");
-	if (existsSync(templateClaude)) {
-		if (!existsSync("CLAUDE.md")) {
-			copyFileSync(templateClaude, "CLAUDE.md");
-			createdFiles.push("CLAUDE.md");
-			log("Created CLAUDE.md");
-		} else if (
-			readFileSync(templateClaude, "utf8") !== readFileSync("CLAUDE.md", "utf8")
-		) {
-			log("CLAUDE.md differs from the template:");
-			const diff = tryExec(
-				"diff",
-				["-u", "CLAUDE.md", templateClaude],
-				process.cwd(),
-			);
-			const preview = diff.stdout.split("\n").slice(0, 40).join("\n");
-			if (preview.trim()) {
-				process.stderr.write(`${preview}\n\n`);
-			}
-			const rl = readline.createInterface({ input, output: process.stderr });
-			const overwrite = await promptYesNo(
-				rl,
-				"Overwrite CLAUDE.md with template? (your changes will be lost)",
-				"n",
-			);
-			rl.close();
-			if (overwrite === "y") {
-				copyFileSync(templateClaude, "CLAUDE.md");
-				updatedFiles.push("CLAUDE.md");
-				log("Updated CLAUDE.md");
-			} else {
-				log("Skipped CLAUDE.md");
-			}
-		} else {
-			log("CLAUDE.md is up to date");
-		}
+	if (existsSync(profilePath)) {
+		await updateClaudeFromProfile(profilePath, createdFiles, updatedFiles);
+	} else {
+		await updateClaudeTemplateOnly(templateClaude, createdFiles, updatedFiles);
+		log(
+			"No .specflow/profile.json found. Run `specflow.setup` to generate a project profile.",
+		);
 	}
 
 	log("Done. All templates updated.");
@@ -486,7 +581,9 @@ Initialize a new specflow + OpenSpec project.
 	if (!existsSync(resolve(root, "CLAUDE.md")) && existsSync(claudeTemplate)) {
 		copyFileSync(claudeTemplate, resolve(root, "CLAUDE.md"));
 		createdFiles.push("CLAUDE.md");
-		log("Created CLAUDE.md — edit to match your project");
+		log(
+			"Created CLAUDE.md — run '/specflow.setup' to generate a project profile and render managed sections",
+		);
 	} else if (existsSync(resolve(root, "CLAUDE.md"))) {
 		log("CLAUDE.md already exists, skipped");
 	}
@@ -513,8 +610,13 @@ Initialize a new specflow + OpenSpec project.
 	log(`  Main agent: ${mainAgent}`);
 	log(`  Review agent: ${reviewAgent}`);
 	log("Next steps:");
-	log("  1. Edit CLAUDE.md — fill in Tech Stack, Commands, Code Style");
-	log("  2. Run '/specflow <issue-url-or-text>' to start your first feature");
+	log(
+		"  1. Run '/specflow.setup' to generate .specflow/profile.json and render CLAUDE.md",
+	);
+	log(
+		"  2. Add any repository-specific notes below the managed block in CLAUDE.md if needed",
+	);
+	log("  3. Run '/specflow <issue-url-or-text>' to start your first feature");
 	printSchemaJson("init-project", {
 		mode: "init",
 		project_name: projectName,

--- a/src/contracts/command-bodies.ts
+++ b/src/contracts/command-bodies.ts
@@ -703,14 +703,13 @@ export const commandBodies: Record<string, CommandBody> = {
 	},
 	"specflow.setup": {
 		frontmatter: {
-			description:
-				"CLAUDE.md をインタラクティブに設定（Tech Stack, Commands, Code Style）",
+			description: "Repository profile を解析・生成し、CLAUDE.md を更新する",
 		},
 		sections: [
 			{
 				title: "Overview",
 				content:
-					"\nプロジェクトの CLAUDE.md をインタラクティブに設定する。\nユーザーに質問しながら Tech Stack、Commands、Code Style セクションを埋める。",
+					"\nリポジトリのエコシステムを検出し、構造化された project profile (`.specflow/profile.json`) を生成する。\n生成後、Claude adapter が profile から CLAUDE.md の managed セクションを自動レンダリングする。",
 			},
 			{
 				title: "Prerequisites",
@@ -718,34 +717,34 @@ export const commandBodies: Record<string, CommandBody> = {
 					'\n1. Run `ls CLAUDE.md` via Bash to confirm CLAUDE.md exists.\n   - If missing: "`CLAUDE.md` が見つかりません。先に `specflow-init` を実行してください。" → **STOP**.\n\n2. Read the current `CLAUDE.md` file to understand existing content.',
 			},
 			{
-				title: "Step 1: Analyze Project [1/4]",
+				title: "Step 1: Scope & Ecosystem Detection",
 				content:
-					"\nAutomatically detect what you can from the project:\n\n1. Check for common config files to infer the tech stack:\n   - `package.json` → Node.js / npm project (read to get dependencies, scripts)\n   - `tsconfig.json` → TypeScript\n   - `pyproject.toml` or `requirements.txt` → Python\n   - `Cargo.toml` → Rust\n   - `go.mod` → Go\n   - `Gemfile` → Ruby\n   - `*.csproj` or `*.sln` → C# / .NET\n   - `build.gradle` or `pom.xml` → Java / Kotlin\n\n2. Check for build/test/lint tooling:\n   - Read `package.json` scripts if present\n   - Check for `Makefile`, `justfile`, `taskfile.yml`\n   - Check for `.eslintrc*`, `prettier.config.*`, `biome.json`\n   - Check for CI config (`.github/workflows/`, `.gitlab-ci.yml`)\n\n3. Check for existing code style patterns:\n   - Linter configs\n   - `.editorconfig`\n   - Existing code conventions (sample a few source files)\n\nReport what you found:\n\n```\n[1/4] プロジェクト解析完了\n\n検出:\n  言語: TypeScript 5.x\n  フレームワーク: React 19, Next.js 15\n  ランタイム: Node.js 22\n  パッケージマネージャ: pnpm\n  テスト: vitest\n  リンター: ESLint, Prettier\n  ...\n```",
+					"\nリポジトリルートでエコシステム検出を実行する。\n\n**検出マトリクス（優先順）:**\n1. `package.json` → JavaScript/TypeScript（lockfile で toolchain 判定: npm/pnpm/yarn/bun）\n2. `Cargo.toml`（`[workspace]` なし）→ Rust / cargo\n3. `go.mod` → Go / go\n4. `pyproject.toml` → Python（uv.lock/poetry.lock で toolchain 判定: uv/poetry/pip）\n\n**Out-of-scope 判定:**\n- Primary indicator が2つ以上 → エラー終了\n- Workspace 定義あり（`pnpm-workspace.yaml`, `Cargo.toml [workspace]`, `lerna.json`）→ エラー終了\n- Primary indicator なし → エラー終了\n- 同一エコシステム内で toolchain 曖昧 → ユーザーに選択を求める\n\nOut-of-scope の場合:\n```\nこのリポジトリ構成は現在のバージョンではサポートされていません。\n単一言語・単一ルートのリポジトリで setup を実行してください。\n```\n→ **STOP**.\n\n検出結果を報告:\n```\n[1/5] エコシステム検出完了\n\n言語: typescript\nツールチェーン: npm\nビルド: npm run build\nテスト: npm test\nリント: npm run lint\nフォーマット: npm run format\nソース: src/\nテスト: tests/\n生成物: dist/\n```\n\nユーザーに確認: 「検出結果を確認してください。修正があれば教えてください。」",
 			},
 			{
-				title: "Step 2: Tech Stack の確認 [2/4]",
+				title: "Step 2: Profile Load / Migration / Diff-and-Resolve",
 				content:
-					"\n検出した内容をもとに、ユーザーに確認する:\n\n**質問:**\n「Tech Stack を以下で設定します。追加・修正があれば教えてください。」\n\n検出した tech stack を箇条書きで提示する。\n\nユーザーの回答を待つ。修正があれば反映する。",
+					"\n**初回生成（`.specflow/profile.json` なし）:**\nStep 1 の検出結果からプロファイルを組み立て、ユーザーに確認する。\n\n追加で以下を質問:\n- 「編集禁止ゾーン（生成ファイル等）はありますか？」→ `forbiddenEditZones`\n- 「contract-sensitive なモジュールはありますか？」→ `contractSensitiveModules`\n- 「コーディング規約はありますか？」→ `codingConventions`\n- 「変更後の検証期待事項はありますか？」→ `verificationExpectations`\n\nスキップ可能（null として記録）。\n\n**再実行（既存 profile あり）:**\n`loadProfileForSetup()` で読み込む:\n- 古い schemaVersion → 自動 migration → ユーザー確認\n- 現在の schemaVersion → field-level diff\n  - 変更なし → 「変更は検出されませんでした。」で終了\n  - 差分あり → 各差分をユーザーに提示し、accept/reject を選択\n\nRequired 項目（`languages`, `toolchain`）が検出できない場合は対話的に入力を求め、入力完了までブロックする。",
 			},
 			{
-				title: "Step 3: Commands の確認 [3/4]",
+				title: "Step 3: Schema Validation & Profile Write",
 				content:
-					"\n検出したビルド・テスト・リントコマンドをもとに確認:\n\n**質問:**\n「以下のコマンドを CLAUDE.md に設定します。追加・修正があれば教えてください。」\n\n```\nビルド:  npm run build\nテスト:  npm test\nリント:  npm run lint\nフォーマット: npm run format\n```\n\nユーザーの回答を待つ。\n\nさらに聞く:\n「他に Claude が知っておくべきコマンド（デプロイ、DB マイグレーション、コード生成など）はありますか？なければ Enter で進みます。」",
+					"\n確定したプロファイルを schema validation にかける。\n\nValidation 失敗時:\n- エラー詳細を表示\n- ユーザーに修正を促す\n- 再度 validation を実行\n\nValidation 成功時:\n- `.specflow/profile.json` に atomic write で書き出す\n- 書き出し完了を報告:\n```\n[3/5] Profile 生成完了: .specflow/profile.json\n```",
 			},
 			{
-				title: "Step 4: Code Style の確認 [4/4]",
+				title: "Step 4: Claude Adapter Render Planning",
 				content:
-					"\n検出したスタイル設定をもとに確認:\n\n**質問:**\n「コーディング規約について、以下を確認させてください:」\n\n1. 「命名規則に特別なルールはありますか？（例: コンポーネントは PascalCase、ユーティリティは camelCase）」\n2. 「インポート順序のルールはありますか？」\n3. 「コメント言語は日本語・英語どちらですか？」\n4. 「その他 Claude に守ってほしいコーディングルールがあれば教えてください。なければ Enter で進みます。」\n\n各質問をまとめて聞き、ユーザーの回答を待つ。",
+					"\nProfile から CLAUDE.md の managed セクションをレンダリングする。\n\nRenderer は `RenderResult` を返す:\n- `nextContent`: 提案される CLAUDE.md の内容\n- `warning`: 警告メッセージ（あれば）\n- `diffPreview`: 変更の diff プレビュー\n- `writeDisposition`: `safe-write` | `confirmation-required` | `abort`",
 			},
 			{
-				title: "Step 5: CLAUDE.md を更新",
+				title: "Step 5: CLAUDE.md Write Gate",
 				content:
-					"\nユーザーの回答をもとに CLAUDE.md を更新する。\n\n**更新ルール:**\n\n- `## specflow Integration` セクション（先頭〜`## Tech Stack` の直前）は **変更しない**\n- `## Tech Stack` セクションの HTML コメント (`<!-- ... -->`) を削除し、実際の内容で置き換える\n- `## Commands` セクションも同様に置き換える\n- `## Code Style` セクションも同様に置き換える\n- `## MANUAL ADDITIONS` セクションは **変更しない**（既存内容があればそのまま残す）\n- 既にユーザーが記入済みの内容がある場合、上書き前に確認する\n\n更新後、差分を表示してユーザーに確認:\n\n```\nCLAUDE.md を更新しました:\n\n  ## Tech Stack\n  - TypeScript 5.x\n  - React 19, Next.js 15\n  - Node.js 22 LTS\n  - pnpm\n\n  ## Commands\n  - ビルド: pnpm build\n  - テスト: pnpm test\n  - リント: pnpm lint\n\n  ## Code Style\n  - ESLint + Prettier で自動フォーマット\n  - コメントは日本語\n  ...\n```",
+					"\nRenderer の `writeDisposition` に基づいて分岐する:\n\n**`safe-write`（マーカーあり、通常更新）:**\n- diff を表示して自動書き込み\n- 完了報告\n\n**`confirmation-required`（legacy migration）:**\n- warning を表示\n- diff プレビューを表示\n- ユーザーに accept/reject を求める\n- accept → CLAUDE.md を書き込み\n- reject → ファイルを変更しない\n\n**`abort`（マーカー異常 or version mismatch）:**\n- エラーメッセージを表示\n- CLAUDE.md を変更しない\n\n最終報告:\n```\n[5/5] Setup 完了\n\n生成されたファイル:\n  .specflow/profile.json\n  CLAUDE.md (updated)\n```",
 			},
 			{
 				title: "Important Rules",
 				content:
-					"\n- CLAUDE.md の `## specflow Integration` セクションは絶対に変更しない。\n- `## MANUAL ADDITIONS` セクションの既存内容を消さない。\n- 検出結果を鵜呑みにせず、必ずユーザーに確認してから書き込む。\n- ユーザーが「わからない」「あとで」と言ったセクションはコメントのまま残す。\n- 既に記入済みの CLAUDE.md に対して実行された場合、既存内容を表示して上書きするか確認する。",
+					"\n- Schema validation は profile 書き出し前に必ず実行する。\n- 検出結果を鵜呑みにせず、必ずユーザーに確認してから書き込む。\n- 検出できない項目は silent guess せず、`null` として記録するかユーザーに入力を求める。\n- Required 項目（languages, toolchain）は検出失敗時にブロックし、ユーザー入力を必須とする。\n- Setup のみが古い profile の schema migration を実行する。他の reader は version mismatch で中断する。\n- CLAUDE.md の書き込みは renderer の `writeDisposition` に従う。`confirmation-required` 時はユーザー確認なしに書き込まない。\n- `## MANUAL ADDITIONS` や managed マーカー外のコンテンツは一切変更しない。",
 			},
 		],
 	},

--- a/src/contracts/commands.ts
+++ b/src/contracts/commands.ts
@@ -196,7 +196,7 @@ export const commandContracts: readonly CommandContract[] = [
 	),
 	command(
 		"specflow.setup",
-		"CLAUDE.md をインタラクティブに設定（Tech Stack, Commands, Code Style）",
+		"Repository profile を生成・更新し、CLAUDE.md の managed セクションを再レンダリング",
 		[],
 	),
 	command(

--- a/src/lib/agent-context-template.ts
+++ b/src/lib/agent-context-template.ts
@@ -1,0 +1,243 @@
+/**
+ * Surface-neutral five-layer agent context model.
+ *
+ * This module defines the canonical layer definitions, namespace identifiers,
+ * precedence constants, and adapter-facing types that all surface adapters
+ * and runtime injectors depend on. No surface-specific (e.g. Claude, Cursor)
+ * wording belongs here.
+ */
+
+// ---------------------------------------------------------------------------
+// Layer identifiers
+// ---------------------------------------------------------------------------
+
+export type AgentContextLayerId =
+	| "global-invariants"
+	| "project-profile"
+	| "phase-contract"
+	| "runtime-task-instance"
+	| "evidence-context";
+
+// ---------------------------------------------------------------------------
+// Layer descriptor
+// ---------------------------------------------------------------------------
+
+export interface LayerDescriptor {
+	readonly id: AgentContextLayerId;
+	readonly name: string;
+	readonly ownership: string;
+	readonly persistence: "template" | "file" | "command-body" | "volatile";
+	readonly editable: boolean;
+	readonly priority: number;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical layer descriptors (Task 2.1)
+// ---------------------------------------------------------------------------
+
+export const LAYER_DESCRIPTORS: ReadonlyMap<
+	AgentContextLayerId,
+	LayerDescriptor
+> = new Map<AgentContextLayerId, LayerDescriptor>([
+	[
+		"global-invariants",
+		{
+			id: "global-invariants",
+			name: "Global Invariants",
+			ownership: "specflow-core",
+			persistence: "template",
+			editable: false,
+			priority: 1,
+		},
+	],
+	[
+		"phase-contract",
+		{
+			id: "phase-contract",
+			name: "Phase Contract",
+			ownership: "command-body",
+			persistence: "command-body",
+			editable: false,
+			priority: 2,
+		},
+	],
+	[
+		"project-profile",
+		{
+			id: "project-profile",
+			name: "Project Profile",
+			ownership: "setup",
+			persistence: "file",
+			editable: true,
+			priority: 3,
+		},
+	],
+	[
+		"runtime-task-instance",
+		{
+			id: "runtime-task-instance",
+			name: "Runtime Task Instance",
+			ownership: "run-state",
+			persistence: "volatile",
+			editable: false,
+			priority: 4,
+		},
+	],
+	[
+		"evidence-context",
+		{
+			id: "evidence-context",
+			name: "Evidence Context",
+			ownership: "review-apply",
+			persistence: "volatile",
+			editable: false,
+			priority: 5,
+		},
+	],
+]);
+
+/**
+ * All layer IDs sorted by ascending priority (highest priority first).
+ */
+export const LAYER_PRIORITY_ORDER: readonly AgentContextLayerId[] = [
+	...[...LAYER_DESCRIPTORS.values()]
+		.sort((a, b) => a.priority - b.priority)
+		.map((descriptor) => descriptor.id),
+];
+
+// ---------------------------------------------------------------------------
+// Global invariants content (Task 2.2)
+// ---------------------------------------------------------------------------
+
+export interface GlobalInvariants {
+	readonly contractDiscipline: readonly string[];
+}
+
+export const GLOBAL_INVARIANTS: GlobalInvariants = {
+	contractDiscipline: [
+		"Prefer explicit, enforceable contracts over implicit behavior.",
+		"Strengthen contracts instead of relying on hidden assumptions or hardcoded logic.",
+		"Avoid hardcoding behavior that should be defined by contracts, schemas, configuration, or shared generators.",
+		"Do not add special-case behavior unless it is explicitly part of the contract.",
+		"If a contract changes, update the corresponding tests in the same change.",
+		"Contract validation is required, not optional.",
+		"After making changes, run the repository's defined verification steps for the affected scope.",
+		"This includes formatting, linting, type checking, tests, and build steps whenever the repository defines them and they are relevant to the change.",
+		"Do not consider a change complete until the relevant verification steps pass.",
+		"Prefer repository-defined commands and workflows over ad hoc validation.",
+	],
+};
+
+// ---------------------------------------------------------------------------
+// Adapter-facing types (Task 2.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Input that callers provide to build a context envelope.
+ * Each field maps to one of the five canonical layers.
+ */
+export interface AgentContextTemplateInput {
+	readonly globalInvariants: Record<string, unknown>;
+	readonly projectProfile: Record<string, unknown> | null;
+	readonly phaseContract: Record<string, unknown> | null;
+	readonly runtimeTask: Record<string, unknown> | null;
+	readonly evidenceContext: Record<string, unknown> | null;
+}
+
+/**
+ * Resolved envelope with namespace-separated layers.
+ * Always contains entries for all five layers; layers with null input
+ * are represented as empty records.
+ */
+export interface ResolvedAgentContextEnvelope {
+	readonly layers: ReadonlyMap<AgentContextLayerId, Record<string, unknown>>;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter-facing helpers (Task 2.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an input field to its canonical layer ID.
+ */
+function inputToLayerMap(
+	input: AgentContextTemplateInput,
+): ReadonlyMap<AgentContextLayerId, Record<string, unknown>> {
+	return new Map<AgentContextLayerId, Record<string, unknown>>([
+		["global-invariants", { ...input.globalInvariants }],
+		[
+			"project-profile",
+			input.projectProfile ? { ...input.projectProfile } : {},
+		],
+		["phase-contract", input.phaseContract ? { ...input.phaseContract } : {}],
+		[
+			"runtime-task-instance",
+			input.runtimeTask ? { ...input.runtimeTask } : {},
+		],
+		[
+			"evidence-context",
+			input.evidenceContext ? { ...input.evidenceContext } : {},
+		],
+	]);
+}
+
+/**
+ * Resolve an envelope from input.
+ * Applies namespace separation: each layer's content is shallow-copied
+ * into an independent record keyed by layer ID.
+ */
+export function resolveAgentContextEnvelope(
+	input: AgentContextTemplateInput,
+): ResolvedAgentContextEnvelope {
+	return { layers: inputToLayerMap(input) };
+}
+
+/**
+ * Get a specific layer's content from the envelope.
+ * Returns `undefined` when the layer ID is not present (should not
+ * happen for well-formed envelopes).
+ */
+export function getLayer(
+	envelope: ResolvedAgentContextEnvelope,
+	layerId: AgentContextLayerId,
+): Record<string, unknown> | undefined {
+	return envelope.layers.get(layerId);
+}
+
+/**
+ * Resolve conflicts between layers for a given key.
+ * Returns the value from the highest-priority layer (lowest priority
+ * number) that contains the key, together with the source layer ID.
+ * Returns `undefined` when no layer contains the key.
+ */
+export function resolveConflict(
+	envelope: ResolvedAgentContextEnvelope,
+	key: string,
+):
+	| { readonly value: unknown; readonly source: AgentContextLayerId }
+	| undefined {
+	for (const layerId of LAYER_PRIORITY_ORDER) {
+		const layerContent = envelope.layers.get(layerId);
+		if (layerContent && Object.hasOwn(layerContent, key)) {
+			return { value: layerContent[key], source: layerId };
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Compare two layer IDs by priority.
+ * Returns a negative number when `a` has higher priority (lower number)
+ * than `b`, zero when equal, positive when lower priority.
+ */
+export function comparePriority(
+	a: AgentContextLayerId,
+	b: AgentContextLayerId,
+): number {
+	const descriptorA = LAYER_DESCRIPTORS.get(a);
+	const descriptorB = LAYER_DESCRIPTORS.get(b);
+	if (!descriptorA || !descriptorB) {
+		throw new Error(`Unknown layer ID: ${!descriptorA ? a : b}`);
+	}
+	return descriptorA.priority - descriptorB.priority;
+}

--- a/src/lib/claude-renderer.ts
+++ b/src/lib/claude-renderer.ts
@@ -1,0 +1,380 @@
+import { GLOBAL_INVARIANTS } from "./agent-context-template.js";
+import type { ProfileSchema } from "./profile-schema.js";
+import { CURRENT_PROFILE_SCHEMA_VERSION } from "./profile-schema.js";
+
+// ---------------------------------------------------------------------------
+// Task 5.1: Types
+// ---------------------------------------------------------------------------
+
+export type WriteDisposition = "safe-write" | "confirmation-required" | "abort";
+
+export interface RenderResult {
+	readonly nextContent: string;
+	readonly warning: string | null;
+	readonly diffPreview: string | null;
+	readonly writeDisposition: WriteDisposition;
+}
+
+export interface ParsedClaudeMd {
+	readonly managedContent: string | null;
+	readonly unmanagedBefore: string;
+	readonly unmanagedAfter: string;
+	readonly hasMarkers: boolean;
+	readonly markerAnomaly: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Markers
+// ---------------------------------------------------------------------------
+
+const MARKER_START = "<!-- specflow:managed:start -->";
+const MARKER_END = "<!-- specflow:managed:end -->";
+
+// ---------------------------------------------------------------------------
+// Task 5.2: parseClaudeMd
+// ---------------------------------------------------------------------------
+
+export function parseClaudeMd(content: string): ParsedClaudeMd {
+	const startIndices = allIndicesOf(content, MARKER_START);
+	const endIndices = allIndicesOf(content, MARKER_END);
+
+	const anomaly = detectMarkerAnomaly(startIndices, endIndices, content);
+	if (anomaly !== null) {
+		return {
+			managedContent: null,
+			unmanagedBefore: "",
+			unmanagedAfter: content,
+			hasMarkers: false,
+			markerAnomaly: anomaly,
+		};
+	}
+
+	if (startIndices.length === 0 && endIndices.length === 0) {
+		return {
+			managedContent: null,
+			unmanagedBefore: "",
+			unmanagedAfter: content,
+			hasMarkers: false,
+			markerAnomaly: null,
+		};
+	}
+
+	const startIdx = startIndices[0];
+	const endIdx = endIndices[0];
+	const managedStart = startIdx + MARKER_START.length;
+	const rawManaged = content.slice(managedStart, endIdx);
+	const managed = stripSurroundingNewlines(rawManaged);
+
+	return {
+		managedContent: managed,
+		unmanagedBefore: content.slice(0, startIdx),
+		unmanagedAfter: content.slice(endIdx + MARKER_END.length),
+		hasMarkers: true,
+		markerAnomaly: null,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Task 5.3: renderManagedBlock
+// ---------------------------------------------------------------------------
+
+export function renderManagedBlock(profile: ProfileSchema): string {
+	const sections: string[] = [];
+
+	sections.push(renderContractDiscipline());
+	sections.push(renderProjectProfile(profile));
+
+	const optional = renderOptionalSections(profile);
+	if (optional !== null) {
+		sections.push(optional);
+	}
+
+	return sections.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Task 5.4: renderClaudeMd
+// ---------------------------------------------------------------------------
+
+export function renderClaudeMd(
+	profile: ProfileSchema,
+	existingContent: string | null,
+): RenderResult {
+	const managed = renderManagedBlock(profile);
+	const wrappedBlock = wrapInMarkers(managed);
+
+	if (existingContent === null) {
+		return {
+			nextContent: wrappedBlock,
+			warning: null,
+			diffPreview: null,
+			writeDisposition: "safe-write",
+		};
+	}
+
+	const parsed = parseClaudeMd(existingContent);
+
+	if (parsed.markerAnomaly !== null) {
+		return {
+			nextContent: existingContent,
+			warning: `Marker anomaly detected: ${parsed.markerAnomaly}. Manual repair required.`,
+			diffPreview: null,
+			writeDisposition: "abort",
+		};
+	}
+
+	if (parsed.hasMarkers) {
+		const nextContent = composeManagedDocument(
+			parsed.unmanagedBefore,
+			wrappedBlock,
+			parsed.unmanagedAfter,
+		);
+		return {
+			nextContent,
+			warning: null,
+			diffPreview: null,
+			writeDisposition: "safe-write",
+		};
+	}
+
+	return renderLegacyMigration(wrappedBlock, existingContent);
+}
+
+// ---------------------------------------------------------------------------
+// Task 5.5: Legacy migration
+// ---------------------------------------------------------------------------
+
+function renderLegacyMigration(
+	wrappedBlock: string,
+	existingContent: string,
+): RenderResult {
+	const nextContent = prependManagedBlock(wrappedBlock, existingContent);
+
+	const diffPreview = buildLegacyDiffPreview(wrappedBlock, existingContent);
+
+	return {
+		nextContent,
+		warning:
+			"Existing CLAUDE.md has no specflow markers. " +
+			"A managed block will be prepended and existing content preserved as unmanaged.",
+		diffPreview,
+		writeDisposition: "confirmation-required",
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Task 5.6: renderClaudeMdStrict
+// ---------------------------------------------------------------------------
+
+export function renderClaudeMdStrict(
+	profile: ProfileSchema,
+	existingContent: string | null,
+): RenderResult {
+	if (profile.schemaVersion !== CURRENT_PROFILE_SCHEMA_VERSION) {
+		return {
+			nextContent: existingContent ?? "",
+			warning:
+				`Profile schemaVersion "${profile.schemaVersion}" does not match ` +
+				`the current version "${CURRENT_PROFILE_SCHEMA_VERSION}". ` +
+				"Run the setup command to migrate your profile before rendering.",
+			diffPreview: null,
+			writeDisposition: "abort",
+		};
+	}
+
+	return renderClaudeMd(profile, existingContent);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers: marker utilities
+// ---------------------------------------------------------------------------
+
+function allIndicesOf(haystack: string, needle: string): readonly number[] {
+	const indices: number[] = [];
+	let pos = 0;
+	while (pos < haystack.length) {
+		const idx = haystack.indexOf(needle, pos);
+		if (idx === -1) break;
+		indices.push(idx);
+		pos = idx + needle.length;
+	}
+	return indices;
+}
+
+function detectMarkerAnomaly(
+	startIndices: readonly number[],
+	endIndices: readonly number[],
+	content: string,
+): string | null {
+	if (startIndices.length > 1 || endIndices.length > 1) {
+		return "Duplicate markers found.";
+	}
+	if (startIndices.length === 1 && endIndices.length === 0) {
+		return "Start marker found without matching end marker.";
+	}
+	if (startIndices.length === 0 && endIndices.length === 1) {
+		return "End marker found without matching start marker.";
+	}
+	if (startIndices.length === 1 && endIndices.length === 1) {
+		const startPos = content.indexOf(MARKER_START);
+		const endPos = content.indexOf(MARKER_END);
+		if (endPos < startPos) {
+			return "End marker appears before start marker.";
+		}
+	}
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers: string composition
+// ---------------------------------------------------------------------------
+
+function stripSurroundingNewlines(text: string): string {
+	let start = 0;
+	let end = text.length;
+	if (text[start] === "\n") start += 1;
+	if (end > start && text[end - 1] === "\n") end -= 1;
+	return text.slice(start, end);
+}
+
+function wrapInMarkers(managed: string): string {
+	return `${MARKER_START}\n${managed}\n${MARKER_END}`;
+}
+
+function composeManagedDocument(
+	before: string,
+	wrappedBlock: string,
+	after: string,
+): string {
+	return `${before}${wrappedBlock}${after}`;
+}
+
+function prependManagedBlock(
+	wrappedBlock: string,
+	existingContent: string,
+): string {
+	if (existingContent === "") {
+		return wrappedBlock;
+	}
+	return `${wrappedBlock}\n\n${existingContent}`;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers: rendering sections
+// ---------------------------------------------------------------------------
+
+function renderContractDiscipline(): string {
+	const items = GLOBAL_INVARIANTS.contractDiscipline;
+	const bullets = items.map((item) => `- ${item}`).join("\n");
+	return `## Contract Discipline\n\n${bullets}`;
+}
+
+function renderProjectProfile(profile: ProfileSchema): string {
+	const lines: string[] = [];
+	lines.push(`- **Languages:** ${profile.languages.join(", ")}`);
+	lines.push(`- **Toolchain:** ${profile.toolchain}`);
+
+	appendCommandField(lines, "Build", profile.commands.build);
+	appendCommandField(lines, "Test", profile.commands.test);
+	appendCommandField(lines, "Lint", profile.commands.lint);
+	appendCommandField(lines, "Format", profile.commands.format);
+
+	appendDirectoryField(lines, "Source", profile.directories.source);
+	appendDirectoryField(lines, "Test dirs", profile.directories.test);
+	appendDirectoryField(lines, "Generated", profile.directories.generated);
+
+	return `## Project Profile\n\n${lines.join("\n")}`;
+}
+
+function renderOptionalSections(profile: ProfileSchema): string | null {
+	const parts: string[] = [];
+
+	if (profile.forbiddenEditZones !== null) {
+		parts.push(
+			renderStringListSection(
+				"Forbidden Edit Zones",
+				profile.forbiddenEditZones,
+			),
+		);
+	}
+
+	if (profile.contractSensitiveModules !== null) {
+		parts.push(
+			renderStringListSection(
+				"Contract-Sensitive Modules",
+				profile.contractSensitiveModules,
+			),
+		);
+	}
+
+	if (profile.codingConventions !== null) {
+		parts.push(
+			renderStringListSection("Coding Conventions", profile.codingConventions),
+		);
+	}
+
+	if (profile.verificationExpectations !== null) {
+		parts.push(
+			renderStringListSection(
+				"Verification Expectations",
+				profile.verificationExpectations,
+			),
+		);
+	}
+
+	return parts.length > 0 ? parts.join("\n\n") : null;
+}
+
+function renderStringListSection(
+	heading: string,
+	items: readonly string[],
+): string {
+	const bullets = items.map((item) => `- ${item}`).join("\n");
+	return `## ${heading}\n\n${bullets}`;
+}
+
+function appendCommandField(
+	lines: string[],
+	label: string,
+	value: string | null,
+): void {
+	if (value !== null) {
+		lines.push(`- **${label}:** \`${value}\``);
+	}
+}
+
+function appendDirectoryField(
+	lines: string[],
+	label: string,
+	dirs: readonly string[] | null,
+): void {
+	if (dirs !== null) {
+		lines.push(`- **${label}:** ${dirs.join(", ")}`);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers: diff preview
+// ---------------------------------------------------------------------------
+
+function buildLegacyDiffPreview(
+	wrappedBlock: string,
+	existingContent: string,
+): string {
+	const previewLines: string[] = [];
+	previewLines.push("--- CLAUDE.md (before)");
+	previewLines.push("+++ CLAUDE.md (after)");
+	previewLines.push("@@ migration: prepend managed block @@");
+
+	for (const line of wrappedBlock.split("\n")) {
+		previewLines.push(`+ ${line}`);
+	}
+
+	previewLines.push("+");
+
+	for (const line of existingContent.split("\n")) {
+		previewLines.push(`  ${line}`);
+	}
+
+	return previewLines.join("\n");
+}

--- a/src/lib/ecosystem-detector.ts
+++ b/src/lib/ecosystem-detector.ts
@@ -1,0 +1,425 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type EcosystemId = "javascript" | "rust" | "go" | "python";
+export type ToolchainId = string;
+
+export interface DetectedEcosystem {
+	readonly ecosystem: EcosystemId;
+	readonly language: string;
+	readonly toolchain: ToolchainId;
+	readonly toolchainAmbiguous: boolean;
+	readonly commands: {
+		readonly build: string | null;
+		readonly test: string | null;
+		readonly lint: string | null;
+		readonly format: string | null;
+	};
+	readonly directories: {
+		readonly source: readonly string[] | null;
+		readonly test: readonly string[] | null;
+		readonly generated: readonly string[] | null;
+	};
+}
+
+export type DetectionResult =
+	| { readonly status: "detected"; readonly result: DetectedEcosystem }
+	| {
+			readonly status: "ambiguous-toolchain";
+			readonly ecosystem: EcosystemId;
+			readonly candidates: readonly ToolchainId[];
+	  }
+	| { readonly status: "out-of-scope"; readonly reason: string };
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function fileExists(rootDir: string, name: string): boolean {
+	return existsSync(join(rootDir, name));
+}
+
+function readTextOrNull(rootDir: string, name: string): string | null {
+	const path = join(rootDir, name);
+	if (!existsSync(path)) {
+		return null;
+	}
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return null;
+	}
+}
+
+// ── Task 3.2: Primary indicator scanning ───────────────────────────────
+
+interface PrimaryIndicator {
+	readonly ecosystem: EcosystemId;
+	readonly language: string;
+}
+
+function scanPrimaryIndicators(rootDir: string): readonly PrimaryIndicator[] {
+	const indicators: PrimaryIndicator[] = [];
+
+	if (fileExists(rootDir, "package.json")) {
+		const content = readTextOrNull(rootDir, "package.json");
+		const language = detectJsLanguage(rootDir, content);
+		indicators.push({ ecosystem: "javascript", language });
+	}
+
+	if (fileExists(rootDir, "Cargo.toml")) {
+		const content = readTextOrNull(rootDir, "Cargo.toml");
+		if (content === null || !content.includes("[workspace]")) {
+			indicators.push({ ecosystem: "rust", language: "rust" });
+		}
+	}
+
+	if (fileExists(rootDir, "go.mod")) {
+		indicators.push({ ecosystem: "go", language: "go" });
+	}
+
+	if (fileExists(rootDir, "pyproject.toml")) {
+		indicators.push({ ecosystem: "python", language: "python" });
+	}
+
+	return indicators;
+}
+
+function detectJsLanguage(
+	rootDir: string,
+	packageJsonContent: string | null,
+): string {
+	if (fileExists(rootDir, "tsconfig.json")) {
+		return "typescript";
+	}
+	if (packageJsonContent !== null) {
+		try {
+			const pkg = JSON.parse(packageJsonContent) as Record<string, unknown>;
+			const devDeps = pkg.devDependencies as
+				| Record<string, unknown>
+				| undefined;
+			if (devDeps && "typescript" in devDeps) {
+				return "typescript";
+			}
+		} catch {
+			// fall through to default
+		}
+	}
+	return "javascript";
+}
+
+// ── Task 3.3: Conflict detection ───────────────────────────────────────
+
+function detectConflicts(
+	rootDir: string,
+	indicators: readonly PrimaryIndicator[],
+): string | null {
+	if (indicators.length === 0) {
+		return "No ecosystem indicators found";
+	}
+
+	const ecosystems = new Set(indicators.map((i) => i.ecosystem));
+	if (ecosystems.size > 1) {
+		const names = [...ecosystems].sort().join(", ");
+		return `Multiple ecosystems detected: ${names}`;
+	}
+
+	if (fileExists(rootDir, "pnpm-workspace.yaml")) {
+		return "Workspace detected: pnpm-workspace.yaml";
+	}
+
+	if (fileExists(rootDir, "lerna.json")) {
+		return "Workspace detected: lerna.json";
+	}
+
+	if (fileExists(rootDir, "Cargo.toml")) {
+		const content = readTextOrNull(rootDir, "Cargo.toml");
+		if (content?.includes("[workspace]")) {
+			return "Workspace detected: Cargo.toml [workspace]";
+		}
+	}
+
+	return null;
+}
+
+// ── Task 3.4: Toolchain resolution ─────────────────────────────────────
+
+type ToolchainResolved = {
+	readonly status: "resolved";
+	readonly toolchain: ToolchainId;
+};
+type ToolchainAmbiguous = {
+	readonly status: "ambiguous";
+	readonly candidates: readonly ToolchainId[];
+};
+type ToolchainResult = ToolchainResolved | ToolchainAmbiguous;
+
+function resolveToolchain(
+	rootDir: string,
+	ecosystem: EcosystemId,
+): ToolchainResult {
+	switch (ecosystem) {
+		case "javascript":
+			return resolveJsToolchain(rootDir);
+		case "rust":
+			return { status: "resolved", toolchain: "cargo" };
+		case "go":
+			return { status: "resolved", toolchain: "go" };
+		case "python":
+			return resolvePythonToolchain(rootDir);
+	}
+}
+
+function resolveJsToolchain(rootDir: string): ToolchainResult {
+	const lockfiles: readonly (readonly [string, ToolchainId])[] = [
+		["package-lock.json", "npm"],
+		["pnpm-lock.yaml", "pnpm"],
+		["yarn.lock", "yarn"],
+		["bun.lockb", "bun"],
+	];
+
+	const found = lockfiles.filter(([file]) => fileExists(rootDir, file));
+
+	if (found.length === 1) {
+		return { status: "resolved", toolchain: found[0][1] };
+	}
+
+	if (found.length > 1) {
+		return { status: "ambiguous", candidates: found.map(([, id]) => id) };
+	}
+
+	return { status: "resolved", toolchain: "npm" };
+}
+
+function resolvePythonToolchain(rootDir: string): ToolchainResult {
+	if (fileExists(rootDir, "uv.lock")) {
+		return { status: "resolved", toolchain: "uv" };
+	}
+	if (fileExists(rootDir, "poetry.lock")) {
+		return { status: "resolved", toolchain: "poetry" };
+	}
+	return { status: "resolved", toolchain: "pip" };
+}
+
+// ── Task 3.5: Command detection ────────────────────────────────────────
+
+interface Commands {
+	readonly build: string | null;
+	readonly test: string | null;
+	readonly lint: string | null;
+	readonly format: string | null;
+}
+
+function detectCommands(
+	rootDir: string,
+	ecosystem: EcosystemId,
+	toolchain: ToolchainId,
+): Commands {
+	switch (ecosystem) {
+		case "javascript":
+			return detectJsCommands(rootDir, toolchain);
+		case "rust":
+			return detectRustCommands();
+		case "go":
+			return detectGoCommands();
+		case "python":
+			return detectPythonCommands(rootDir, toolchain);
+	}
+}
+
+function detectJsCommands(rootDir: string, toolchain: ToolchainId): Commands {
+	const content = readTextOrNull(rootDir, "package.json");
+	if (content === null) {
+		return fallbackToMakefile(rootDir);
+	}
+
+	let scripts: Record<string, unknown> = {};
+	try {
+		const pkg = JSON.parse(content) as Record<string, unknown>;
+		scripts = (pkg.scripts as Record<string, unknown>) ?? {};
+	} catch {
+		return fallbackToMakefile(rootDir);
+	}
+
+	const runPrefix = toolchain === "npm" ? "npm run" : toolchain;
+	const scriptCmd = (name: string): string | null =>
+		typeof scripts[name] === "string" ? `${runPrefix} ${name}` : null;
+
+	return applyMakefileFallback(rootDir, {
+		build: scriptCmd("build"),
+		test: scriptCmd("test"),
+		lint: scriptCmd("lint"),
+		format: scriptCmd("format"),
+	});
+}
+
+function detectRustCommands(): Commands {
+	return {
+		build: "cargo build",
+		test: "cargo test",
+		lint: "cargo clippy",
+		format: "cargo fmt",
+	};
+}
+
+function detectGoCommands(): Commands {
+	return {
+		build: "go build ./...",
+		test: "go test ./...",
+		lint: null,
+		format: "go fmt ./...",
+	};
+}
+
+function detectPythonCommands(
+	rootDir: string,
+	toolchain: ToolchainId,
+): Commands {
+	const content = readTextOrNull(rootDir, "pyproject.toml");
+	let testCmd: string | null = null;
+	let lintCmd: string | null = null;
+	let formatCmd: string | null = null;
+
+	if (content !== null) {
+		const prefix = toolchain === "uv" ? "uv run " : "";
+
+		if (content.includes("[tool.pytest")) {
+			testCmd = `${prefix}pytest`;
+		}
+		if (content.includes("[tool.ruff")) {
+			lintCmd = `${prefix}ruff check .`;
+			formatCmd = `${prefix}ruff format .`;
+		}
+		if (content.includes("[tool.black") && formatCmd === null) {
+			formatCmd = `${prefix}black .`;
+		}
+	}
+
+	return applyMakefileFallback(rootDir, {
+		build: null,
+		test: testCmd,
+		lint: lintCmd,
+		format: formatCmd,
+	});
+}
+
+function fallbackToMakefile(rootDir: string): Commands {
+	return applyMakefileFallback(rootDir, {
+		build: null,
+		test: null,
+		lint: null,
+		format: null,
+	});
+}
+
+function applyMakefileFallback(rootDir: string, commands: Commands): Commands {
+	const content = readTextOrNull(rootDir, "Makefile");
+	if (content === null) {
+		return commands;
+	}
+
+	const targets = parseMakefileTargets(content);
+	const makeCmd = (name: keyof Commands): string | null =>
+		commands[name] ?? (targets.has(name) ? `make ${name}` : null);
+
+	return {
+		build: makeCmd("build"),
+		test: makeCmd("test"),
+		lint: makeCmd("lint"),
+		format: makeCmd("format"),
+	};
+}
+
+function parseMakefileTargets(content: string): ReadonlySet<string> {
+	const targets = new Set<string>();
+	for (const line of content.split("\n")) {
+		const match = line.match(/^([a-zA-Z_][a-zA-Z0-9_-]*):/);
+		if (match) {
+			targets.add(match[1]);
+		}
+	}
+	return targets;
+}
+
+// ── Task 3.6: Directory detection ──────────────────────────────────────
+
+interface Directories {
+	readonly source: readonly string[] | null;
+	readonly test: readonly string[] | null;
+	readonly generated: readonly string[] | null;
+}
+
+function detectDirectories(rootDir: string): Directories {
+	const sourceCandidates = ["src", "lib"];
+	const testCandidates = ["test", "tests", "__tests__"];
+	const generatedCandidates = ["dist", "build", "target"];
+
+	const source = filterExistingDirs(rootDir, sourceCandidates);
+	const test = filterExistingDirs(rootDir, testCandidates);
+	const generated = filterExistingDirs(rootDir, generatedCandidates);
+
+	return {
+		source: source.length > 0 ? source : null,
+		test: test.length > 0 ? test : null,
+		generated: generated.length > 0 ? generated : null,
+	};
+}
+
+function filterExistingDirs(
+	rootDir: string,
+	candidates: readonly string[],
+): readonly string[] {
+	return candidates.filter((dir) => {
+		const path = join(rootDir, dir);
+		if (!existsSync(path)) {
+			return false;
+		}
+		try {
+			return statSync(path).isDirectory();
+		} catch {
+			return false;
+		}
+	});
+}
+
+// ── Task 3.1: Main detection function ──────────────────────────────────
+
+export function detectEcosystem(rootDir: string): DetectionResult {
+	const indicators = scanPrimaryIndicators(rootDir);
+
+	const conflict = detectConflicts(rootDir, indicators);
+	if (conflict !== null) {
+		return { status: "out-of-scope", reason: conflict };
+	}
+
+	const indicator = indicators[0];
+	const toolchainResult = resolveToolchain(rootDir, indicator.ecosystem);
+
+	if (toolchainResult.status === "ambiguous") {
+		return {
+			status: "ambiguous-toolchain",
+			ecosystem: indicator.ecosystem,
+			candidates: toolchainResult.candidates,
+		};
+	}
+
+	const commands = detectCommands(
+		rootDir,
+		indicator.ecosystem,
+		toolchainResult.toolchain,
+	);
+
+	const directories = detectDirectories(rootDir);
+
+	return {
+		status: "detected",
+		result: {
+			ecosystem: indicator.ecosystem,
+			language: indicator.language,
+			toolchain: toolchainResult.toolchain,
+			toolchainAmbiguous: false,
+			commands,
+			directories,
+		},
+	};
+}

--- a/src/lib/profile-diff.ts
+++ b/src/lib/profile-diff.ts
@@ -1,0 +1,186 @@
+import type { ProfileSchema } from "./profile-schema.js";
+
+// ---------------------------------------------------------------------------
+// Task 4.1-4.3: Profile diffing
+// ---------------------------------------------------------------------------
+
+// --- Types ---
+
+export type DiffAction = "unchanged" | "conflict" | "proposed" | "preserved";
+
+export interface FieldDiff {
+	readonly path: string;
+	readonly action: DiffAction;
+	readonly existingValue: unknown;
+	readonly newValue: unknown;
+}
+
+export interface ProfileDiffResult {
+	readonly diffs: readonly FieldDiff[];
+	readonly hasChanges: boolean;
+}
+
+// --- Internal helpers ---
+
+/** Sort-normalize an array for stable comparison. Returns null when input is null. */
+function sortNormalized(
+	arr: readonly string[] | null,
+): readonly string[] | null {
+	if (arr === null) {
+		return null;
+	}
+	return [...arr].sort();
+}
+
+/** Serialize a value to a canonical JSON string for comparison. */
+function canonical(value: unknown): string {
+	return JSON.stringify(value);
+}
+
+// --- Task 4.2: Diff action rules ---
+
+/**
+ * Determine the diff action for a single field.
+ *
+ * - existing === detected (by canonical comparison) -> unchanged
+ * - Both non-null but different                     -> conflict
+ * - existing is null, detected is non-null           -> proposed
+ * - existing is non-null, detected is null           -> preserved
+ */
+function classifyAction(existing: unknown, detected: unknown): DiffAction {
+	if (canonical(existing) === canonical(detected)) {
+		return "unchanged";
+	}
+	if (existing === null && detected !== null) {
+		return "proposed";
+	}
+	if (existing !== null && detected === null) {
+		return "preserved";
+	}
+	return "conflict";
+}
+
+function createFieldDiff(
+	path: string,
+	existing: unknown,
+	detected: unknown,
+): FieldDiff {
+	return {
+		path,
+		action: classifyAction(existing, detected),
+		existingValue: existing,
+		newValue: detected,
+	};
+}
+
+// --- Task 4.3: Diff flattening helpers ---
+
+/** Diff each child key of an object field individually, producing dotted paths. */
+function diffObjectField(
+	parentPath: string,
+	existing: Readonly<Record<string, unknown>>,
+	detected: Readonly<Record<string, unknown>>,
+): readonly FieldDiff[] {
+	const keys = new Set([...Object.keys(existing), ...Object.keys(detected)]);
+	const result: FieldDiff[] = [];
+	for (const key of keys) {
+		const existingVal = key in existing ? existing[key] : null;
+		const detectedVal = key in detected ? detected[key] : null;
+		result.push(
+			createFieldDiff(`${parentPath}.${key}`, existingVal, detectedVal),
+		);
+	}
+	return result;
+}
+
+/** Diff an array field after sort-normalizing both sides. */
+function diffArrayField(
+	path: string,
+	existing: readonly string[] | null,
+	detected: readonly string[] | null,
+): FieldDiff {
+	const sortedExisting = sortNormalized(existing);
+	const sortedDetected = sortNormalized(detected);
+	return createFieldDiff(path, sortedExisting, sortedDetected);
+}
+
+// --- Nullable array field names (top-level) ---
+
+const NULLABLE_ARRAY_FIELDS: readonly (keyof ProfileSchema)[] = [
+	"forbiddenEditZones",
+	"contractSensitiveModules",
+	"codingConventions",
+	"verificationExpectations",
+] as const;
+
+// --- Task 4.1: diffProfiles ---
+
+/**
+ * Compare two ProfileSchema instances field by field.
+ *
+ * - `commands` and `directories` are flattened into child-key diffs.
+ * - Array fields are sort-normalized before comparison.
+ * - Top-level primitives are compared directly.
+ *
+ * Returns all diffs in a single flat list with dotted paths.
+ */
+export function diffProfiles(
+	existing: ProfileSchema,
+	detected: ProfileSchema,
+): ProfileDiffResult {
+	const diffs: FieldDiff[] = [];
+
+	// Top-level primitives
+	diffs.push(
+		createFieldDiff(
+			"schemaVersion",
+			existing.schemaVersion,
+			detected.schemaVersion,
+		),
+	);
+	diffs.push(
+		createFieldDiff("toolchain", existing.toolchain, detected.toolchain),
+	);
+
+	// languages: sort-normalize before comparing
+	diffs.push(
+		diffArrayField(
+			"languages",
+			existing.languages as readonly string[],
+			detected.languages as readonly string[],
+		),
+	);
+
+	// commands: flatten per child key
+	diffs.push(
+		...diffObjectField(
+			"commands",
+			existing.commands as unknown as Record<string, unknown>,
+			detected.commands as unknown as Record<string, unknown>,
+		),
+	);
+
+	// directories: flatten per child key
+	diffs.push(
+		...diffObjectField(
+			"directories",
+			existing.directories as unknown as Record<string, unknown>,
+			detected.directories as unknown as Record<string, unknown>,
+		),
+	);
+
+	// Nullable array fields: sort-normalize
+	for (const field of NULLABLE_ARRAY_FIELDS) {
+		diffs.push(
+			diffArrayField(
+				field,
+				existing[field] as readonly string[] | null,
+				detected[field] as readonly string[] | null,
+			),
+		);
+	}
+
+	const hasChanges = diffs.some((d) => d.action !== "unchanged");
+
+	return { diffs, hasChanges };
+}

--- a/src/lib/profile-schema.ts
+++ b/src/lib/profile-schema.ts
@@ -1,0 +1,406 @@
+import { atomicWriteText, readText } from "./fs.js";
+import { parseJson } from "./json.js";
+
+// ---------------------------------------------------------------------------
+// Task 1.1: TypeScript types
+// ---------------------------------------------------------------------------
+
+export interface ProfileCommands {
+	readonly build: string | null;
+	readonly test: string | null;
+	readonly lint: string | null;
+	readonly format: string | null;
+}
+
+export interface ProfileDirectories {
+	readonly source: readonly string[] | null;
+	readonly test: readonly string[] | null;
+	readonly generated: readonly string[] | null;
+}
+
+export interface ProfileSchema {
+	readonly schemaVersion: string;
+	readonly languages: readonly string[];
+	readonly toolchain: string;
+	readonly commands: ProfileCommands;
+	readonly directories: ProfileDirectories;
+	readonly forbiddenEditZones: readonly string[] | null;
+	readonly contractSensitiveModules: readonly string[] | null;
+	readonly codingConventions: readonly string[] | null;
+	readonly verificationExpectations: readonly string[] | null;
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.2: Schema version constant and utilities
+// ---------------------------------------------------------------------------
+
+export const CURRENT_PROFILE_SCHEMA_VERSION = "1";
+
+export function sniffSchemaVersion(raw: unknown): string | null {
+	if (
+		raw !== null &&
+		typeof raw === "object" &&
+		!Array.isArray(raw) &&
+		"schemaVersion" in raw &&
+		typeof (raw as Record<string, unknown>).schemaVersion === "string"
+	) {
+		return (raw as Record<string, unknown>).schemaVersion as string;
+	}
+	return null;
+}
+
+export function compareSchemaVersion(
+	version: string,
+	current: string,
+): "current" | "older" | "newer" {
+	const v = Number.parseInt(version, 10);
+	const c = Number.parseInt(current, 10);
+	if (v === c) {
+		return "current";
+	}
+	return v < c ? "older" : "newer";
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.3: Validation
+// ---------------------------------------------------------------------------
+
+const COMMANDS_KEYS: ReadonlySet<string> = new Set([
+	"build",
+	"test",
+	"lint",
+	"format",
+]);
+
+const DIRECTORIES_KEYS: ReadonlySet<string> = new Set([
+	"source",
+	"test",
+	"generated",
+]);
+
+const TOP_LEVEL_KEYS: ReadonlySet<string> = new Set([
+	"schemaVersion",
+	"languages",
+	"toolchain",
+	"commands",
+	"directories",
+	"forbiddenEditZones",
+	"contractSensitiveModules",
+	"codingConventions",
+	"verificationExpectations",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function push(errors: string[], path: string, message: string): void {
+	errors.push(`${path} ${message}`);
+}
+
+function validateNullableStringArray(
+	value: unknown,
+	path: string,
+	errors: string[],
+): void {
+	if (value === null) {
+		return;
+	}
+	if (!Array.isArray(value)) {
+		push(errors, path, "must be an array of strings or null.");
+		return;
+	}
+	for (let i = 0; i < value.length; i += 1) {
+		if (typeof value[i] !== "string") {
+			push(errors, `${path}[${i}]`, "must be a string.");
+		}
+	}
+}
+
+function validateCommands(
+	value: unknown,
+	path: string,
+	errors: string[],
+): void {
+	if (!isRecord(value)) {
+		push(errors, path, "must be an object.");
+		return;
+	}
+	for (const key of Object.keys(value)) {
+		if (!COMMANDS_KEYS.has(key)) {
+			push(errors, `${path}.${key}`, "is an unknown key.");
+		}
+	}
+	for (const key of COMMANDS_KEYS) {
+		if (!(key in value)) {
+			push(errors, `${path}.${key}`, "is required.");
+			continue;
+		}
+		const v = value[key];
+		if (v !== null && typeof v !== "string") {
+			push(errors, `${path}.${key}`, "must be a string or null.");
+		}
+	}
+}
+
+function validateDirectories(
+	value: unknown,
+	path: string,
+	errors: string[],
+): void {
+	if (!isRecord(value)) {
+		push(errors, path, "must be an object.");
+		return;
+	}
+	for (const key of Object.keys(value)) {
+		if (!DIRECTORIES_KEYS.has(key)) {
+			push(errors, `${path}.${key}`, "is an unknown key.");
+		}
+	}
+	for (const key of DIRECTORIES_KEYS) {
+		if (!(key in value)) {
+			push(errors, `${path}.${key}`, "is required.");
+			continue;
+		}
+		validateNullableStringArray(value[key], `${path}.${key}`, errors);
+	}
+}
+
+export function validateProfile(value: unknown): string[] {
+	const errors: string[] = [];
+
+	if (!isRecord(value)) {
+		push(errors, "$", "must be an object.");
+		return errors;
+	}
+
+	for (const key of Object.keys(value)) {
+		if (!TOP_LEVEL_KEYS.has(key)) {
+			push(errors, `$.${key}`, "is an unknown key.");
+		}
+	}
+
+	// Check for missing top-level keys
+	for (const key of TOP_LEVEL_KEYS) {
+		if (!(key in value)) {
+			push(errors, `$.${key}`, "is required.");
+		}
+	}
+
+	// schemaVersion
+	if ("schemaVersion" in value) {
+		if (
+			typeof value.schemaVersion !== "string" ||
+			!/^[1-9]\d*$/.test(value.schemaVersion)
+		) {
+			push(errors, "$.schemaVersion", "must be a monotonic integer string.");
+		}
+	}
+
+	// languages
+	if ("languages" in value) {
+		if (!Array.isArray(value.languages) || value.languages.length === 0) {
+			push(errors, "$.languages", "must be a non-empty array of strings.");
+		} else if (value.languages.length !== 1) {
+			push(errors, "$.languages", "must contain exactly one language in v1.");
+		} else {
+			for (let i = 0; i < value.languages.length; i += 1) {
+				if (typeof value.languages[i] !== "string") {
+					push(errors, `$.languages[${i}]`, "must be a string.");
+				}
+			}
+		}
+	}
+
+	// toolchain
+	if ("toolchain" in value) {
+		if (typeof value.toolchain !== "string" || value.toolchain === "") {
+			push(errors, "$.toolchain", "must be a non-empty string.");
+		}
+	}
+
+	// commands
+	if ("commands" in value) {
+		validateCommands(value.commands, "$.commands", errors);
+	}
+
+	// directories
+	if ("directories" in value) {
+		validateDirectories(value.directories, "$.directories", errors);
+	}
+
+	// Nullable string array fields
+	const nullableArrayFields = [
+		"forbiddenEditZones",
+		"contractSensitiveModules",
+		"codingConventions",
+		"verificationExpectations",
+	] as const;
+
+	for (const field of nullableArrayFields) {
+		if (field in value) {
+			validateNullableStringArray(value[field], `$.${field}`, errors);
+		}
+	}
+
+	return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.4: Load/write utilities
+// ---------------------------------------------------------------------------
+
+export function createBlankProfile(
+	languages: readonly string[],
+	toolchain: string,
+): ProfileSchema {
+	return {
+		schemaVersion: CURRENT_PROFILE_SCHEMA_VERSION,
+		languages: [...languages],
+		toolchain,
+		commands: {
+			build: null,
+			test: null,
+			lint: null,
+			format: null,
+		},
+		directories: {
+			source: null,
+			test: null,
+			generated: null,
+		},
+		forbiddenEditZones: null,
+		contractSensitiveModules: null,
+		codingConventions: null,
+		verificationExpectations: null,
+	};
+}
+
+export function writeProfile(filePath: string, profile: ProfileSchema): void {
+	const errors = validateProfile(profile);
+	if (errors.length > 0) {
+		throw new Error(
+			`Profile validation failed before write: ${errors.join(" ")}`,
+		);
+	}
+	atomicWriteText(filePath, `${JSON.stringify(profile, null, 2)}\n`);
+}
+
+export function loadProfileForSetup(
+	filePath: string,
+): { profile: ProfileSchema; migrated: boolean } | { error: string } {
+	let raw: string;
+	try {
+		raw = readText(filePath);
+	} catch {
+		return { error: `Failed to read profile file: ${filePath}` };
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = parseJson<unknown>(raw, filePath);
+	} catch {
+		return {
+			error: `Profile is not valid JSON: ${filePath}`,
+		};
+	}
+
+	if (!isRecord(parsed)) {
+		return { error: "Profile root must be a JSON object." };
+	}
+
+	const version = sniffSchemaVersion(parsed);
+	if (version === null) {
+		return { error: "Profile is missing schemaVersion." };
+	}
+
+	const comparison = compareSchemaVersion(
+		version,
+		CURRENT_PROFILE_SCHEMA_VERSION,
+	);
+	let migrated = false;
+	let record = parsed;
+
+	if (comparison === "older") {
+		record = migrateProfile(record, version);
+		migrated = true;
+	} else if (comparison === "newer") {
+		return {
+			error: `Profile schemaVersion "${version}" is newer than the supported version "${CURRENT_PROFILE_SCHEMA_VERSION}". Please upgrade your tooling.`,
+		};
+	}
+
+	const errors = validateProfile(record);
+	if (errors.length > 0) {
+		return {
+			error: `Profile validation failed: ${errors.join(" ")}`,
+		};
+	}
+
+	return { profile: record as unknown as ProfileSchema, migrated };
+}
+
+export function readProfileStrict(
+	filePath: string,
+): { profile: ProfileSchema } | { error: string } {
+	let raw: string;
+	try {
+		raw = readText(filePath);
+	} catch {
+		return { error: `Failed to read profile file: ${filePath}` };
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = parseJson<unknown>(raw, filePath);
+	} catch {
+		return {
+			error: `Profile is not valid JSON: ${filePath}`,
+		};
+	}
+
+	if (!isRecord(parsed)) {
+		return { error: "Profile root must be a JSON object." };
+	}
+
+	const version = sniffSchemaVersion(parsed);
+	if (version === null) {
+		return { error: "Profile is missing schemaVersion." };
+	}
+
+	const comparison = compareSchemaVersion(
+		version,
+		CURRENT_PROFILE_SCHEMA_VERSION,
+	);
+	if (comparison !== "current") {
+		const direction = comparison === "older" ? "older" : "newer";
+		return {
+			error: `Profile schemaVersion "${version}" is ${direction} than the current version "${CURRENT_PROFILE_SCHEMA_VERSION}". Run the setup command to migrate your profile.`,
+		};
+	}
+
+	const errors = validateProfile(parsed);
+	if (errors.length > 0) {
+		return {
+			error: `Profile validation failed: ${errors.join(" ")}`,
+		};
+	}
+
+	return { profile: parsed as unknown as ProfileSchema };
+}
+
+// ---------------------------------------------------------------------------
+// Task 1.5: Migration helpers
+// ---------------------------------------------------------------------------
+
+export function migrateProfile(
+	raw: Record<string, unknown>,
+	fromVersion: string,
+): Record<string, unknown> {
+	if (fromVersion === CURRENT_PROFILE_SCHEMA_VERSION) {
+		return { ...raw };
+	}
+	throw new Error(
+		`Cannot migrate profile from unknown schemaVersion "${fromVersion}".`,
+	);
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -16,17 +16,18 @@ import type {
 	LedgerSeverityCounts,
 	LedgerSnapshot,
 	ProposalSource,
+	RereviewClassification,
 	ReviewDiffSummary,
 	ReviewFinding,
 	ReviewPayload,
 	ReviewResult,
-	RereviewClassification,
-	SourceMetadata,
 	RunAgents,
 	RunHistoryEntry,
 	RunState,
 	SchemaId,
+	SourceMetadata,
 } from "../types/contracts.js";
+import { validateProfile as validateProfileImpl } from "./profile-schema.js";
 
 type ValidationErrors = string[];
 type SchemaValidator = (
@@ -909,6 +910,17 @@ function createSubIssuesResultValidator(
 	);
 }
 
+function profileValidator(
+	value: unknown,
+	_path: string,
+	errors: ValidationErrors,
+): void {
+	const profileErrors = validateProfileImpl(value);
+	for (const error of profileErrors) {
+		errors.push(error);
+	}
+}
+
 export const schemaValidators: Readonly<Record<SchemaId, SchemaValidator>> = {
 	"issue-metadata": issueMetadataValidator,
 	"source-metadata": sourceMetadataValidator,
@@ -924,6 +936,7 @@ export const schemaValidators: Readonly<Record<SchemaId, SchemaValidator>> = {
 	"run-state": runStateValidator,
 	"create-sub-issues-input": createSubIssuesInputValidator,
 	"create-sub-issues-result": createSubIssuesResultValidator,
+	profile: profileValidator,
 };
 
 export function schemaIds(): readonly SchemaId[] {
@@ -996,13 +1009,13 @@ export type {
 	LedgerSeverityCounts,
 	LedgerSnapshot,
 	ProposalSource,
+	RereviewClassification,
 	ReviewDiffSummary,
 	ReviewFinding,
 	ReviewPayload,
 	ReviewResult,
-	RereviewClassification,
-	SourceMetadata,
 	RunAgents,
 	RunHistoryEntry,
 	RunState,
+	SourceMetadata,
 };

--- a/src/tests/claude-renderer.test.ts
+++ b/src/tests/claude-renderer.test.ts
@@ -51,7 +51,9 @@ test("renderClaudeMd preserves unmanaged content on both sides of the managed bl
 	assert.equal(result.warning, null);
 	assert.ok(result.nextContent.includes("## Project Profile"));
 	assert.ok(
-		result.nextContent.startsWith("# Repository Notes\n\nKeep this preface.\n\n"),
+		result.nextContent.startsWith(
+			"# Repository Notes\n\nKeep this preface.\n\n",
+		),
 	);
 	assert.ok(result.nextContent.includes("## Manual Notes\n\nkeep me\n"));
 	assert.ok(

--- a/src/tests/claude-renderer.test.ts
+++ b/src/tests/claude-renderer.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	renderClaudeMd,
+	renderClaudeMdStrict,
+} from "../lib/claude-renderer.js";
+import type { ProfileSchema } from "../lib/profile-schema.js";
+
+const sampleProfile: ProfileSchema = {
+	schemaVersion: "1",
+	languages: ["typescript"],
+	toolchain: "npm",
+	commands: {
+		build: "npm run build",
+		test: "npm test",
+		lint: "npm run lint",
+		format: "npm run format",
+	},
+	directories: {
+		source: ["src/"],
+		test: ["tests/"],
+		generated: ["dist/"],
+	},
+	forbiddenEditZones: null,
+	contractSensitiveModules: ["src/contracts/**"],
+	codingConventions: ["Keep contracts explicit."],
+	verificationExpectations: ["npm test"],
+};
+
+test("renderClaudeMd preserves unmanaged content on both sides of the managed block", () => {
+	const existing = [
+		"# Repository Notes",
+		"",
+		"Keep this preface.",
+		"",
+		"<!-- specflow:managed:start -->",
+		"## Contract Discipline",
+		"",
+		"- stale rule",
+		"<!-- specflow:managed:end -->",
+		"",
+		"## Manual Notes",
+		"",
+		"keep me",
+		"",
+	].join("\n");
+
+	const result = renderClaudeMd(sampleProfile, existing);
+
+	assert.equal(result.writeDisposition, "safe-write");
+	assert.equal(result.warning, null);
+	assert.ok(result.nextContent.includes("## Project Profile"));
+	assert.ok(
+		result.nextContent.startsWith("# Repository Notes\n\nKeep this preface.\n\n"),
+	);
+	assert.ok(result.nextContent.includes("## Manual Notes\n\nkeep me\n"));
+	assert.ok(
+		result.nextContent.indexOf("# Repository Notes") <
+			result.nextContent.indexOf("<!-- specflow:managed:start -->"),
+	);
+	assert.ok(
+		result.nextContent.indexOf("## Manual Notes") >
+			result.nextContent.indexOf("<!-- specflow:managed:end -->"),
+	);
+});
+
+test("renderClaudeMdStrict aborts on marker anomalies", () => {
+	const existing = [
+		"<!-- specflow:managed:start -->",
+		"managed",
+		"<!-- specflow:managed:end -->",
+		"<!-- specflow:managed:end -->",
+	].join("\n");
+
+	const result = renderClaudeMdStrict(sampleProfile, existing);
+
+	assert.equal(result.writeDisposition, "abort");
+	assert.match(result.warning ?? "", /marker anomaly/i);
+	assert.equal(result.nextContent, existing);
+});
+
+test("renderClaudeMdStrict aborts on profile schema version mismatch", () => {
+	const result = renderClaudeMdStrict(
+		{ ...sampleProfile, schemaVersion: "2" },
+		"<!-- specflow:managed:start -->\nold\n<!-- specflow:managed:end -->\n",
+	);
+
+	assert.equal(result.writeDisposition, "abort");
+	assert.match(result.warning ?? "", /schemaVersion "2"/);
+});

--- a/src/tests/generation.test.ts
+++ b/src/tests/generation.test.ts
@@ -1,6 +1,6 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
+import test from "node:test";
 import { contracts } from "../contracts/install.js";
 import {
 	mergeProjectGitignore,
@@ -107,6 +107,9 @@ test("prompt templates render contract-driven output schemas", () => {
 });
 
 test("build emits a dist package for installer assets", () => {
+	assert.ok(existsSync("dist/lib/agent-context-template.js"));
+	assert.ok(existsSync("dist/lib/profile-schema.js"));
+	assert.ok(existsSync("dist/lib/claude-renderer.js"));
 	assert.ok(existsSync("dist/package/global/claude-settings.json"));
 	assert.ok(existsSync("dist/package/global/workflow/state-machine.json"));
 	assert.ok(existsSync("dist/package/global/prompts/review_design_prompt.md"));
@@ -119,6 +122,14 @@ test("build emits a dist package for installer assets", () => {
 	assert.ok(existsSync("dist/package/template/_specflow/config.env"));
 	assert.ok(existsSync("dist/package/template/CLAUDE.md"));
 	assert.equal(existsSync("template"), false);
+});
+
+test("packaged CLAUDE.md template ships managed markers and an unmanaged notes section", () => {
+	const templateClaude = readFileSync("dist/package/template/CLAUDE.md", "utf8");
+
+	assert.ok(templateClaude.startsWith("<!-- specflow:managed:start -->"));
+	assert.ok(templateClaude.includes("<!-- specflow:managed:end -->"));
+	assert.ok(templateClaude.includes("## MANUAL ADDITIONS"));
 });
 
 test("repo .gitignore matches the shared specflow ignore layout", () => {

--- a/src/tests/generation.test.ts
+++ b/src/tests/generation.test.ts
@@ -125,7 +125,10 @@ test("build emits a dist package for installer assets", () => {
 });
 
 test("packaged CLAUDE.md template ships managed markers and an unmanaged notes section", () => {
-	const templateClaude = readFileSync("dist/package/template/CLAUDE.md", "utf8");
+	const templateClaude = readFileSync(
+		"dist/package/template/CLAUDE.md",
+		"utf8",
+	);
 
 	assert.ok(templateClaude.startsWith("<!-- specflow:managed:start -->"));
 	assert.ok(templateClaude.includes("<!-- specflow:managed:end -->"));

--- a/src/tests/release-distribution.test.ts
+++ b/src/tests/release-distribution.test.ts
@@ -1,7 +1,7 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import test from "node:test";
 import { makeTempDir, removeTempDir, repoRoot } from "./test-helpers.js";
 
 const releaseUrl =
@@ -51,6 +51,9 @@ test("npm pack dry-run includes the runtime bundle needed by release installs", 
 		assert.ok(paths.has("dist/bin/specflow-install.js"));
 		assert.ok(paths.has("dist/bin/specflow-prepare-change.js"));
 		assert.ok(paths.has("dist/bin/specflow-run.js"));
+		assert.ok(paths.has("dist/lib/agent-context-template.js"));
+		assert.ok(paths.has("dist/lib/profile-schema.js"));
+		assert.ok(paths.has("dist/lib/claude-renderer.js"));
 		assert.ok(paths.has("dist/package/global/workflow/state-machine.json"));
 		assert.ok(paths.has("dist/package/global/commands/specflow.md"));
 		assert.ok(paths.has("dist/package/template/_gitignore"));

--- a/src/tests/utility-cli.test.ts
+++ b/src/tests/utility-cli.test.ts
@@ -1,4 +1,3 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
@@ -10,6 +9,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { basename, join } from "node:path";
+import test from "node:test";
 import {
 	addImplementationDiff,
 	createFixtureRepo,
@@ -23,6 +23,71 @@ import {
 	repoRoot,
 	runNodeCli,
 } from "./test-helpers.js";
+
+function createUpdateRepo(tempRoot: string): {
+	home: string;
+	repoPath: string;
+} {
+	const home = createInstalledHome(tempRoot);
+	const repoPath = join(tempRoot, "repo");
+	mkdirSync(repoPath, { recursive: true });
+	spawnSync("git", ["init", "--quiet"], { cwd: repoPath, stdio: "ignore" });
+	return { home, repoPath };
+}
+
+function createProfileJson(
+	overrides: Partial<{
+		schemaVersion: string;
+		languages: string[];
+		toolchain: string;
+		commands: {
+			build: string | null;
+			test: string | null;
+			lint: string | null;
+			format: string | null;
+		};
+		directories: {
+			source: string[] | null;
+			test: string[] | null;
+			generated: string[] | null;
+		};
+		forbiddenEditZones: string[] | null;
+		contractSensitiveModules: string[] | null;
+		codingConventions: string[] | null;
+		verificationExpectations: string[] | null;
+	}> = {},
+): string {
+	return `${JSON.stringify(
+		{
+			schemaVersion: "1",
+			languages: ["typescript"],
+			toolchain: "npm",
+			commands: {
+				build: "npm run build",
+				test: "npm test",
+				lint: "npm run lint",
+				format: "npm run format",
+			},
+			directories: {
+				source: ["src/"],
+				test: ["tests/"],
+				generated: ["dist/"],
+			},
+			forbiddenEditZones: null,
+			contractSensitiveModules: ["src/contracts/**"],
+			codingConventions: ["Keep contracts explicit."],
+			verificationExpectations: ["npm test"],
+			...overrides,
+		},
+		null,
+		2,
+	)}\n`;
+}
+
+function writeProfileFile(repoPath: string, rawProfile: string): void {
+	mkdirSync(join(repoPath, ".specflow"), { recursive: true });
+	writeFileSync(join(repoPath, ".specflow/profile.json"), rawProfile, "utf8");
+}
 
 test("specflow-fetch-issue returns the expected issue payload", () => {
 	const tempRoot = makeTempDir("fetch-issue-");
@@ -329,13 +394,10 @@ test("specflow-analyze returns structured project metadata", () => {
 	assert.equal(json.package_manager, "npm");
 });
 
-test("specflow-init --update refreshes installed commands from manifest", () => {
+test("specflow-init --update refreshes installed commands and skips profile rendering when no profile exists", () => {
 	const tempRoot = makeTempDir("specflow-init-update-");
 	try {
-		const home = createInstalledHome(tempRoot);
-		const repoPath = join(tempRoot, "repo");
-		mkdirSync(repoPath, { recursive: true });
-		spawnSync("git", ["init", "--quiet"], { cwd: repoPath, stdio: "ignore" });
+		const { home, repoPath } = createUpdateRepo(tempRoot);
 		writeFileSync(join(repoPath, "CLAUDE.md"), "custom\n", "utf8");
 		const result = runNodeCli(
 			"specflow-init",
@@ -355,6 +417,124 @@ test("specflow-init --update refreshes installed commands from manifest", () => 
 		assert.ok(json.installed_commands.includes("specflow"));
 		assert.ok(existsSync(join(repoPath, ".mcp.json")));
 		assert.ok(existsSync(join(home, ".claude/commands/specflow.md")));
+		assert.equal(readFileSync(join(repoPath, "CLAUDE.md"), "utf8"), "custom\n");
+		assert.match(
+			result.stderr,
+			/No \.specflow\/profile\.json found\. Run `specflow\.setup` to generate a project profile\./,
+		);
+		assert.equal(
+			result.stderr.includes("Rendered CLAUDE.md from profile"),
+			false,
+		);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-init --update rerenders CLAUDE.md from a valid profile", () => {
+	const tempRoot = makeTempDir("specflow-init-profile-render-");
+	try {
+		const { home, repoPath } = createUpdateRepo(tempRoot);
+		writeProfileFile(repoPath, createProfileJson());
+		writeFileSync(
+			join(repoPath, "CLAUDE.md"),
+			[
+				"<!-- specflow:managed:start -->",
+				"## Contract Discipline",
+				"",
+				"- stale rule",
+				"<!-- specflow:managed:end -->",
+				"",
+				"## Manual Notes",
+				"",
+				"keep me",
+				"",
+			].join("\n"),
+			"utf8",
+		);
+
+		const result = runNodeCli("specflow-init", ["--update"], repoPath, {
+			HOME: home,
+		});
+
+		assert.equal(result.status, 0, result.stderr);
+		assert.equal(
+			result.stderr.includes("Overwrite CLAUDE.md with template?"),
+			false,
+		);
+		assert.match(result.stderr, /Rendered CLAUDE\.md from profile/);
+		const claude = readFileSync(join(repoPath, "CLAUDE.md"), "utf8");
+		assert.ok(claude.startsWith("<!-- specflow:managed:start -->"));
+		assert.ok(claude.includes("## Project Profile"));
+		assert.ok(claude.includes("- **Toolchain:** npm"));
+		assert.ok(claude.includes("- **Build:** `npm run build`"));
+		assert.ok(claude.includes("## Contract-Sensitive Modules"));
+		assert.ok(claude.includes("## Verification Expectations"));
+		assert.ok(claude.includes("## Manual Notes\n\nkeep me"));
+		const json = JSON.parse(result.stdout) as { updated_files: string[] };
+		assert.ok(json.updated_files.includes("CLAUDE.md (profile-rendered)"));
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-init --update aborts when the profile is invalid", () => {
+	const tempRoot = makeTempDir("specflow-init-invalid-profile-");
+	try {
+		const { home, repoPath } = createUpdateRepo(tempRoot);
+		writeProfileFile(
+			repoPath,
+			`${JSON.stringify({ schemaVersion: "1", languages: ["typescript"] })}\n`,
+		);
+		writeFileSync(join(repoPath, "CLAUDE.md"), "custom\n", "utf8");
+
+		const result = runNodeCli("specflow-init", ["--update"], repoPath, {
+			HOME: home,
+		});
+
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /Profile validation failed:/);
+		assert.match(result.stderr, /Run 'specflow\.setup' to fix the profile\./);
+		assert.equal(
+			result.stderr.includes("Overwrite CLAUDE.md with template?"),
+			false,
+		);
+		assert.equal(readFileSync(join(repoPath, "CLAUDE.md"), "utf8"), "custom\n");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-init --update asks for confirmation before migrating a legacy CLAUDE.md", () => {
+	const tempRoot = makeTempDir("specflow-init-legacy-claude-");
+	try {
+		const { home, repoPath } = createUpdateRepo(tempRoot);
+		writeProfileFile(repoPath, createProfileJson());
+		writeFileSync(
+			join(repoPath, "CLAUDE.md"),
+			"# Legacy CLAUDE\n\nKeep this section.\n",
+			"utf8",
+		);
+
+		const result = runNodeCli(
+			"specflow-init",
+			["--update"],
+			repoPath,
+			{ HOME: home },
+			"y\n",
+		);
+
+		assert.equal(result.status, 0, result.stderr);
+		assert.match(result.stderr, /Apply profile-rendered CLAUDE\.md changes\?/);
+		assert.match(result.stderr, /has no specflow markers/i);
+		assert.equal(
+			result.stderr.includes("Overwrite CLAUDE.md with template?"),
+			false,
+		);
+		const claude = readFileSync(join(repoPath, "CLAUDE.md"), "utf8");
+		assert.ok(claude.startsWith("<!-- specflow:managed:start -->"));
+		assert.ok(claude.includes("## Project Profile"));
+		assert.ok(claude.includes("# Legacy CLAUDE\n\nKeep this section."));
 	} finally {
 		removeTempDir(tempRoot);
 	}

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -176,7 +176,8 @@ export type SchemaId =
 	| "review-proposal-result"
 	| "run-state"
 	| "create-sub-issues-input"
-	| "create-sub-issues-result";
+	| "create-sub-issues-result"
+	| "profile";
 
 export type ReviewSeverity = "high" | "medium" | "low" | string;
 export type ReviewFindingStatus =


### PR DESCRIPTION
## Summary
- Add surface-neutral five-layer agent context model (`agent-context-template.ts`) with namespace separation and Layer 1 > 3 > 2 > 4 > 5 conflict priority
- Add repository profile schema (`.specflow/profile.json`) with closed objects, versioned JSON contract, dual load paths (setup migration vs strict reader), and field-level diff-and-resolve
- Add ecosystem detector for JS/TS, Rust, Go, Python single-root repositories with out-of-scope detection
- Add Claude adapter renderer with marker-based managed/unmanaged boundary, `writeDisposition`-gated file writes, and legacy migration
- Rewrite `specflow.setup` command body for profile-first workflow (detect → profile → validate → render)
- Update `specflow-init --update` with profile-aware rendering and confirmation gates

## Issue
Closes https://github.com/skr19930617/specflow/issues/104