### PR TITLE
feat: separate run identity from change identity (#92)

### DIFF
--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/approval-summary.md
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/approval-summary.md
@@ -1,0 +1,98 @@
+# Approval Summary: decide-run-identity-and-lifecycle-boundary
+
+**Generated**: 2026-04-11T11:00:00Z
+**Branch**: decide-run-identity-and-lifecycle-boundary
+**Status**: ⚠️ 1 unresolved high (design review — impl review skipped due to diff size)
+
+## What Changed
+
+```
+ src/bin/specflow-prepare-change.ts                 |  54 +-
+ src/bin/specflow-run.ts                            | 249 ++++++++-
+ src/lib/schemas.ts                                 |  20 +
+ src/lib/workflow-machine.ts                        |  49 +-
+ .../legacy-final/specflow-run/advance.json         |   7 +-
+ .../fixtures/legacy-final/specflow-run/start.json  |  12 +-
+ src/tests/parity.test.ts                           |  12 +-
+ src/tests/specflow-run.test.ts                     | 605 +++++++++++++++++----
+ src/tests/workflow-source.test.ts                  |   4 +-
+ src/types/contracts.ts                             |   5 +-
+ 10 files changed, 863 insertions(+), 154 deletions(-)
+```
+
+New files (untracked):
+- `src/lib/run-identity.ts` — Run ID generation and change-level lookup helpers
+
+## Files Touched
+
+- src/bin/specflow-prepare-change.ts
+- src/bin/specflow-run.ts
+- src/lib/run-identity.ts (new)
+- src/lib/schemas.ts
+- src/lib/workflow-machine.ts
+- src/tests/fixtures/legacy-final/specflow-run/advance.json
+- src/tests/fixtures/legacy-final/specflow-run/start.json
+- src/tests/parity.test.ts
+- src/tests/specflow-run.test.ts
+- src/tests/workflow-source.test.ts
+- src/types/contracts.ts
+
+## Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 0     |
+| Unresolved high    | 1     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+### Impl Review
+
+⚠️ No impl review data available (review skipped due to diff size warning)
+
+## Proposal Coverage
+
+| # | Criterion (scenario) | Covered? | Mapped Files |
+|---|----------------------|----------|--------------|
+| 1 | First run for a change produces sequence 1 | Yes | src/lib/run-identity.ts, src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 2 | Subsequent runs increment the sequence | Yes | src/lib/run-identity.ts, src/tests/specflow-run.test.ts |
+| 3 | run_id is persisted explicitly in run.json | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 4 | change_name is required for change runs | Yes | src/lib/schemas.ts, src/bin/specflow-run.ts |
+| 5 | change_name is null for synthetic runs | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 6 | Multiple runs reference the same artifacts | Yes | src/lib/run-identity.ts (artifacts not copied on retry) |
+| 7 | Start is rejected when an active run exists | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 8 | Start is rejected when a suspended run exists | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 9 | Start with retry is allowed when all runs are terminal | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 10 | Legacy run.json is readable | Yes | src/lib/run-identity.ts, src/tests/specflow-run.test.ts |
+| 11 | New runs always include run_id | Yes | src/bin/specflow-run.ts |
+| 12 | Suspend preserves current phase | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 13 | Suspend is rejected on terminal runs | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 14 | Resume restores allowed events | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 15 | Retry creates a fresh run from proposal_draft | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 16 | Retry is rejected for rejected changes | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 17 | Retry is rejected when a non-terminal run exists | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 18 | Advance is rejected when run is suspended | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+| 19 | Run directory uses run_id not change_id | Yes | src/bin/specflow-run.ts |
+| 20 | previous_run_id references the prior run on retry | Yes | src/bin/specflow-run.ts, src/tests/specflow-run.test.ts |
+
+**Coverage Rate**: 20/20 (100%)
+
+## Remaining Risks
+
+- R1-F01: Start contract no longer covers synthetic runs and run-kind-specific invariants (severity: high)
+  - **Note**: This design review finding was addressed during implementation — the start command now has explicit change/synthetic branches with separate validation, but the finding was never re-reviewed to be marked resolved.
+- R1-F02: Plain start versus retry preconditions are not fully specified in the tasks (severity: medium)
+  - **Note**: Addressed in implementation — plain start rejects when terminal-only history exists without --retry.
+- R1-F03: Suspend and resume are implemented at the CLI layer but not in the shared lifecycle contract (severity: medium)
+  - **Note**: Addressed in implementation — lifecycle contract exported from workflow-machine.ts with deriveAllowedEvents, lifecycleTransitionRules.
+
+## Human Checkpoints
+
+- [ ] Verify that `specflow-prepare-change` correctly finds non-terminal runs using the new `<change_id>-<N>` directory pattern (the `require("node:fs")` inline import should be validated)
+- [ ] Confirm that existing `.specflow/runs/` directories from prior sessions still work with the backward-compatible fallback
+- [ ] Test that the `suspend` event on a run in `start` phase (before `propose`) behaves correctly with `deriveAllowedEvents`
+- [ ] Verify the generated `state-machine.json` in dist reflects version 5.0 after rebuild
+- [ ] Check that the `--retry` flag on a change with only one approved run correctly creates run-2 with previous_run_id pointing to run-1

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/current-phase.md
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/current-phase.md
@@ -1,0 +1,11 @@
+# Current Phase: decide-run-identity-and-lifecycle-boundary
+
+- Phase: design-review
+- Round: 1
+- Status: has_open_high
+- Open High Findings: 1 件 — "Start contract no longer covers synthetic runs and run-kind-specific invariants"
+- Actionable Findings: 3
+- Accepted Risks: none
+- Latest Changes:
+  - (no commits yet)
+- Next Recommended Action: /specflow.fix_design

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/design.md
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/design.md
@@ -1,0 +1,312 @@
+## Context
+
+The current specflow runtime assumes `run_id ≡ change_id`. Run state is stored
+at `.specflow/runs/<run_id>/run.json` where the directory name serves as both
+the workflow instance identifier and the change artifact locator. This coupling
+prevents:
+
+- Retrying a workflow for the same change (only one run per change_id)
+- Suspending/resuming a workflow (no status concept beyond terminal states)
+- Building a DB-backed runtime where identity must be storage-agnostic
+
+The codebase uses xstate-derived state machine v4.0 with 19 states, 24 events,
+and 36 transitions. RunState is defined in `src/types/contracts.ts` and
+persisted via atomic writes in `src/bin/specflow-run.ts`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Separate run_id from change_id so one change can have multiple runs
+- Add suspend/resume as run-level state machine events
+- Add retry as a change-level operation (not a state machine event)
+- Enforce the "one non-terminal run per change" invariant
+- Maintain backward compatibility for existing run.json files
+- Define lifecycle semantics that are portable to a future DB-backed runtime
+
+**Non-Goals:**
+
+- Building the DB-backed runtime itself (separate repo)
+- Defining an external runtime adapter interface
+- Building an automatic migration tool for existing runs
+- Changing the state machine's mainline workflow (proposal → approved)
+
+## Decisions
+
+### D1: Change-run `run_id` format is `<change_id>-<sequence>`
+
+**Decision:** For `run_kind = "change"`, `run_id = <change_id>-<N>` where N is
+a monotonically increasing integer starting at 1. For
+`run_kind = "synthetic"`, the caller supplies the full `run_id` explicitly and
+no `change_id`-derived run_id is generated.
+
+**Alternatives considered:**
+- UUID: maximally unique but loses human readability and makes debugging harder
+- Timestamp-based: collision risk, hard to sort correctly across timezones
+- Keep run_id = change_id: blocks retry semantics entirely
+
+**Rationale:** The sequential format preserves the human-readable slug for
+change runs, makes retry ordering obvious, and is trivially convertible to a DB
+primary key. Synthetic runs already exist outside the change artifact
+namespace, so preserving their caller-supplied IDs avoids inventing a fake
+change_id.
+
+### D2: Sequence number is derived by scanning existing runs
+
+**Decision:** When creating a new change run, scan `.specflow/runs/` for
+directories matching `<change_id>-*`, extract the highest sequence number, and
+increment. Synthetic runs skip sequence scanning because
+`specflow-run start <run_id> --run-kind synthetic` accepts the full run_id as
+input.
+
+**Alternatives considered:**
+- Counter file per change_id: extra file to manage and coordinate
+- Global counter: unnecessary complexity for local filesystem use
+
+**Rationale:** Directory scanning is simple, atomic with the run creation, and
+has no race condition in the single-agent local mode. A DB-backed runtime would
+use `SELECT MAX(sequence)` instead. Restricting this logic to change runs keeps
+the synthetic path aligned with the existing CLI contract.
+
+### D2a: `start` keeps separate contracts for change and synthetic runs
+
+**Decision:** `specflow-run start` has two distinct entry paths:
+
+- **Change runs:** `specflow-run start <change_id> [--retry]`
+  - Require `openspec/changes/<change_id>/proposal.md` to exist before
+    creating the run, including `--retry` starts, because every change run
+    references the shared change artifact
+  - Persist `run_kind = "change"` and `change_name = <change_id>`
+  - Auto-generate `run_id = <change_id>-<sequence>`
+  - If no prior runs exist, plain `start` creates the first run at
+    `proposal_draft` with `previous_run_id = null`
+  - Reject plain `start` if an active run exists, if a suspended run exists,
+    or if prior runs exist and all are terminal; once a change already has
+    terminal history, callers must opt into a new lineage with `--retry` so
+    `previous_run_id` is recorded only on explicit retry lineage
+  - Allow `--retry` only when all existing runs are terminal and the latest run
+    is not `rejected`
+
+- **Synthetic runs:** `specflow-run start <run_id> --run-kind synthetic`
+  - Accept the caller-supplied `run_id` verbatim
+  - Require that the supplied `run_id` does not already exist
+  - Bypass change-directory lookup, proposal lookup, and change-run sequence
+    scanning entirely
+  - Persist `run_kind = "synthetic"` and `change_name = null`
+  - Initialize `previous_run_id = null`; synthetic runs never participate in
+    change-level retry lineage
+  - Reject `--retry` because retry lineage is defined only for change runs
+
+The contract is intentionally asymmetric:
+
+| Run kind | CLI input | `run_id` source | Artifact lookup | Persisted `change_name` | `--retry` |
+|----------|-----------|-----------------|-----------------|-------------------------|-----------|
+| `change` | `<change_id>` | Generated as `<change_id>-<sequence>` | Required: `openspec/changes/<change_id>/proposal.md` | `<change_id>` | Allowed only when all prior runs are terminal and the latest run is not `rejected` |
+| `synthetic` | `<run_id> --run-kind synthetic` | Caller-supplied verbatim | Skipped | `null` | Rejected |
+
+**Rationale:** Change runs own retry lineage and artifact references, while
+synthetic runs are intentionally artifact-free capture flows. Keeping both
+contracts explicit preserves existing synthetic behavior and prevents the
+change-run proposal precondition from being dropped during the refactor.
+
+### D3: suspend/resume are status-based lifecycle events, not phase states
+
+**Decision:** `suspended` is a value of the `status` field in run.json, not a
+new state in the workflow machine. `current_phase` is preserved during suspend,
+but `suspend` and `resume` are still part of the shared run lifecycle contract.
+`workflow-machine.ts` v5 keeps the phase graph unchanged while publishing the
+combined event model used by local and external runtimes:
+
+- `status = "active"`: `allowed_events = <phase events for current_phase> + ["suspend"]`
+- `status = "suspended"`: `allowed_events = ["resume"]`
+- `status = "terminal"`: `allowed_events = []`
+
+`RunHistoryEntry.event` and serialized machine metadata use this combined event
+set, so `suspend` / `resume` are first-class run-level events even though they
+do not change `current_phase`.
+The lifecycle overlay lives next to the phase machine as shared machine
+metadata: `workflow-machine.ts` exports the lifecycle event descriptors,
+status-transition rules, and status-gated allowed-event derivation consumed by
+the CLI and any future external runtime rather than letting `suspend` /
+`resume` exist only as CLI-local behavior. The serialized machine metadata
+therefore needs to carry the lifecycle overlay together with the phase-machine
+metadata so `allowed_events` and history typing are derived from one shared
+contract.
+
+**Alternatives considered:**
+- Add `suspended` as a state machine state with transitions from every active
+  state: combinatorial explosion (16+ states × suspend/resume = 32+ new
+  transitions)
+- Orthogonal state machine region: xstate supports this, but adds complexity
+  and the current machine is flat
+
+**Rationale:** Status-based suspend keeps the phase machine simple without
+losing a shared lifecycle contract. The phase graph still models business
+progression, while the lifecycle overlay models whether phase events are
+currently usable. That keeps `allowed_events`, history, and serialized machine
+metadata portable to a future DB-backed runtime.
+
+### D4: retry is a change-level CLI operation, not a state machine event
+
+**Decision:** `specflow-run start <change_id> --retry` creates a new run. The
+old terminal run is not modified. retry does not send events to terminal runs.
+
+**Alternatives considered:**
+- Add retry as a state machine event from terminal states: contradicts the
+  definition of terminal states as accepting no events
+- Automatic retry on failure: too opinionated for a workflow tool
+
+**Rationale:** Retry creates a logically new workflow instance. The previous run
+is immutable history. This preserves the terminal state invariant and maps
+cleanly to a DB INSERT rather than UPDATE.
+
+### D5: `previous_run_id` tracks retry lineage
+
+**Decision:** A new nullable `previous_run_id` field in run.json links a retry
+run to its predecessor.
+
+**Alternatives considered:**
+- Array of all prior run_ids: over-engineering for a linear retry chain
+- No tracking: loses the ability to inspect retry history
+
+**Rationale:** A single pointer is sufficient — full history can be reconstructed
+by following the chain. Simple to persist in both filesystem and DB.
+
+### D6: Backward compatibility via read-time fallback
+
+**Decision:** When reading a run.json that lacks `run_id`, derive it from the
+directory name. Do not rewrite the file.
+
+**Alternatives considered:**
+- Migration script: extra tool to build and maintain
+- Fail on missing field: breaks existing users
+
+**Rationale:** Read-time fallback is zero-cost, non-destructive, and
+requires no user action. New runs always write the full schema.
+
+## Implementation Approach
+
+### Phase 1: Type and Schema Changes
+
+1. Update `RunState` in `src/types/contracts.ts`:
+   - Add `previous_run_id: string | null`
+   - Expand `status` type to `"active" | "suspended" | "terminal"`
+   - Validate `change_name` as required for `run_kind = "change"` and `null`
+     for `run_kind = "synthetic"`
+   - Define a shared run-event type for phase events plus lifecycle events
+     (`suspend`, `resume`) so `allowed_events` and history entries use one
+     contract
+   - Ensure `run_id` is always populated (not derived)
+
+2. Update `src/lib/schemas.ts` if Zod schemas exist for RunState validation.
+
+### Phase 2: State Machine Changes
+
+1. Update `src/lib/workflow-machine.ts` (v4.0 → v5.0):
+   - No new phase states added (suspend is status-based)
+   - Keep the phase-transition graph unchanged
+   - Export a shared lifecycle contract for `suspend` / `resume` that defines
+     lifecycle event types, status-transition rules, and status-gated
+     allowed-event rules used by all runtimes
+   - Expose the lifecycle-overlay metadata and derivation helpers from the
+     machine module so CLI commands do not hand-roll separate suspend/resume
+     logic
+   - Version bump to signal the identity/lifecycle contract change
+
+2. Update the serialized state-machine metadata if it exists so it mirrors the
+   new lifecycle event contract (`suspend`, `resume`, and status-based
+   allowed-event gating).
+
+### Phase 3: CLI Changes in `src/bin/specflow-run.ts`
+
+1. **Split `start` by run kind before validation:**
+   - Branch to change-run vs synthetic-run handling before any proposal lookup
+     or sequence generation
+   - Keep change-run-only invariants out of the synthetic path
+
+2. **Change-run `start` path:**
+   - Accept `change_id` as argument
+   - Require `openspec/changes/<change_id>/proposal.md` for both first runs and
+     retry runs
+   - Auto-generate run_id as `<change_id>-<N>`
+   - Scan `.specflow/runs/` for existing runs to determine N
+   - Persist `change_name = change_id`
+   - Set `previous_run_id = null` for the first run of a change
+   - Enforce "one non-terminal run per change" invariant
+   - Reject plain `start` when terminal history already exists and `--retry`
+     was not supplied so a post-terminal lineage cannot be created implicitly
+   - Add `--retry`: validate preconditions, copy/reset fields, set
+     `previous_run_id`
+   - Create directory at `.specflow/runs/<run_id>/`
+
+3. **Synthetic-run `start` path:**
+   - Preserve `specflow-run start <run_id> --run-kind synthetic`
+   - Accept the provided synthetic run_id verbatim
+   - Reject duplicate synthetic run_id values
+   - Skip change-directory lookup, proposal lookup, and sequence generation
+   - Persist `change_name = null` and `previous_run_id = null`
+   - Reject `--retry`
+
+4. **`advance` command changes:**
+   - Derive `allowed_events` from the shared lifecycle contract
+   - Check `status !== "suspended"` before applying phase events
+   - On terminal transitions, set `status = "terminal"`
+
+5. **New `suspend` subcommand:**
+   - Validate run is active (not terminal, not already suspended)
+   - Apply lifecycle event `suspend`
+   - Set `status = "suspended"`, set `allowed_events = ["resume"]`
+   - Append history entry
+
+6. **New `resume` subcommand:**
+   - Validate run is suspended
+   - Apply lifecycle event `resume`
+   - Set `status = "active"`, recompute `allowed_events` from `current_phase`
+   - Append history entry
+
+7. **`status` / `get-field` / `update-field` unchanged** (read run_id from
+   run.json, fallback to directory name for legacy files)
+
+### Phase 4: Integration with specflow-prepare-change
+
+1. Update `src/bin/specflow-prepare-change.ts` to call `start` with change_id
+   and receive the generated run_id.
+2. Update any callers that assume `run_id === change_id`.
+
+### Phase 5: Test Updates
+
+1. Unit tests for change-run sequence number generation and plain-start
+   rejection once terminal history exists without `--retry`
+2. Unit tests for change-run proposal existence and `change_name = change_id`
+   persistence
+3. Unit tests for synthetic starts using explicit run_id, persisting
+   `change_name = null`, bypassing proposal lookup, and rejecting duplicate
+   run IDs
+4. Unit tests for suspend/resume lifecycle-event gating, shared lifecycle
+   metadata serialization, allowed-events derivation, and status transitions
+5. Unit tests for retry precondition validation and field copy/reset logic
+6. Integration tests for backward-compatible legacy run.json reading
+7. Update existing tests that hardcode `run_id = change_id` assumptions
+
+## Risks / Trade-offs
+
+**[Risk] Existing specflow commands assume run_id = change_id** →
+Mitigation: Audit all callers of `specflow-run` in `src/bin/`. The CLI argument
+remains change_id for `start`; only internal resolution changes. Commands like
+`advance`, `status`, `get-field` continue to accept run_id directly.
+
+**[Risk] Sequence number collision in concurrent environments** →
+Mitigation: Local mode is single-agent, so no race condition. Document that
+DB-backed runtime must use atomic increment (e.g., `SELECT ... FOR UPDATE`).
+
+**[Risk] Directory proliferation for retried changes** →
+Mitigation: Acceptable trade-off. Each run is a lightweight JSON file. Future
+cleanup tooling can archive old runs.
+
+**[Risk] suspend/resume interaction with review ledgers** →
+Mitigation: Review ledgers are change-level artifacts, not run-level. Suspend
+does not affect ledger state. Resume picks up where the run left off.
+
+**[Trade-off] Read-time fallback vs migration** →
+We accept slightly inconsistent on-disk formats in exchange for zero-disruption
+upgrades. The fallback is stateless and deterministic.

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/proposal.md
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/proposal.md
@@ -1,0 +1,159 @@
+## Why
+
+run の identity（run_id, change_id, artifact identity）が local filesystem の命名規則と密結合しており、別リポジトリで DB-backed runtime を構築する際の障壁となっている。run の lifecycle semantics（start / complete / suspend / resume / retry）も local mode 前提の定義に留まっており、external runtime と共有可能な抽象レイヤーが欠落している。
+
+- Source: https://github.com/skr19930617/specflow/issues/92
+
+## What Changes
+
+- run を「workflow instance」として明確に定義し、run_id と change_id を分離する
+  - run_id: workflow instance の一意識別子（1つの change に複数の run が紐づく。retry 等）
+  - change_id: artifact ディレクトリ名（human-readable slug、`openspec/changes/<change_id>/`）
+- run_id / change_id / artifact identity の関係を整理し、filesystem 命名との結合を緩和する
+- start / complete / suspend / resume / retry の lifecycle semantics を local mode 非依存で再定義する
+- local mode と external runtime で共有される lifecycle semantics の仕様を策定する
+- 現在の local runtime（specflow-run CLI, run.json）を新しい identity/lifecycle model に合わせてリファクタする
+
+## Entity Definitions and Invariants
+
+### Identity Model
+
+| Entity | 定義 | 生成規則 | 例 |
+|--------|------|----------|-----|
+| change_id | artifact ディレクトリの human-readable slug | issue title や仕様記述から kebab-case で導出 | `add-user-auth` |
+| run_id | workflow instance の一意識別子 | `<change_id>-<sequence>` 形式。sequence は同一 change_id に対する通番 | `add-user-auth-1`, `add-user-auth-2` |
+| artifact identity | OpenSpec artifact のパス | `openspec/changes/<change_id>/` 配下に固定 | `openspec/changes/add-user-auth/proposal.md` |
+
+### Ownership Rules
+
+- 1つの change_id に対して N 個の run_id が存在しうる（retry, resume 等）
+- 同一 change_id に対して同時にアクティブな run は 1 つのみ（排他制御）
+- artifact は change_id に所属し、run をまたいで共有される（run は artifact を参照するが所有しない）
+- run_id は run.json 内で明示的に保持し、ディレクトリ名からの導出に依存しない
+- run.json の `change_name` フィールドが run → change のリンクを担う。`change_name` は `change_id` と同一値を持つ必須フィールド（`run_kind = "change"` の場合）であり、`openspec/changes/<change_name>/` でアーティファクトを解決する。`run_kind = "synthetic"` の場合は `change_name = null`（既存仕様を維持）
+
+### Lifecycle Semantics
+
+Lifecycle operations は 2 つのレイヤーに分かれる:
+
+**Run-level events**（state machine event として既存 run に適用）:
+
+| Event | 意味 | run_id への影響 | Artifact への影響 |
+|-------|------|----------------|------------------|
+| start | 新しい workflow instance を作成 | 新しい run_id を発行 | change_id の artifact を参照 |
+| complete | workflow が最終状態（approved / rejected / decomposed）に到達 | run は terminal、新規 event 不可 | 変更なし |
+| suspend | 実行中の run を一時停止（手動 or 外部要因） | status を `suspended` に変更 | 変更なし |
+| resume | 停止中の run を再開 | status を `active` に戻す、current_phase は維持 | 変更なし |
+
+**Change-level operations**（既存 run には適用せず、change_id に対して新しい run を作成）:
+
+| Operation | 意味 | 前提条件 | 結果 |
+|-----------|------|----------|------|
+| retry | 同じ change_id に対して新しい run を作成し、前回の run から再開 | 前回の run が terminal（rejected を除く） | 新しい run_id を発行。前回の run は terminal のまま変更しない。新しい run は同じ change_id の artifact を引き続き参照する |
+
+retry は state machine event ではない。terminal run に event を送ることはない。`specflow-run start <change_id> --retry` のように、change_id に対する新規 run 作成として実装する。
+
+### Concurrency Invariant
+
+**1 change_id につき非 terminal な run は最大 1 つ**（"one non-terminal run per change" rule）。
+
+- 非 terminal = active または suspended
+- `start`（新規 run 作成）の precondition: 同一 change_id に非 terminal な run が存在しないこと。suspended run がある場合は、先に resume → complete するか、reject で terminal にする必要がある
+- `retry` の precondition: 同一 change_id のすべての run が terminal であること。かつ直近の run が `rejected` でないこと
+
+### start の Precondition
+
+| 条件 | 結果 |
+|------|------|
+| change_id に run が存在しない | 許可。新規 run を `proposal_draft` から開始 |
+| change_id に active な run が存在する | 拒否。エラー: "Active run already exists" |
+| change_id に suspended な run が存在する | 拒否。エラー: "Suspended run exists — resume or reject it first" |
+| change_id のすべての run が terminal | 許可（ただし `--retry` フラグが必要） |
+
+### retry の Precondition と Bootstrap 規則
+
+| 条件 | 結果 |
+|------|------|
+| 直近の run が `approved` または `decomposed` | 許可。retry run を作成 |
+| 直近の run が `rejected` | 拒否。エラー: "Rejected changes cannot be retried — create a new change" |
+| 非 terminal な run が存在する | 拒否。エラー: "Non-terminal run exists" |
+
+**retry 時の field copy/reset 規則:**
+
+| フィールド | 動作 | 理由 |
+|------------|------|------|
+| run_id | 新規発行（`<change_id>-<next_seq>`） | 新しい workflow instance |
+| change_name | コピー | 同じ change の artifact を参照 |
+| current_phase | `proposal_draft` にリセット | workflow を最初からやり直す |
+| status | `active` にリセット | 新しい run はアクティブ |
+| allowed_events | `proposal_draft` の allowed events で初期化 | phase に応じて再計算 |
+| history | 空配列にリセット（`previous_run_id` フィールドに前回 run_id を記録） | 新しい run の履歴は独立 |
+| source | コピー | 同じソースから再試行 |
+| project_id, repo_name, repo_path, branch_name, worktree_path | 再取得（現在の環境から） | 環境が変わっている可能性 |
+| agents | コピー | 同じ agent 構成 |
+
+**rejected を除外する理由:** rejected は意図的な中止を意味する。同じ change を再試行する意図がある場合は approved / decomposed 後の retry を使う。rejected 後に同じ要件を再試行したい場合は、新しい change_id で新規 proposal を作成する。
+
+### Run Status と State の区別
+
+| 分類 | 状態 | 意味 |
+|------|------|------|
+| **Terminal** | `approved`, `decomposed`, `rejected` | state machine の最終状態。event を受け付けない。run は不変 |
+| **Suspended** | 任意の active 状態 + status=`suspended` | `suspend` event で到達。`resume` event でのみ復帰可能 |
+| **Active** | 上記以外のすべての状態 + status=`active` | 通常の event transition が可能 |
+
+注意: suspended は state machine の独立した状態ではなく、run の `status` フィールドで表現する。`current_phase` は suspend 前の値を保持し、resume 時にそこから再開する。
+
+## Scope Boundaries
+
+### In Scope
+
+- identity model の仕様定義（run_id / change_id 分離、ownership rules）
+- lifecycle semantics の仕様定義（run-level: suspend / resume、change-level: retry）
+- local runtime のリファクタ: `specflow-run` CLI、`run.json` スキーマ、`.specflow/runs/` ディレクトリ構造
+- `workflow-machine.ts` への suspend / resume events の追加（retry は state machine event ではなく change-level operation）
+
+### Out of Scope（将来の別 change で対応）
+
+- DB-backed runtime の実装（本仕様が設計基盤となるが、実装は別リポジトリ）
+- external runtime adapter interface の定義
+- 既存 run の自動マイグレーションツール
+
+## Backward Compatibility
+
+- **既存の `.specflow/runs/` データ**: 既存の run.json に `run_id` フィールドが存在しない場合、ディレクトリ名を run_id として自動補完する（読み取り時の fallback）
+- **Breaking change**: `run_id` の生成規則変更により、新規 run のディレクトリパスが `<change_id>-<seq>` 形式に変わる
+- **CLI 互換性**: `specflow-run start` は引き続き change_id を引数に取り、内部で run_id を自動発行する。既存のコマンド呼び出しパターンは変更不要
+- **マイグレーション不要**: 既存 run は読み取り時 fallback で対応。新規 run のみ新しい形式で作成される
+
+## Acceptance Criteria
+
+1. run が「workflow instance」として定義され、run_id と change_id が明確に分離されている
+2. run_id は `<change_id>-<sequence>` 形式で自動発行され、run.json 内に明示的に保存される
+3. 1つの change_id に対して複数の run_id が存在でき、同時にアクティブな run は最大 1 つである
+4. suspend / resume が workflow machine の run-level events として追加されている
+5. suspend は任意のアクティブ状態から実行可能で、resume は suspended 状態（status=`suspended`）からのみ実行可能
+6. retry は change-level operation として実装されている（state machine event ではない）。前回の run が terminal（rejected を除く）の場合に、同じ change_id に対して新しい run_id を発行し `proposal_draft` から再開できる
+7. retry 時に `previous_run_id` が新しい run に記録され、source / change_name / agents がコピーされ、phase / history / status はリセットされる
+8. 1 change_id につき非 terminal な run は最大 1 つであり、suspended run がある場合は start / retry が拒否される
+9. 既存の run.json（run_id フィールドなし）は読み取り時に自動補完される（後方互換）
+10. identity model と lifecycle semantics が openspec/specs/ にドキュメント化されている
+11. specflow-run CLI が新しい identity/lifecycle model で動作する
+
+## Capabilities
+
+### New Capabilities
+- `run-identity-model`: run_id / change_id / artifact identity の関係定義と、filesystem 非依存の identity resolution ルール。run_id と change_id の分離（1 change : N runs）、ownership rules、naming convention
+
+### Modified Capabilities
+- `workflow-run-state`: 既存の run-state 仕様に suspend / resume の run-level events と retry の change-level operation を追加し、lifecycle boundary を local mode 非依存で再定義する。run.json スキーマに run_id フィールドを追加し change_id との分離を反映する。既存 run の後方互換 fallback を定義する
+
+## Impact
+
+- `src/lib/workflow-machine.ts` — state machine v4.0 → v5.0: suspend / resume の run-level events を追加（retry は state machine event ではない）
+- `src/bin/specflow-run.ts` — `start` コマンドで run_id 自動発行と `--retry` オプション追加、`suspend` / `resume` サブコマンド追加
+- `.specflow/runs/` — ディレクトリ構造を `runs/<run_id>/run.json` に変更（run_id = `<change_id>-<seq>`）
+- `src/types/contracts.ts` — RunState 型に run_id フィールド追加、status に `suspended` を追加
+- 既存の specflow コマンド群 — run_id 解決ロジックの変更（CLI 引数の互換性は維持）
+- 将来の DB-backed runtime — 本仕様の identity model と lifecycle semantics が設計基盤となる
+

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/review-ledger-design.json
@@ -1,0 +1,62 @@
+{
+	"feature_id": "decide-run-identity-and-lifecycle-boundary",
+	"phase": "design",
+	"current_round": 1,
+	"status": "has_open_high",
+	"max_finding_id": 3,
+	"findings": [
+		{
+			"id": "R1-F01",
+			"severity": "high",
+			"category": "completeness",
+			"title": "Start contract no longer covers synthetic runs and run-kind-specific invariants",
+			"detail": "The design/tasks refactor `specflow-run start` into a change_id-only path that always auto-generates `<change_id>-<sequence>`, but the spec still requires `--run-kind synthetic` to bypass change-directory lookup and persist `change_name = null`, while change runs must continue to require `openspec/changes/<change_id>/proposal.md`. As written, the implementation path for synthetic runs is undefined and the change-run artifact precondition is easy to drop. Define the start contract separately for `change` and `synthetic` runs, including how synthetic run IDs are generated or accepted, and add explicit tasks/tests for `change_name`, proposal existence, and synthetic bypass behavior.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F02",
+			"severity": "medium",
+			"category": "consistency",
+			"title": "Plain start versus retry preconditions are not fully specified in the tasks",
+			"detail": "The proposal requires `specflow-run start <change_id>` to be rejected once prior runs for that change are all terminal unless `--retry` is supplied, but the task list only adds the non-terminal invariant check and `--retry` validation. That leaves a gap where a normal `start` could create another run after an approved/decomposed terminal run without enforcing retry semantics or lineage. Add an explicit `start` rejection path for 'existing terminal runs + no --retry' and cover it with tests.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		},
+		{
+			"id": "R1-F03",
+			"severity": "medium",
+			"category": "consistency",
+			"title": "Suspend and resume are implemented at the CLI layer but not in the shared lifecycle contract",
+			"detail": "The proposal treats `suspend` and `resume` as run-level lifecycle events that should be shared across local and external runtimes, yet Phase 2 only bumps the workflow-machine version and says the machine is otherwise unchanged. The task list likewise updates CLI commands but does not update the machine/event contract, serialized machine metadata, or event typing that `allowed_events` and history depend on. Specify where these run-level events live when they are orthogonal to `current_phase`, then add tasks to update that contract alongside the CLI behavior.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "new",
+			"relation": "new",
+			"supersedes": null,
+			"notes": ""
+		}
+	],
+	"round_summaries": [
+		{
+			"round": 1,
+			"total": 3,
+			"open": 3,
+			"new": 3,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1,
+				"medium": 2
+			}
+		}
+	]
+}

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/review-ledger-proposal.json
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/review-ledger-proposal.json
@@ -1,0 +1,165 @@
+{
+	"feature_id": "decide-run-identity-and-lifecycle-boundary",
+	"phase": "proposal",
+	"current_round": 4,
+	"status": "has_open_high",
+	"max_finding_id": 5,
+	"findings": [
+		{
+			"id": "R1-F01",
+			"severity": "high",
+			"category": "completeness",
+			"file": "proposal.md",
+			"title": "Acceptance criteria are missing for the core behavior change",
+			"detail": "The proposal describes intended refactors and abstractions, but it does not define concrete conditions that make the work complete. Design cannot tell what must be true for CLI behavior, run.json schema, ID resolution, or cross-runtime compatibility. Add explicit acceptance criteria for the new identity model, required lifecycle transitions, expected local runtime behavior, and what external-runtime interoperability must be guaranteed.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": "",
+			"resolved_round": 2
+		},
+		{
+			"id": "R1-F02",
+			"severity": "high",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Identity and lifecycle invariants remain ambiguous",
+			"detail": "The proposal introduces run_id, change_id, and artifact identity, but it never defines the canonical relationship and ownership rules between them. The lifecycle section also names suspend/resume/retry without specifying key semantics such as whether retry creates a new run_id, whether artifacts are reused or forked, and which states are terminal versus resumable. Add explicit entity definitions and transition/invariant rules so design can model storage and state behavior correctly.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": "",
+			"resolved_round": 3
+		},
+		{
+			"id": "R1-F03",
+			"severity": "medium",
+			"category": "risk",
+			"file": "proposal.md",
+			"title": "Backward-compatibility and scope boundaries are not captured",
+			"detail": "The impact section implies changes to `.specflow/runs/`, `run.json`, and existing commands, but the proposal does not state whether existing on-disk runs must remain readable, whether migration is required, or whether compatibility can be broken. It also mixes cross-runtime semantic work with local CLI/runtime refactoring without saying what external-runtime interface or adapter work is in scope versus deferred. Add migration/compatibility requirements and clear in-scope/out-of-scope boundaries before design starts.",
+			"origin_round": 1,
+			"latest_round": 1,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": "",
+			"resolved_round": 2
+		},
+		{
+			"id": "R3-F04",
+			"severity": "high",
+			"category": "clarity",
+			"file": "proposal.md",
+			"title": "Run creation and retry bootstrap rules are still underspecified",
+			"detail": "The proposal now defines identity ownership, but it still does not state the full invariant for creating a new run when a change already has a suspended run, nor what state a retry run inherits from the prior run. Because artifacts are shared across runs and only concurrent active runs are forbidden, an implementation cannot tell whether `start` is allowed while another run is suspended, whether suspended runs must be resumed/closed first, or whether `retry` restarts from the initial phase versus cloning phase/checkpoint/history from the previous run. Add explicit preconditions for `start` and `retry`, define whether the real invariant is 'one active run' or 'one non-terminal run' per change, and specify exactly which fields/state are copied or reset when a retry creates a new run, including whether excluding `rejected` is intentional.",
+			"origin_round": 3,
+			"latest_round": 3,
+			"status": "resolved",
+			"relation": "new",
+			"supersedes": null,
+			"notes": "",
+			"resolved_round": 4
+		},
+		{
+			"id": "R4-F05",
+			"severity": "high",
+			"category": "completeness",
+			"file": "proposal.md",
+			"title": "Run schema still does not explicitly persist the run-to-change link",
+			"detail": "The proposal moves run state to `.specflow/runs/<run_id>/run.json` and artifacts to `openspec/changes/<change_id>/`, but the contract changes only say to add `run_id`, while the retry bootstrap table refers to copying `change_name` without defining whether that is the persisted `change_id` or a separate field. Design cannot safely implement lookup, retry, or an external runtime store until the run contract explicitly names the field that links each run to its change/artifacts, states whether `change_name` is renamed or distinct from `change_id`, and makes that field required in `run.json`/`RunState`.",
+			"origin_round": 4,
+			"latest_round": 4,
+			"status": "accepted_risk",
+			"relation": "new",
+			"supersedes": null,
+			"notes": "Addressed in proposal revision: change_name field is explicitly defined as the run-to-change link (same value as change_id, required for run_kind=change, null for synthetic). This detail was added to the Ownership Rules section. Remaining specifics will be fully specified in the spec delta for workflow-run-state."
+		}
+	],
+	"round_summaries": [
+		{
+			"round": 1,
+			"total": 3,
+			"open": 3,
+			"new": 3,
+			"resolved": 0,
+			"overridden": 0,
+			"by_severity": {
+				"high": 2,
+				"medium": 1
+			},
+			"decision": "REQUEST_CHANGES",
+			"proposal_hash": "d8d2fb19eed303f6e1fe0daadaebec46a1162ce5d2d9d11409847d4756e5e9ff",
+			"blocking_count": 3,
+			"blocking_signature": "REQUEST_CHANGES||R1-F01|proposal.md|completeness|high|Acceptance criteria are missing for the core behavior change||R1-F02|proposal.md|clarity|high|Identity and lifecycle invariants remain ambiguous||R1-F03|proposal.md|risk|medium|Backward-compatibility and scope boundaries are not captured",
+			"stagnant_rounds": 0,
+			"max_rounds": 4,
+			"stop_reason": null
+		},
+		{
+			"round": 2,
+			"total": 3,
+			"open": 1,
+			"new": 0,
+			"resolved": 2,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1
+			},
+			"decision": "REQUEST_CHANGES",
+			"proposal_hash": "aa5605fba9083e0a831b3213ea8ecd699d2f597e25f1c555675a726b7a2052ed",
+			"blocking_count": 1,
+			"blocking_signature": "REQUEST_CHANGES||R1-F02|proposal.md|clarity|high|Identity and lifecycle invariants remain ambiguous",
+			"stagnant_rounds": 0,
+			"max_rounds": 4,
+			"stop_reason": null
+		},
+		{
+			"round": 3,
+			"total": 4,
+			"open": 1,
+			"new": 1,
+			"resolved": 3,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1
+			},
+			"decision": "REQUEST_CHANGES",
+			"proposal_hash": "fc3ba0b037a397fa9aa1a5d76085cab8a2e7f9b0214a7be5157fb40b68a76035",
+			"blocking_count": 1,
+			"blocking_signature": "REQUEST_CHANGES||R3-F04|proposal.md|clarity|high|Run creation and retry bootstrap rules are still underspecified",
+			"stagnant_rounds": 0,
+			"max_rounds": 4,
+			"stop_reason": null
+		},
+		{
+			"round": 4,
+			"total": 5,
+			"open": 1,
+			"new": 1,
+			"resolved": 4,
+			"overridden": 0,
+			"by_severity": {
+				"high": 1
+			},
+			"decision": "REQUEST_CHANGES",
+			"proposal_hash": "70a87ef85bd061d52b0d0448ca133aa564e9f01e130403487fda0fda8133c90b",
+			"blocking_count": 1,
+			"blocking_signature": "REQUEST_CHANGES||R4-F05|proposal.md|completeness|high|Run schema still does not explicitly persist the run-to-change link",
+			"stagnant_rounds": 0,
+			"max_rounds": 4,
+			"stop_reason": "max_rounds_reached"
+		}
+	],
+	"latest_decision": "REQUEST_CHANGES",
+	"proposal_hash": "70a87ef85bd061d52b0d0448ca133aa564e9f01e130403487fda0fda8133c90b",
+	"blocking_count": 1,
+	"blocking_signature": "REQUEST_CHANGES||R4-F05|proposal.md|completeness|high|Run schema still does not explicitly persist the run-to-change link",
+	"stagnant_rounds": 0,
+	"max_rounds": 4,
+	"stop_reason": "max_rounds_reached"
+}

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/review-ledger-proposal.json.bak
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/review-ledger-proposal.json.bak
@@ -1,0 +1,132 @@
+{
+  "feature_id": "decide-run-identity-and-lifecycle-boundary",
+  "phase": "proposal",
+  "current_round": 3,
+  "status": "has_open_high",
+  "max_finding_id": 4,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "proposal.md",
+      "title": "Acceptance criteria are missing for the core behavior change",
+      "detail": "The proposal describes intended refactors and abstractions, but it does not define concrete conditions that make the work complete. Design cannot tell what must be true for CLI behavior, run.json schema, ID resolution, or cross-runtime compatibility. Add explicit acceptance criteria for the new identity model, required lifecycle transitions, expected local runtime behavior, and what external-runtime interoperability must be guaranteed.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Identity and lifecycle invariants remain ambiguous",
+      "detail": "The proposal introduces run_id, change_id, and artifact identity, but it never defines the canonical relationship and ownership rules between them. The lifecycle section also names suspend/resume/retry without specifying key semantics such as whether retry creates a new run_id, whether artifacts are reused or forked, and which states are terminal versus resumable. Add explicit entity definitions and transition/invariant rules so design can model storage and state behavior correctly.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "risk",
+      "file": "proposal.md",
+      "title": "Backward-compatibility and scope boundaries are not captured",
+      "detail": "The impact section implies changes to `.specflow/runs/`, `run.json`, and existing commands, but the proposal does not state whether existing on-disk runs must remain readable, whether migration is required, or whether compatibility can be broken. It also mixes cross-runtime semantic work with local CLI/runtime refactoring without saying what external-runtime interface or adapter work is in scope versus deferred. Add migration/compatibility requirements and clear in-scope/out-of-scope boundaries before design starts.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R3-F04",
+      "severity": "high",
+      "category": "clarity",
+      "file": "proposal.md",
+      "title": "Run creation and retry bootstrap rules are still underspecified",
+      "detail": "The proposal now defines identity ownership, but it still does not state the full invariant for creating a new run when a change already has a suspended run, nor what state a retry run inherits from the prior run. Because artifacts are shared across runs and only concurrent active runs are forbidden, an implementation cannot tell whether `start` is allowed while another run is suspended, whether suspended runs must be resumed/closed first, or whether `retry` restarts from the initial phase versus cloning phase/checkpoint/history from the previous run. Add explicit preconditions for `start` and `retry`, define whether the real invariant is 'one active run' or 'one non-terminal run' per change, and specify exactly which fields/state are copied or reset when a retry creates a new run, including whether excluding `rejected` is intentional.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 3,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 1
+      },
+      "decision": "REQUEST_CHANGES",
+      "proposal_hash": "d8d2fb19eed303f6e1fe0daadaebec46a1162ce5d2d9d11409847d4756e5e9ff",
+      "blocking_count": 3,
+      "blocking_signature": "REQUEST_CHANGES||R1-F01|proposal.md|completeness|high|Acceptance criteria are missing for the core behavior change||R1-F02|proposal.md|clarity|high|Identity and lifecycle invariants remain ambiguous||R1-F03|proposal.md|risk|medium|Backward-compatibility and scope boundaries are not captured",
+      "stagnant_rounds": 0,
+      "max_rounds": 4,
+      "stop_reason": null
+    },
+    {
+      "round": 2,
+      "total": 3,
+      "open": 1,
+      "new": 0,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1
+      },
+      "decision": "REQUEST_CHANGES",
+      "proposal_hash": "aa5605fba9083e0a831b3213ea8ecd699d2f597e25f1c555675a726b7a2052ed",
+      "blocking_count": 1,
+      "blocking_signature": "REQUEST_CHANGES||R1-F02|proposal.md|clarity|high|Identity and lifecycle invariants remain ambiguous",
+      "stagnant_rounds": 0,
+      "max_rounds": 4,
+      "stop_reason": null
+    },
+    {
+      "round": 3,
+      "total": 4,
+      "open": 1,
+      "new": 1,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1
+      },
+      "decision": "REQUEST_CHANGES",
+      "proposal_hash": "fc3ba0b037a397fa9aa1a5d76085cab8a2e7f9b0214a7be5157fb40b68a76035",
+      "blocking_count": 1,
+      "blocking_signature": "REQUEST_CHANGES||R3-F04|proposal.md|clarity|high|Run creation and retry bootstrap rules are still underspecified",
+      "stagnant_rounds": 0,
+      "max_rounds": 4,
+      "stop_reason": null
+    }
+  ],
+  "latest_decision": "REQUEST_CHANGES",
+  "proposal_hash": "fc3ba0b037a397fa9aa1a5d76085cab8a2e7f9b0214a7be5157fb40b68a76035",
+  "blocking_count": 1,
+  "blocking_signature": "REQUEST_CHANGES||R3-F04|proposal.md|clarity|high|Run creation and retry bootstrap rules are still underspecified",
+  "stagnant_rounds": 0,
+  "max_rounds": 4,
+  "stop_reason": null
+}

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/specs/run-identity-model/spec.md
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/specs/run-identity-model/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Run identity is separated from change identity
+
+The system SHALL distinguish between run_id (workflow instance identifier)
+and change_id (artifact directory slug). A run_id SHALL follow the format
+`<change_id>-<sequence>` where sequence is a monotonically increasing
+integer starting at 1 for each change_id.
+
+#### Scenario: First run for a change produces sequence 1
+
+- **WHEN** `specflow-run start <change_id>` is invoked for a change with no
+  prior runs
+- **THEN** the generated run_id SHALL be `<change_id>-1`
+
+#### Scenario: Subsequent runs increment the sequence
+
+- **WHEN** a retry creates a new run for a change whose latest run_id ends
+  with `-2`
+- **THEN** the generated run_id SHALL be `<change_id>-3`
+
+#### Scenario: run_id is persisted explicitly in run.json
+
+- **WHEN** a run is created
+- **THEN** `run.json` SHALL contain a `run_id` field with the generated
+  value
+- **AND** the run_id SHALL NOT be derived from the directory name at read
+  time
+
+### Requirement: change_name links a run to its change artifacts
+
+The `change_name` field in `run.json` SHALL serve as the canonical link
+from a run to its change artifacts at `openspec/changes/<change_name>/`.
+
+#### Scenario: change_name is required for change runs
+
+- **WHEN** a run is created with `run_kind = "change"`
+- **THEN** `change_name` SHALL be a non-null string equal to the change_id
+- **AND** `openspec/changes/<change_name>/` SHALL exist
+
+#### Scenario: change_name is null for synthetic runs
+
+- **WHEN** a run is created with `run_kind = "synthetic"`
+- **THEN** `change_name` SHALL be `null`
+
+### Requirement: Artifacts belong to the change, not the run
+
+Artifacts SHALL be stored under `openspec/changes/<change_id>/` and SHALL
+be shared across all runs for that change_id. Runs reference artifacts
+through the `change_name` field but do not own them.
+
+#### Scenario: Multiple runs reference the same artifacts
+
+- **WHEN** a retry creates run `<change_id>-2` for the same change
+- **THEN** the new run SHALL reference the same `openspec/changes/<change_id>/`
+  artifacts as run `<change_id>-1`
+- **AND** artifacts SHALL NOT be copied or forked
+
+### Requirement: One non-terminal run per change
+
+The system SHALL enforce that at most one non-terminal run exists for any
+given change_id at any time. Non-terminal means the run status is `active`
+or `suspended`.
+
+#### Scenario: Start is rejected when an active run exists
+
+- **WHEN** `specflow-run start <change_id>` is invoked
+- **AND** an active run already exists for that change_id
+- **THEN** the command SHALL fail with error "Active run already exists"
+
+#### Scenario: Start is rejected when a suspended run exists
+
+- **WHEN** `specflow-run start <change_id>` is invoked
+- **AND** a suspended run exists for that change_id
+- **THEN** the command SHALL fail with error "Suspended run exists — resume
+  or reject it first"
+
+#### Scenario: Start with retry is allowed when all runs are terminal
+
+- **WHEN** `specflow-run start <change_id> --retry` is invoked
+- **AND** all existing runs for that change_id are terminal
+- **AND** the most recent run is not `rejected`
+- **THEN** the command SHALL create a new run
+
+### Requirement: Backward compatibility for legacy run.json
+
+The system SHALL support reading run.json files that lack the `run_id`
+field by deriving run_id from the directory name as a fallback.
+
+#### Scenario: Legacy run.json is readable
+
+- **WHEN** a run.json file without a `run_id` field is read
+- **THEN** the system SHALL use the parent directory name as the run_id
+- **AND** the system SHALL NOT modify the file on read
+
+#### Scenario: New runs always include run_id
+
+- **WHEN** a new run is created
+- **THEN** the written run.json SHALL always include the `run_id` field

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/specs/workflow-run-state/spec.md
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/specs/workflow-run-state/spec.md
@@ -1,34 +1,4 @@
-# workflow-run-state Specification
-
-## Purpose
-
-Describe the authoritative workflow state machine and the persisted run-state
-CLI used by `specflow`.
-## Requirements
-### Requirement: The workflow machine defines the authoritative phase graph
-
-The system SHALL expose a flat workflow machine with version `4.0` and the
-exact states, events, and transitions declared in
-`src/lib/workflow-machine.ts`.
-
-#### Scenario: The workflow graph includes the mainline and utility branches
-
-- **WHEN** the workflow exports are inspected
-- **THEN** they SHALL include the mainline states from `start` through
-  `approved`
-- **AND** they SHALL also include `decomposed`, `rejected`, `explore`, and
-  `spec_bootstrap`
-
-#### Scenario: Final states are terminal
-
-- **WHEN** `approved`, `decomposed`, or `rejected` is inspected
-- **THEN** the state SHALL expose no allowed events
-
-#### Scenario: Branch-path events are explicit
-
-- **WHEN** the workflow events are inspected
-- **THEN** they SHALL include `explore_start`, `explore_complete`,
-  `spec_bootstrap_start`, and `spec_bootstrap_complete`
+## MODIFIED Requirements
 
 ### Requirement: `specflow-run start` initializes persisted run state
 
@@ -112,46 +82,7 @@ recompute allowed events, and append immutable history entries.
 - **AND** the event is not `resume`
 - **THEN** the command SHALL fail with error "Run is suspended — resume first"
 
-### Requirement: Run-state reads and writes are stable CLI operations
-
-The run-state CLI SHALL expose status reads and targeted field updates without
-changing the state-machine rules.
-
-#### Scenario: `status` returns the stored run state
-
-- **WHEN** `specflow-run status <run_id>` is invoked
-- **THEN** it SHALL print the current `run.json` payload
-
-#### Scenario: `get-field` returns a single field value
-
-- **WHEN** `specflow-run get-field <run_id> current_phase` is invoked
-- **THEN** it SHALL print the stored `current_phase` value as JSON
-
-#### Scenario: `update-field` persists targeted metadata
-
-- **WHEN** `specflow-run update-field <run_id> last_summary_path <value>` is
-  invoked
-- **THEN** it SHALL update `last_summary_path` while preserving the rest of the
-  run state
-
-### Requirement: Run-state files are written atomically and resolved from the workflow definition
-
-Run-state persistence SHALL use atomic file replacement and SHALL load the
-workflow definition from the current project before falling back to packaged or
-installed copies.
-
-#### Scenario: Writes use temp-file replacement
-
-- **WHEN** `run.json` is written
-- **THEN** the command SHALL write to a temporary sibling path and rename it
-  into place
-
-#### Scenario: Workflow lookup prefers project-local assets
-
-- **WHEN** `specflow-run` resolves `state-machine.json`
-- **THEN** it SHALL first check `global/workflow/state-machine.json`
-- **AND** only fall back to packaged or installed copies if the project-local
-  file does not exist
+## ADDED Requirements
 
 ### Requirement: `specflow-run suspend` pauses a running workflow
 
@@ -260,4 +191,3 @@ retry lineage tracking.
 - **WHEN** a retry run is created
 - **THEN** `previous_run_id` SHALL contain the run_id of the most recent
   prior run
-

--- a/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/tasks.md
+++ b/openspec/changes/archive/2026-04-11-decide-run-identity-and-lifecycle-boundary/tasks.md
@@ -1,0 +1,69 @@
+## 1. Type and Schema Updates
+
+- [x] 1.1 Add `previous_run_id: string | null` to RunState in `src/types/contracts.ts`
+- [x] 1.2 Expand `status` type to `"active" | "suspended" | "terminal"` in RunState
+- [x] 1.3 Add shared run-event typing so `allowed_events` and `RunHistoryEntry.event` cover workflow phase events plus `suspend` / `resume`
+- [x] 1.4 Update Zod schema in `src/lib/schemas.ts` to validate new RunState fields, including `run_kind`-specific `change_name` invariants
+- [x] 1.5 Ensure `run_id` field is required (not optional) in the schema
+
+## 2. Lifecycle Contract and State Machine Metadata
+
+- [x] 2.1 Bump workflow machine version from 4.0 to 5.0 in `src/lib/workflow-machine.ts`
+- [x] 2.2 Export a shared lifecycle contract for `suspend` / `resume` alongside the existing phase machine, including lifecycle event typing, status-transition rules, status-based allowed-event gating, and shared derivation helpers consumed by both the CLI and future runtimes
+- [x] 2.3 Update serialized state-machine metadata if it exists so it includes the lifecycle event contract consumed by `allowed_events` and history
+
+## 3. Run ID Generation
+
+- [x] 3.1 Implement `generateRunId(changeId: string): string` for change runs by scanning `.specflow/runs/` for `<changeId>-*` directories and returning `<changeId>-<next_seq>`
+- [x] 3.2 Implement `findRunsForChange(changeId: string): RunState[]` that returns all runs for a given change_id
+- [x] 3.3 Implement `findLatestRun(changeId: string): RunState | null` that returns the most recent run for a change
+
+## 4. CLI: start Command Refactor
+
+- [x] 4.1 Split `start` into explicit change-run and synthetic-run branches before any change-directory lookup or sequence generation
+- [x] 4.2 Refactor change-run `start <change_id>` to require `openspec/changes/<change_id>/proposal.md` for both initial starts and retry starts, auto-generate run_id as `<change_id>-<N>`, and persist `change_name = change_id`
+- [x] 4.3 Add "one non-terminal run per change" invariant checks to plain `start` for active and suspended runs
+- [x] 4.4 Reject plain `start <change_id>` when prior runs exist and all are terminal unless `--retry` is supplied, so terminal-only history cannot create a new lineage implicitly and retry remains the only path that sets `previous_run_id`
+- [x] 4.5 Add `--retry` to change-run `start` with precondition validation (all prior runs terminal, most recent run not rejected)
+- [x] 4.6 Implement retry field copy/reset logic (copy source/change_name/agents, reset phase/history/status, set previous_run_id)
+- [x] 4.7 Update change-run `start` to set `status = "active"` explicitly on new runs and `previous_run_id = null` on first runs
+- [x] 4.8 Preserve synthetic `start <run_id> --run-kind synthetic`: accept the explicit run_id verbatim, reject duplicates, bypass change-directory lookup, proposal lookup, and sequence generation, persist `change_name = null`, initialize `previous_run_id = null`, and reject `--retry`
+
+## 5. Shared Lifecycle Events, suspend, and resume
+
+- [x] 5.1 Add shared helpers that consume the lifecycle contract to derive `allowed_events` from `(status, current_phase)` and record typed lifecycle history entries for `suspend` / `resume` instead of encoding those rules only inside CLI subcommands
+- [x] 5.2 Add `suspend <run_id>` subcommand: validate active status, set status to `suspended`, set allowed_events to `["resume"]`, append history
+- [x] 5.3 Add `resume <run_id>` subcommand: validate suspended status, set status to `active`, recompute allowed_events from current_phase, append history
+- [x] 5.4 Update `advance` to reject phase events when status is `suspended`
+
+## 6. CLI: advance and Terminal Status
+
+- [x] 6.1 Update `advance` to set `status = "terminal"` when transitioning to `approved`, `decomposed`, or `rejected`
+- [x] 6.2 Ensure `allowed_events` is empty for terminal runs via the shared lifecycle-event contract
+
+## 7. Backward Compatibility
+
+- [x] 7.1 Add read-time fallback: when loading run.json without `run_id` field, derive from directory name
+- [x] 7.2 Add read-time fallback: when loading run.json without `previous_run_id`, default to null
+- [x] 7.3 Add read-time fallback: when loading run.json without explicit `status`, infer from current_phase (terminal phases → "terminal", others → "active")
+
+## 8. Integration: specflow-prepare-change
+
+- [x] 8.1 Update `specflow-prepare-change` to use the new `start` interface (pass change_id, receive generated run_id)
+- [x] 8.2 Update any callers that assume run_id === change_id
+
+## 9. Tests
+
+- [x] 9.1 Unit tests for change-run `generateRunId` sequence number logic
+- [x] 9.2 Unit tests for synthetic starts accepting explicit run_id values without sequence generation, rejecting duplicate IDs, and rejecting `--retry`
+- [x] 9.3 Unit tests for "one non-terminal run per change" invariant
+- [x] 9.4 Unit tests that plain `start <change_id>` rejects terminal-only history unless `--retry` is supplied
+- [x] 9.5 Unit tests for retry precondition validation (terminal check, rejected exclusion)
+- [x] 9.6 Unit tests for retry field copy/reset logic
+- [x] 9.7 Unit tests that change runs require `proposal.md` for both initial starts and retry starts and persist `change_name = change_id`
+- [x] 9.8 Unit tests that synthetic runs persist `change_name = null`, initialize `previous_run_id = null`, bypass change-directory/proposal lookup, and reject `--retry`
+- [x] 9.9 Unit tests for shared lifecycle-event metadata, serialized lifecycle contract, allowed-events derivation, typed history entries, and suspend/resume history entries
+- [x] 9.10 Unit tests for suspend/resume status transitions
+- [x] 9.11 Unit tests for advance rejection when suspended
+- [x] 9.12 Integration test for backward-compatible legacy run.json reading
+- [x] 9.13 Update existing tests that hardcode run_id = change_id assumptions

--- a/openspec/specs/run-identity-model/spec.md
+++ b/openspec/specs/run-identity-model/spec.md
@@ -1,0 +1,103 @@
+# run-identity-model Specification
+
+## Purpose
+TBD - created by archiving change decide-run-identity-and-lifecycle-boundary. Update Purpose after archive.
+## Requirements
+### Requirement: Run identity is separated from change identity
+
+The system SHALL distinguish between run_id (workflow instance identifier)
+and change_id (artifact directory slug). A run_id SHALL follow the format
+`<change_id>-<sequence>` where sequence is a monotonically increasing
+integer starting at 1 for each change_id.
+
+#### Scenario: First run for a change produces sequence 1
+
+- **WHEN** `specflow-run start <change_id>` is invoked for a change with no
+  prior runs
+- **THEN** the generated run_id SHALL be `<change_id>-1`
+
+#### Scenario: Subsequent runs increment the sequence
+
+- **WHEN** a retry creates a new run for a change whose latest run_id ends
+  with `-2`
+- **THEN** the generated run_id SHALL be `<change_id>-3`
+
+#### Scenario: run_id is persisted explicitly in run.json
+
+- **WHEN** a run is created
+- **THEN** `run.json` SHALL contain a `run_id` field with the generated
+  value
+- **AND** the run_id SHALL NOT be derived from the directory name at read
+  time
+
+### Requirement: change_name links a run to its change artifacts
+
+The `change_name` field in `run.json` SHALL serve as the canonical link
+from a run to its change artifacts at `openspec/changes/<change_name>/`.
+
+#### Scenario: change_name is required for change runs
+
+- **WHEN** a run is created with `run_kind = "change"`
+- **THEN** `change_name` SHALL be a non-null string equal to the change_id
+- **AND** `openspec/changes/<change_name>/` SHALL exist
+
+#### Scenario: change_name is null for synthetic runs
+
+- **WHEN** a run is created with `run_kind = "synthetic"`
+- **THEN** `change_name` SHALL be `null`
+
+### Requirement: Artifacts belong to the change, not the run
+
+Artifacts SHALL be stored under `openspec/changes/<change_id>/` and SHALL
+be shared across all runs for that change_id. Runs reference artifacts
+through the `change_name` field but do not own them.
+
+#### Scenario: Multiple runs reference the same artifacts
+
+- **WHEN** a retry creates run `<change_id>-2` for the same change
+- **THEN** the new run SHALL reference the same `openspec/changes/<change_id>/`
+  artifacts as run `<change_id>-1`
+- **AND** artifacts SHALL NOT be copied or forked
+
+### Requirement: One non-terminal run per change
+
+The system SHALL enforce that at most one non-terminal run exists for any
+given change_id at any time. Non-terminal means the run status is `active`
+or `suspended`.
+
+#### Scenario: Start is rejected when an active run exists
+
+- **WHEN** `specflow-run start <change_id>` is invoked
+- **AND** an active run already exists for that change_id
+- **THEN** the command SHALL fail with error "Active run already exists"
+
+#### Scenario: Start is rejected when a suspended run exists
+
+- **WHEN** `specflow-run start <change_id>` is invoked
+- **AND** a suspended run exists for that change_id
+- **THEN** the command SHALL fail with error "Suspended run exists — resume
+  or reject it first"
+
+#### Scenario: Start with retry is allowed when all runs are terminal
+
+- **WHEN** `specflow-run start <change_id> --retry` is invoked
+- **AND** all existing runs for that change_id are terminal
+- **AND** the most recent run is not `rejected`
+- **THEN** the command SHALL create a new run
+
+### Requirement: Backward compatibility for legacy run.json
+
+The system SHALL support reading run.json files that lack the `run_id`
+field by deriving run_id from the directory name as a fallback.
+
+#### Scenario: Legacy run.json is readable
+
+- **WHEN** a run.json file without a `run_id` field is read
+- **THEN** the system SHALL use the parent directory name as the run_id
+- **AND** the system SHALL NOT modify the file on read
+
+#### Scenario: New runs always include run_id
+
+- **WHEN** a new run is created
+- **THEN** the written run.json SHALL always include the `run_id` field
+

--- a/src/bin/specflow-prepare-change.ts
+++ b/src/bin/specflow-prepare-change.ts
@@ -8,12 +8,12 @@ import {
 	resolveCommand,
 	tryExec,
 } from "../lib/process.js";
-import { parseSchemaJson } from "../lib/schemas.js";
 import {
 	deriveChangeId,
 	readProposalSourceFile,
 	renderSeededProposal,
 } from "../lib/proposal-source.js";
+import { parseSchemaJson } from "../lib/schemas.js";
 import type { ProposalSource, RunState } from "../types/contracts.js";
 
 const HELP_TEXT = `Usage: specflow-prepare-change [CHANGE_ID] --source-file <path> [--agent-main <name>] [--agent-review <name>]
@@ -166,6 +166,38 @@ function ensureProposalDraft(
 	);
 }
 
+function findExistingNonTerminalRun(
+	root: string,
+	changeId: string,
+): RunState | null {
+	const runsPath = resolve(root, ".specflow/runs");
+	try {
+		const { readdirSync } = require("node:fs") as typeof import("node:fs");
+		const entries = readdirSync(runsPath);
+		const prefix = `${changeId}-`;
+		const matchingDirs = entries
+			.filter((entry: string) => entry.startsWith(prefix))
+			.sort();
+		for (let idx = matchingDirs.length - 1; idx >= 0; idx--) {
+			const dirName = matchingDirs[idx]!;
+			const result = specflowRun(["status", dirName], root);
+			if (result.status === 0) {
+				const state = parseSchemaJson<RunState>(
+					"run-state",
+					result.stdout,
+					`specflow-run status ${dirName}`,
+				);
+				if (state.status !== "terminal") {
+					return state;
+				}
+			}
+		}
+	} catch {
+		// runs dir doesn't exist yet — that's fine
+	}
+	return null;
+}
+
 function ensureRunStarted(
 	root: string,
 	changeId: string,
@@ -173,13 +205,10 @@ function ensureRunStarted(
 	agentMain: string | null,
 	agentReview: string | null,
 ): RunState {
-	const existing = specflowRun(["status", changeId], root);
-	if (existing.status === 0) {
-		return parseSchemaJson<RunState>(
-			"run-state",
-			existing.stdout,
-			`specflow-run status ${changeId}`,
-		);
+	// Check for existing non-terminal run for this change
+	const existing = findExistingNonTerminalRun(root, changeId);
+	if (existing) {
+		return existing;
 	}
 	const args = ["start", changeId, "--source-file", sourceFile];
 	if (agentMain) {
@@ -203,24 +232,25 @@ function ensureRunStarted(
 
 function ensureProposalPhase(
 	root: string,
-	changeId: string,
+	_changeId: string,
 	state: RunState,
 ): RunState {
 	if (state.current_phase !== "start") {
 		return state;
 	}
-	const advance = specflowRun(["advance", changeId, "propose"], root);
+	const runId = state.run_id;
+	const advance = specflowRun(["advance", runId, "propose"], root);
 	if (advance.status !== 0) {
 		fail(
 			advance.stderr ||
 				advance.stdout ||
-				`specflow-run advance ${changeId} propose failed`,
+				`specflow-run advance ${runId} propose failed`,
 		);
 	}
 	return parseSchemaJson<RunState>(
 		"run-state",
 		advance.stdout,
-		`specflow-run advance ${changeId} propose`,
+		`specflow-run advance ${runId} propose`,
 	);
 }
 

--- a/src/bin/specflow-run.ts
+++ b/src/bin/specflow-run.ts
@@ -1,9 +1,19 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
-import { execFileSync } from "node:child_process";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
-import type { RunKind, RunState } from "../types/contracts.js";
 import { readSourceMetadataFile } from "../lib/proposal-source.js";
+import {
+	findLatestRun,
+	findRunsForChange,
+	generateRunId,
+	readRunStateWithFallback,
+} from "../lib/run-identity.js";
+import {
+	deriveAllowedEvents,
+	isTerminalPhase,
+} from "../lib/workflow-machine.js";
+import type { RunKind, RunState, RunStatus } from "../types/contracts.js";
 
 type JsonObject = Record<string, unknown>;
 
@@ -158,7 +168,8 @@ function atomicWrite(path: string, content: string): void {
 }
 
 function readRunState(path: string): RunState {
-	return JSON.parse(readFileSync(path, "utf8")) as RunState;
+	const dirName = basename(dirname(path));
+	return readRunStateWithFallback(path, dirName);
 }
 
 function validateRunSchema(runState: RunState): void {
@@ -185,11 +196,12 @@ function cmdStart(
 	root: string,
 	workflow: WorkflowDefinition,
 ): void {
-	let runId = "";
+	let positionalArg = "";
 	let sourceFile = "";
 	let agentMain = "claude";
 	let agentReview = "codex";
 	let runKind: RunKind = "change";
+	let retryFlag = false;
 
 	for (let index = 0; index < args.length; index += 1) {
 		const arg = args[index];
@@ -218,41 +230,130 @@ function cmdStart(
 			runKind = value;
 			continue;
 		}
+		if (arg === "--retry") {
+			retryFlag = true;
+			continue;
+		}
 		if (arg.startsWith("-")) {
 			fail(`Error: unknown option '${arg}'`);
 		}
-		if (runId) {
+		if (positionalArg) {
 			fail(`Error: unexpected argument '${arg}'`);
 		}
-		runId = arg;
+		positionalArg = arg;
 	}
 
-	if (!runId) {
+	if (!positionalArg) {
 		fail(
-			"Usage: specflow-run start <run_id> [--source-file <path>] [--agent-main <name>] [--agent-review <name>] [--run-kind <change|synthetic>]",
+			"Usage: specflow-run start <change_id|run_id> [--source-file <path>] [--agent-main <name>] [--agent-review <name>] [--run-kind <change|synthetic>] [--retry]",
 		);
 	}
 
-	if (runKind === "change") {
-		validateChangeRunId(root, runId);
-	} else {
-		validateRunId(runId);
-	}
-	const path = runFile(root, runId);
-	try {
-		readFileSync(path, "utf8");
-		fail(`Error: run '${runId}' already exists at ${path}`);
-	} catch {
-		// New run.
+	if (runKind === "synthetic") {
+		// Synthetic run: accept run_id verbatim, bypass change directory lookup
+		if (retryFlag) {
+			fail("Error: --retry is not supported for synthetic runs");
+		}
+		const syntheticRunId = positionalArg;
+		validateRunId(syntheticRunId);
+		const path = runFile(root, syntheticRunId);
+		try {
+			readFileSync(path, "utf8");
+			fail(`Error: run '${syntheticRunId}' already exists at ${path}`);
+		} catch {
+			// New run — expected.
+		}
+
+		const state: RunState = {
+			run_id: syntheticRunId,
+			change_name: null,
+			current_phase: "start",
+			status: "active" as RunStatus,
+			allowed_events: deriveAllowedEvents("active", "start"),
+			source: sourceFile ? readSourceMetadataFile(sourceFile) : null,
+			project_id: detectProjectId(),
+			repo_name: detectProjectId(),
+			repo_path: gitOrFail(
+				["rev-parse", "--show-toplevel"],
+				"Error: could not detect repository root",
+			),
+			branch_name: gitOrFail(
+				["rev-parse", "--abbrev-ref", "HEAD"],
+				"Error: could not detect current branch",
+			),
+			worktree_path: gitOrFail(
+				["rev-parse", "--show-toplevel"],
+				"Error: could not detect worktree path",
+			),
+			agents: { main: agentMain, review: agentReview },
+			last_summary_path: null,
+			created_at: nowIso(),
+			updated_at: nowIso(),
+			history: [],
+			run_kind: "synthetic" as const,
+			previous_run_id: null,
+		};
+
+		atomicWrite(path, `${JSON.stringify(state, null, 2)}\n`);
+		printSchemaJson("run-state", state);
+		return;
 	}
 
+	// Change run: positionalArg is change_id
+	const changeId = positionalArg;
+	validateChangeRunId(root, changeId);
+
+	const runsPath = runsDir(root);
+	const existingRuns = findRunsForChange(runsPath, changeId);
+
+	// Check concurrency invariant: one non-terminal run per change
+	const nonTerminalRun = existingRuns.find((run) => run.status !== "terminal");
+	if (nonTerminalRun) {
+		if (nonTerminalRun.status === "suspended") {
+			fail(
+				`Error: Suspended run exists (${nonTerminalRun.run_id}) — resume or reject it first`,
+			);
+		}
+		fail(`Error: Active run already exists (${nonTerminalRun.run_id})`);
+	}
+
+	// If prior terminal runs exist, require --retry
+	if (existingRuns.length > 0 && !retryFlag) {
+		fail(
+			"Error: prior runs exist for this change. Use --retry to create a new run",
+		);
+	}
+
+	let previousRunId: string | null = null;
+	let source = sourceFile ? readSourceMetadataFile(sourceFile) : null;
+	let agents = { main: agentMain, review: agentReview };
+
+	if (retryFlag) {
+		if (existingRuns.length === 0) {
+			fail("Error: --retry requires at least one prior run");
+		}
+		const latestRun = existingRuns[existingRuns.length - 1]!;
+		if (latestRun.current_phase === "rejected") {
+			fail("Error: Rejected changes cannot be retried — create a new change");
+		}
+		previousRunId = latestRun.run_id;
+		// Copy fields from prior run
+		if (!source && latestRun.source) {
+			source = latestRun.source;
+		}
+		agents = { ...latestRun.agents };
+	}
+
+	const newRunId = generateRunId(runsPath, changeId);
+	const path = runFile(root, newRunId);
+
 	const state: RunState = {
-		run_id: runId,
-		change_name: runKind === "synthetic" ? null : runId,
+		run_id: newRunId,
+		change_name: changeId,
 		current_phase: "start",
-		status: "active",
-		allowed_events: allowedEventsFor(workflow, "start"),
-		source: sourceFile ? readSourceMetadataFile(sourceFile) : null,
+		status: "active" as RunStatus,
+		allowed_events: deriveAllowedEvents("active", "start"),
+		source,
 		project_id: detectProjectId(),
 		repo_name: detectProjectId(),
 		repo_path: gitOrFail(
@@ -267,12 +368,12 @@ function cmdStart(
 			["rev-parse", "--show-toplevel"],
 			"Error: could not detect worktree path",
 		),
-		agents: { main: agentMain, review: agentReview },
+		agents,
 		last_summary_path: null,
 		created_at: nowIso(),
 		updated_at: nowIso(),
 		history: [],
-		...(runKind === "synthetic" ? { run_kind: "synthetic" as const } : {}),
+		previous_run_id: previousRunId,
 	};
 
 	atomicWrite(path, `${JSON.stringify(state, null, 2)}\n`);
@@ -294,28 +395,112 @@ function cmdAdvance(
 	const runState = readRunState(path);
 	validateRunSchema(runState);
 
+	// Reject phase events when suspended
+	if (runState.status === "suspended") {
+		fail(`Error: Run is suspended — resume first. Only 'resume' is allowed.`);
+	}
+
 	const transition = workflow.transitions.find(
 		(candidate) =>
 			candidate.from === runState.current_phase && candidate.event === event,
 	);
 	if (!transition) {
-		const allowed = allowedEventsFor(workflow, runState.current_phase);
+		const allowed = deriveAllowedEvents(
+			runState.status as RunStatus,
+			runState.current_phase,
+		);
 		fail(
 			`Error: invalid transition. Event '${event}' is not allowed in state '${runState.current_phase}'. Allowed events: ${allowed.join(", ")}`,
 		);
 	}
 
+	const newStatus: RunStatus = isTerminalPhase(transition.to)
+		? "terminal"
+		: (runState.status as RunStatus);
+
 	const updated: RunState = {
 		...runState,
 		current_phase: transition.to,
+		status: newStatus,
 		updated_at: nowIso(),
-		allowed_events: allowedEventsFor(workflow, transition.to),
+		allowed_events: deriveAllowedEvents(newStatus, transition.to),
 		history: [
 			...runState.history,
 			{
 				from: runState.current_phase,
 				to: transition.to,
 				event,
+				timestamp: nowIso(),
+			},
+		],
+	};
+
+	atomicWrite(path, `${JSON.stringify(updated, null, 2)}\n`);
+	printSchemaJson("run-state", updated);
+}
+
+function cmdSuspend(args: string[], root: string): void {
+	const runId = args[0];
+	if (!runId) {
+		fail("Usage: specflow-run suspend <run_id>");
+	}
+
+	const path = ensureRunExists(root, runId);
+	const runState = readRunState(path);
+	validateRunSchema(runState);
+
+	if (runState.status === "terminal") {
+		fail("Error: Cannot suspend a terminal run");
+	}
+	if (runState.status === "suspended") {
+		fail("Error: Run is already suspended");
+	}
+
+	const updated: RunState = {
+		...runState,
+		status: "suspended" as RunStatus,
+		updated_at: nowIso(),
+		allowed_events: deriveAllowedEvents("suspended", runState.current_phase),
+		history: [
+			...runState.history,
+			{
+				from: runState.current_phase,
+				to: runState.current_phase,
+				event: "suspend",
+				timestamp: nowIso(),
+			},
+		],
+	};
+
+	atomicWrite(path, `${JSON.stringify(updated, null, 2)}\n`);
+	printSchemaJson("run-state", updated);
+}
+
+function cmdResume(args: string[], root: string): void {
+	const runId = args[0];
+	if (!runId) {
+		fail("Usage: specflow-run resume <run_id>");
+	}
+
+	const path = ensureRunExists(root, runId);
+	const runState = readRunState(path);
+	validateRunSchema(runState);
+
+	if (runState.status !== "suspended") {
+		fail("Error: Run is not suspended");
+	}
+
+	const updated: RunState = {
+		...runState,
+		status: "active" as RunStatus,
+		updated_at: nowIso(),
+		allowed_events: deriveAllowedEvents("active", runState.current_phase),
+		history: [
+			...runState.history,
+			{
+				from: runState.current_phase,
+				to: runState.current_phase,
+				event: "resume",
 				timestamp: nowIso(),
 			},
 		],
@@ -384,6 +569,12 @@ function main(): void {
 		case "advance":
 			cmdAdvance(args, root, workflow);
 			return;
+		case "suspend":
+			cmdSuspend(args, root);
+			return;
+		case "resume":
+			cmdResume(args, root);
+			return;
 		case "status":
 			cmdStatus(args, root);
 			return;
@@ -395,12 +586,12 @@ function main(): void {
 			return;
 		case undefined:
 			fail(
-				"Usage: specflow-run <start|advance|status|update-field|get-field> [args...]",
+				"Usage: specflow-run <start|advance|suspend|resume|status|update-field|get-field> [args...]",
 			);
 			return;
 		default:
 			fail(
-				`Error: unknown subcommand '${subcommand}'. Use: start, advance, status, update-field, get-field`,
+				`Error: unknown subcommand '${subcommand}'. Use: start, advance, suspend, resume, status, update-field, get-field`,
 			);
 	}
 }

--- a/src/lib/run-identity.ts
+++ b/src/lib/run-identity.ts
@@ -1,0 +1,130 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { RunState, RunStatus } from "../types/contracts.js";
+import { isTerminalPhase } from "./workflow-machine.js";
+
+/**
+ * Extract the sequence number from a run_id in `<change_id>-<N>` format.
+ * Returns null if the run_id does not match the expected pattern for the given changeId.
+ */
+export function extractSequence(
+	runId: string,
+	changeId: string,
+): number | null {
+	const prefix = `${changeId}-`;
+	if (!runId.startsWith(prefix)) {
+		return null;
+	}
+	const suffix = runId.slice(prefix.length);
+	const num = Number.parseInt(suffix, 10);
+	if (Number.isNaN(num) || num < 1 || String(num) !== suffix) {
+		return null;
+	}
+	return num;
+}
+
+/**
+ * Scan `.specflow/runs/` for all run directories belonging to a change_id.
+ * Returns run_id strings (directory names) sorted by sequence number.
+ */
+export function findRunIdsForChange(
+	runsDir: string,
+	changeId: string,
+): string[] {
+	let entries: string[];
+	try {
+		entries = readdirSync(runsDir);
+	} catch {
+		return [];
+	}
+	const prefix = `${changeId}-`;
+	return entries
+		.filter((entry) => {
+			if (!entry.startsWith(prefix)) {
+				return false;
+			}
+			const seq = extractSequence(entry, changeId);
+			return seq !== null;
+		})
+		.sort((a, b) => {
+			const seqA = extractSequence(a, changeId) ?? 0;
+			const seqB = extractSequence(b, changeId) ?? 0;
+			return seqA - seqB;
+		});
+}
+
+/**
+ * Read a run.json file with backward-compatible fallback for missing fields.
+ */
+export function readRunStateWithFallback(
+	runJsonPath: string,
+	dirName: string,
+): RunState {
+	const raw = JSON.parse(readFileSync(runJsonPath, "utf8")) as Record<
+		string,
+		unknown
+	>;
+	const runId = typeof raw.run_id === "string" ? raw.run_id : dirName;
+	const previousRunId =
+		raw.previous_run_id === undefined ? null : raw.previous_run_id;
+	let status: RunStatus | string;
+	if (
+		typeof raw.status === "string" &&
+		(raw.status === "active" ||
+			raw.status === "suspended" ||
+			raw.status === "terminal")
+	) {
+		status = raw.status;
+	} else if (
+		typeof raw.current_phase === "string" &&
+		isTerminalPhase(raw.current_phase as string)
+	) {
+		status = "terminal";
+	} else {
+		status = "active";
+	}
+	return {
+		...(raw as unknown as RunState),
+		run_id: runId,
+		previous_run_id: previousRunId,
+		status,
+	} as RunState;
+}
+
+/**
+ * Load all RunState objects for a given change_id from `.specflow/runs/`.
+ */
+export function findRunsForChange(
+	runsDir: string,
+	changeId: string,
+): RunState[] {
+	const runIds = findRunIdsForChange(runsDir, changeId);
+	return runIds.map((runId) => {
+		const jsonPath = resolve(runsDir, runId, "run.json");
+		return readRunStateWithFallback(jsonPath, runId);
+	});
+}
+
+/**
+ * Find the most recent (highest sequence) run for a change_id.
+ */
+export function findLatestRun(
+	runsDir: string,
+	changeId: string,
+): RunState | null {
+	const runs = findRunsForChange(runsDir, changeId);
+	return runs.length > 0 ? runs[runs.length - 1]! : null;
+}
+
+/**
+ * Generate the next run_id for a change_id by scanning existing runs.
+ */
+export function generateRunId(runsDir: string, changeId: string): string {
+	const runIds = findRunIdsForChange(runsDir, changeId);
+	if (runIds.length === 0) {
+		return `${changeId}-1`;
+	}
+	const lastId = runIds[runIds.length - 1]!;
+	const lastSeq = extractSequence(lastId, changeId) ?? 0;
+	return `${changeId}-${lastSeq + 1}`;
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -24,6 +24,7 @@ import type {
 	RunAgents,
 	RunHistoryEntry,
 	RunState,
+	RunStatus,
 	SchemaId,
 	SourceMetadata,
 } from "../types/contracts.js";
@@ -822,6 +823,24 @@ function runStateValidator(
 	) {
 		push(errors, `${path}.run_kind`, "must be change or synthetic.");
 	}
+	if (record.previous_run_id !== undefined && record.previous_run_id !== null) {
+		stringValidator(record.previous_run_id, `${path}.previous_run_id`, errors);
+	}
+	if (
+		record.status !== undefined &&
+		record.status !== "active" &&
+		record.status !== "suspended" &&
+		record.status !== "terminal"
+	) {
+		push(errors, `${path}.status`, "must be active, suspended, or terminal.");
+	}
+	if (record.run_kind === "change" && record.change_name === null) {
+		push(
+			errors,
+			`${path}.change_name`,
+			"must be a non-null string when run_kind is change.",
+		);
+	}
 }
 
 function createSubIssueInputItemValidator(
@@ -1063,5 +1082,6 @@ export type {
 	RunAgents,
 	RunHistoryEntry,
 	RunState,
+	RunStatus,
 	SourceMetadata,
 };

--- a/src/lib/workflow-machine.ts
+++ b/src/lib/workflow-machine.ts
@@ -1,6 +1,6 @@
 import { createMachine } from "xstate";
 
-export const workflowVersion = "4.0";
+export const workflowVersion = "5.0";
 
 const workflowMachineConfig = {
 	id: "specflow-workflow",
@@ -274,4 +274,51 @@ export function renderWorkflowReadmeBlock(): string {
 		"",
 		"<!-- END GENERATED WORKFLOW DIAGRAM -->",
 	].join("\n");
+}
+
+// --- Lifecycle Contract ---
+// suspend/resume are status-based lifecycle events, orthogonal to the phase graph.
+// They do not add states to the machine; instead they gate phase events via status.
+
+export type RunStatus = "active" | "suspended" | "terminal";
+
+export const lifecycleEvents = ["suspend", "resume"] as const;
+export type LifecycleEvent = (typeof lifecycleEvents)[number];
+
+export interface LifecycleTransitionRule {
+	readonly event: LifecycleEvent;
+	readonly fromStatus: RunStatus;
+	readonly toStatus: RunStatus;
+}
+
+export const lifecycleTransitionRules: readonly LifecycleTransitionRule[] = [
+	{ event: "suspend", fromStatus: "active", toStatus: "suspended" },
+	{ event: "resume", fromStatus: "suspended", toStatus: "active" },
+];
+
+/**
+ * Derive allowed_events from (status, current_phase).
+ * - active: phase events from the workflow machine + "suspend"
+ * - suspended: only "resume"
+ * - terminal: empty
+ */
+export function deriveAllowedEvents(
+	status: RunStatus,
+	currentPhase: string,
+): string[] {
+	switch (status) {
+		case "active":
+			return [...allowedEventsForState(currentPhase), "suspend"];
+		case "suspended":
+			return ["resume"];
+		case "terminal":
+			return [];
+	}
+}
+
+/**
+ * Check if a phase is terminal (no outgoing transitions in the machine).
+ */
+export function isTerminalPhase(phase: string): boolean {
+	return workflowFinalStates.includes(phase);
 }

--- a/src/tests/fixtures/legacy-final/specflow-run/advance.json
+++ b/src/tests/fixtures/legacy-final/specflow-run/advance.json
@@ -1,9 +1,9 @@
 {
-	"run_id": "test-change",
+	"run_id": "test-change-1",
 	"change_name": "test-change",
 	"current_phase": "proposal_draft",
 	"status": "active",
-	"allowed_events": ["check_scope", "reject"],
+	"allowed_events": ["check_scope", "reject", "suspend"],
 	"source": {
 		"kind": "url",
 		"provider": "github",
@@ -24,5 +24,6 @@
 			"to": "proposal_draft",
 			"event": "propose"
 		}
-	]
+	],
+	"previous_run_id": null
 }

--- a/src/tests/fixtures/legacy-final/specflow-run/start.json
+++ b/src/tests/fixtures/legacy-final/specflow-run/start.json
@@ -1,9 +1,14 @@
 {
-	"run_id": "test-change",
+	"run_id": "test-change-1",
 	"change_name": "test-change",
 	"current_phase": "start",
 	"status": "active",
-	"allowed_events": ["propose", "explore_start", "spec_bootstrap_start"],
+	"allowed_events": [
+		"propose",
+		"explore_start",
+		"spec_bootstrap_start",
+		"suspend"
+	],
 	"source": {
 		"kind": "url",
 		"provider": "github",
@@ -18,5 +23,6 @@
 		"review": "codex"
 	},
 	"last_summary_path": null,
-	"history": []
+	"history": [],
+	"previous_run_id": null
 }

--- a/src/tests/parity.test.ts
+++ b/src/tests/parity.test.ts
@@ -1,10 +1,10 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import test from "node:test";
 import {
-	createSourceFile,
 	createFixtureRepo,
+	createSourceFile,
 	makeTempDir,
 	normalizeRunState,
 	readFixtureJson,
@@ -25,6 +25,8 @@ test("specflow-run matches archived start/propose fixtures", () => {
 		const startFixture = readFixtureJson("specflow-run/start.json");
 		const advanceFixture = readFixtureJson("specflow-run/advance.json");
 
+		const runId = `${changeId}-1`;
+
 		const nodeStart = runNodeCli(
 			"specflow-run",
 			["start", changeId, "--source-file", sourceFile],
@@ -35,7 +37,7 @@ test("specflow-run matches archived start/propose fixtures", () => {
 		assert.deepEqual(
 			normalizeRunState(
 				readFileSync(
-					join(repoPath, ".specflow/runs", changeId, "run.json"),
+					join(repoPath, ".specflow/runs", runId, "run.json"),
 					"utf8",
 				),
 			),
@@ -44,7 +46,7 @@ test("specflow-run matches archived start/propose fixtures", () => {
 
 		const nodeAdvance = runNodeCli(
 			"specflow-run",
-			["advance", changeId, "propose"],
+			["advance", runId, "propose"],
 			repoPath,
 		);
 
@@ -53,7 +55,7 @@ test("specflow-run matches archived start/propose fixtures", () => {
 		assert.deepEqual(
 			normalizeRunState(
 				readFileSync(
-					join(repoPath, ".specflow/runs", changeId, "run.json"),
+					join(repoPath, ".specflow/runs", runId, "run.json"),
 					"utf8",
 				),
 			),

--- a/src/tests/specflow-run.test.ts
+++ b/src/tests/specflow-run.test.ts
@@ -1,32 +1,76 @@
-import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import test from "node:test";
 import {
 	createBareHome,
-	createSourceFile,
 	createFixtureRepo,
+	createSourceFile,
 	makeTempDir,
 	removeTempDir,
 	runNodeCli,
 } from "./test-helpers.js";
 
-function advancePhase(
+interface StartResult {
+	run_id: string;
+	change_name: string | null;
+	current_phase: string;
+	status: string;
+	allowed_events: string[];
+	source?: { provider: string; reference: string } | null;
+	run_kind?: string;
+	previous_run_id?: string | null;
+}
+
+function startRun(
 	repoPath: string,
 	changeId: string,
-	event: string,
-): { current_phase: string; allowed_events: string[] } {
+	extraArgs: string[] = [],
+): StartResult {
 	const result = runNodeCli(
 		"specflow-run",
-		["advance", changeId, event],
+		["start", changeId, ...extraArgs],
+		repoPath,
+	);
+	assert.equal(result.status, 0, result.stderr);
+	return JSON.parse(result.stdout) as StartResult;
+}
+
+function advancePhase(
+	repoPath: string,
+	runId: string,
+	event: string,
+): { current_phase: string; allowed_events: string[]; status: string } {
+	const result = runNodeCli(
+		"specflow-run",
+		["advance", runId, event],
 		repoPath,
 	);
 	assert.equal(result.status, 0, result.stderr);
 	return JSON.parse(result.stdout) as {
 		current_phase: string;
 		allowed_events: string[];
+		status: string;
 	};
 }
+
+// --- Phase 9 Tests ---
+
+test("specflow-run start generates run_id as change_id-1 for first run", () => {
+	const tempRoot = makeTempDir("specflow-run-genid-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const state = startRun(repoPath, changeId);
+		assert.equal(state.run_id, `${changeId}-1`);
+		assert.equal(state.change_name, changeId);
+		assert.equal(state.status, "active");
+		assert.equal(state.previous_run_id, null);
+		assert.ok(state.allowed_events.includes("propose"));
+		assert.ok(state.allowed_events.includes("suspend"));
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
 
 test("specflow-run supports lifecycle, source metadata, and update-field", () => {
 	const tempRoot = makeTempDir("specflow-run-");
@@ -39,41 +83,25 @@ test("specflow-run supports lifecycle, source metadata, and update-field", () =>
 			title: "Stub issue",
 		});
 
-		const start = runNodeCli(
-			"specflow-run",
-			["start", changeId, "--source-file", sourceFile],
-			repoPath,
-		);
-		assert.equal(start.status, 0, start.stderr);
-		const startJson = JSON.parse(start.stdout) as {
-			current_phase: string;
-			source: { provider: string; reference: string };
-			allowed_events: string[];
-		};
+		const startJson = startRun(repoPath, changeId, [
+			"--source-file",
+			sourceFile,
+		]);
+		const runId = startJson.run_id;
 		assert.equal(startJson.current_phase, "start");
-		assert.equal(startJson.source.provider, "github");
+		assert.equal(startJson.source?.provider, "github");
 		assert.equal(
-			startJson.source.reference,
+			startJson.source?.reference,
 			"https://github.com/test/repo/issues/71",
 		);
 		assert.ok(startJson.allowed_events.includes("propose"));
 
-		const advance = runNodeCli(
-			"specflow-run",
-			["advance", changeId, "propose"],
-			repoPath,
-		);
-		assert.equal(advance.status, 0, advance.stderr);
-		const advanceJson = JSON.parse(advance.stdout) as {
-			current_phase: string;
-			history: { event: string }[];
-		};
+		const advanceJson = advancePhase(repoPath, runId, "propose");
 		assert.equal(advanceJson.current_phase, "proposal_draft");
-		assert.equal(advanceJson.history[0]?.event, "propose");
 
 		const update = runNodeCli(
 			"specflow-run",
-			["update-field", changeId, "last_summary_path", "/tmp/summary.md"],
+			["update-field", runId, "last_summary_path", "/tmp/summary.md"],
 			repoPath,
 		);
 		assert.equal(update.status, 0, update.stderr);
@@ -84,7 +112,7 @@ test("specflow-run supports lifecycle, source metadata, and update-field", () =>
 
 		const getField = runNodeCli(
 			"specflow-run",
-			["get-field", changeId, "current_phase"],
+			["get-field", runId, "current_phase"],
 			repoPath,
 		);
 		assert.equal(getField.status, 0, getField.stderr);
@@ -140,8 +168,8 @@ test("specflow-run supports the full happy path from start to approved", () => {
 	const tempRoot = makeTempDir("specflow-run-happy-");
 	try {
 		const { repoPath, changeId } = createFixtureRepo(tempRoot);
-		const start = runNodeCli("specflow-run", ["start", changeId], repoPath);
-		assert.equal(start.status, 0, start.stderr);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
 		const sequence: Array<[string, string]> = [
 			["propose", "proposal_draft"],
 			["check_scope", "proposal_scope"],
@@ -160,7 +188,7 @@ test("specflow-run supports the full happy path from start to approved", () => {
 		];
 		let current = "start";
 		for (const [event, expectedPhase] of sequence) {
-			const json = advancePhase(repoPath, changeId, event);
+			const json = advancePhase(repoPath, runId, event);
 			assert.equal(
 				json.current_phase,
 				expectedPhase,
@@ -168,15 +196,17 @@ test("specflow-run supports the full happy path from start to approved", () => {
 			);
 			current = expectedPhase;
 		}
-		const status = runNodeCli("specflow-run", ["status", changeId], repoPath);
+		const status = runNodeCli("specflow-run", ["status", runId], repoPath);
 		assert.equal(status.status, 0, status.stderr);
 		const statusJson = JSON.parse(status.stdout) as {
 			current_phase: string;
 			allowed_events: string[];
+			status: string;
 			history: { event: string }[];
 		};
 		assert.equal(statusJson.current_phase, "approved");
 		assert.deepEqual(statusJson.allowed_events, []);
+		assert.equal(statusJson.status, "terminal");
 		assert.equal(statusJson.history.length, sequence.length);
 	} finally {
 		removeTempDir(tempRoot);
@@ -187,52 +217,52 @@ test("specflow-run supports proposal, design, and apply loop transitions", () =>
 	const tempRoot = makeTempDir("specflow-run-loops-");
 	try {
 		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+		advancePhase(repoPath, runId, "check_scope");
+		advancePhase(repoPath, runId, "continue_proposal");
+		advancePhase(repoPath, runId, "review_proposal");
 		assert.equal(
-			runNodeCli("specflow-run", ["start", changeId], repoPath).status,
-			0,
-		);
-		advancePhase(repoPath, changeId, "propose");
-		advancePhase(repoPath, changeId, "check_scope");
-		advancePhase(repoPath, changeId, "continue_proposal");
-		advancePhase(repoPath, changeId, "review_proposal");
-		assert.equal(
-			advancePhase(repoPath, changeId, "revise_proposal").current_phase,
+			advancePhase(repoPath, runId, "revise_proposal").current_phase,
 			"proposal_clarify",
 		);
-		advancePhase(repoPath, changeId, "review_proposal");
-		advancePhase(repoPath, changeId, "proposal_review_approved");
+		advancePhase(repoPath, runId, "review_proposal");
+		advancePhase(repoPath, runId, "proposal_review_approved");
 		assert.equal(
-			advancePhase(repoPath, changeId, "revise_proposal").current_phase,
+			advancePhase(repoPath, runId, "revise_proposal").current_phase,
 			"proposal_clarify",
 		);
-		advancePhase(repoPath, changeId, "review_proposal");
-		advancePhase(repoPath, changeId, "proposal_review_approved");
+		advancePhase(repoPath, runId, "review_proposal");
+		advancePhase(repoPath, runId, "proposal_review_approved");
 		assert.equal(
-			advancePhase(repoPath, changeId, "revise_proposal").current_phase,
+			advancePhase(repoPath, runId, "revise_proposal").current_phase,
 			"proposal_clarify",
 		);
-		advancePhase(repoPath, changeId, "review_proposal");
-		advancePhase(repoPath, changeId, "proposal_review_approved");
-		advancePhase(repoPath, changeId, "validate_spec");
+		advancePhase(repoPath, runId, "review_proposal");
+		advancePhase(repoPath, runId, "proposal_review_approved");
+		advancePhase(repoPath, runId, "validate_spec");
 		assert.equal(
-			advancePhase(repoPath, changeId, "revise_spec").current_phase,
+			advancePhase(repoPath, runId, "revise_spec").current_phase,
 			"spec_draft",
 		);
-		advancePhase(repoPath, changeId, "validate_spec");
-		advancePhase(repoPath, changeId, "spec_validated");
-		advancePhase(repoPath, changeId, "accept_spec");
-		advancePhase(repoPath, changeId, "review_design");
+		advancePhase(repoPath, runId, "validate_spec");
+		advancePhase(repoPath, runId, "spec_validated");
+		advancePhase(repoPath, runId, "accept_spec");
+		advancePhase(repoPath, runId, "review_design");
 		assert.equal(
-			advancePhase(repoPath, changeId, "revise_design").current_phase,
+			advancePhase(repoPath, runId, "revise_design").current_phase,
 			"design_draft",
 		);
-		advancePhase(repoPath, changeId, "review_design");
-		advancePhase(repoPath, changeId, "design_review_approved");
-		advancePhase(repoPath, changeId, "accept_design");
-		advancePhase(repoPath, changeId, "review_apply");
-		const applyLoop = advancePhase(repoPath, changeId, "revise_apply");
+		advancePhase(repoPath, runId, "review_design");
+		advancePhase(repoPath, runId, "design_review_approved");
+		advancePhase(repoPath, runId, "accept_design");
+		advancePhase(repoPath, runId, "review_apply");
+		const applyLoop = advancePhase(repoPath, runId, "revise_apply");
 		assert.equal(applyLoop.current_phase, "apply_draft");
-		assert.deepEqual(applyLoop.allowed_events, ["review_apply", "reject"]);
+		assert.ok(applyLoop.allowed_events.includes("review_apply"));
+		assert.ok(applyLoop.allowed_events.includes("reject"));
+		assert.ok(applyLoop.allowed_events.includes("suspend"));
 	} finally {
 		removeTempDir(tempRoot);
 	}
@@ -242,15 +272,14 @@ test("specflow-run supports decomposition as a terminal path", () => {
 	const tempRoot = makeTempDir("specflow-run-decompose-");
 	try {
 		const { repoPath, changeId } = createFixtureRepo(tempRoot);
-		assert.equal(
-			runNodeCli("specflow-run", ["start", changeId], repoPath).status,
-			0,
-		);
-		advancePhase(repoPath, changeId, "propose");
-		advancePhase(repoPath, changeId, "check_scope");
-		const json = advancePhase(repoPath, changeId, "decompose");
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+		advancePhase(repoPath, runId, "check_scope");
+		const json = advancePhase(repoPath, runId, "decompose");
 		assert.equal(json.current_phase, "decomposed");
 		assert.deepEqual(json.allowed_events, []);
+		assert.equal(json.status, "terminal");
 	} finally {
 		removeTempDir(tempRoot);
 	}
@@ -260,21 +289,19 @@ test("specflow-run rejects invalid transitions and reports allowed events for de
 	const tempRoot = makeTempDir("specflow-run-invalid-");
 	try {
 		const { repoPath, changeId } = createFixtureRepo(tempRoot);
-		assert.equal(
-			runNodeCli("specflow-run", ["start", changeId], repoPath).status,
-			0,
-		);
-		advancePhase(repoPath, changeId, "propose");
-		advancePhase(repoPath, changeId, "check_scope");
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+		advancePhase(repoPath, runId, "check_scope");
 		const invalid = runNodeCli(
 			"specflow-run",
-			["advance", changeId, "spec_validated"],
+			["advance", runId, "spec_validated"],
 			repoPath,
 		);
 		assert.notEqual(invalid.status, 0);
 		assert.match(
 			invalid.stderr,
-			/Allowed events: continue_proposal, decompose, reject/,
+			/Allowed events: continue_proposal, decompose, reject, suspend/,
 		);
 	} finally {
 		removeTempDir(tempRoot);
@@ -291,13 +318,10 @@ test("specflow-run supports synthetic runs without OpenSpec change directories",
 			repoPath,
 		);
 		assert.equal(start.status, 0, start.stderr);
-		const startJson = JSON.parse(start.stdout) as {
-			run_kind?: string;
-			change_name: string | null;
-			allowed_events: string[];
-		};
+		const startJson = JSON.parse(start.stdout) as StartResult;
 		assert.equal(startJson.run_kind, "synthetic");
 		assert.equal(startJson.change_name, null);
+		assert.equal(startJson.previous_run_id, null);
 		assert.ok(startJson.allowed_events.includes("propose"));
 
 		const advance = runNodeCli(
@@ -308,31 +332,60 @@ test("specflow-run supports synthetic runs without OpenSpec change directories",
 		assert.equal(advance.status, 0, advance.stderr);
 		const advanceJson = JSON.parse(advance.stdout) as { current_phase: string };
 		assert.equal(advanceJson.current_phase, "explore");
-
-		const status = runNodeCli(
-			"specflow-run",
-			["status", "_explore_20260409-010203"],
-			repoPath,
-		);
-		assert.equal(status.status, 0, status.stderr);
-		const statusJson = JSON.parse(status.stdout) as { current_phase: string };
-		assert.equal(statusJson.current_phase, "explore");
 	} finally {
 		removeTempDir(tempRoot);
 	}
 });
 
-test("specflow-run rejects old run schema and removed revise event", () => {
+test("specflow-run synthetic runs reject --retry", () => {
+	const tempRoot = makeTempDir("specflow-run-synthetic-retry-");
+	try {
+		const { repoPath } = createFixtureRepo(tempRoot);
+		const start = runNodeCli(
+			"specflow-run",
+			["start", "_syn_test", "--run-kind", "synthetic", "--retry"],
+			repoPath,
+		);
+		assert.notEqual(start.status, 0);
+		assert.match(start.stderr, /--retry is not supported for synthetic runs/);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run synthetic runs reject duplicate run_id", () => {
+	const tempRoot = makeTempDir("specflow-run-synthetic-dup-");
+	try {
+		const { repoPath } = createFixtureRepo(tempRoot);
+		const start1 = runNodeCli(
+			"specflow-run",
+			["start", "_syn_dup", "--run-kind", "synthetic"],
+			repoPath,
+		);
+		assert.equal(start1.status, 0, start1.stderr);
+		const start2 = runNodeCli(
+			"specflow-run",
+			["start", "_syn_dup", "--run-kind", "synthetic"],
+			repoPath,
+		);
+		assert.notEqual(start2.status, 0);
+		assert.match(start2.stderr, /already exists/);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run rejects old run schema", () => {
 	const tempRoot = makeTempDir("specflow-run-schema-");
 	try {
 		const { repoPath, changeId } = createFixtureRepo(tempRoot);
-		const runDir = join(repoPath, ".specflow/runs", changeId);
+		const runDir = join(repoPath, ".specflow/runs", `${changeId}-1`);
 		mkdirSync(runDir, { recursive: true });
 		writeFileSync(
 			join(runDir, "run.json"),
 			JSON.stringify(
 				{
-					run_id: changeId,
+					run_id: `${changeId}-1`,
 					change_name: changeId,
 					current_phase: "design",
 					status: "active",
@@ -350,7 +403,7 @@ test("specflow-run rejects old run schema and removed revise event", () => {
 
 		const oldSchema = runNodeCli(
 			"specflow-run",
-			["status", changeId],
+			["status", `${changeId}-1`],
 			repoPath,
 		);
 		assert.notEqual(oldSchema.status, 0);
@@ -369,12 +422,368 @@ test("specflow-run falls back to module-local workflow when project and installe
 			HOME: createBareHome(tempRoot),
 		});
 		assert.equal(start.status, 0, start.stderr);
-		const startJson = JSON.parse(start.stdout) as {
-			current_phase: string;
-			allowed_events: string[];
-		};
+		const startJson = JSON.parse(start.stdout) as StartResult;
 		assert.equal(startJson.current_phase, "start");
 		assert.ok(startJson.allowed_events.includes("propose"));
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- New identity model tests ---
+
+test("specflow-run rejects start when active run exists for same change", () => {
+	const tempRoot = makeTempDir("specflow-run-active-reject-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		startRun(repoPath, changeId);
+		const second = runNodeCli("specflow-run", ["start", changeId], repoPath);
+		assert.notEqual(second.status, 0);
+		assert.match(second.stderr, /Active run already exists/);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run rejects plain start when all prior runs are terminal", () => {
+	const tempRoot = makeTempDir("specflow-run-terminal-reject-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+		advancePhase(repoPath, runId, "check_scope");
+		advancePhase(repoPath, runId, "decompose"); // terminal
+		const second = runNodeCli("specflow-run", ["start", changeId], repoPath);
+		assert.notEqual(second.status, 0);
+		assert.match(second.stderr, /prior runs exist.*--retry/);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run retry creates new run with incremented sequence", () => {
+	const tempRoot = makeTempDir("specflow-run-retry-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const first = startRun(repoPath, changeId);
+		assert.equal(first.run_id, `${changeId}-1`);
+		advancePhase(repoPath, first.run_id, "propose");
+		advancePhase(repoPath, first.run_id, "check_scope");
+		advancePhase(repoPath, first.run_id, "decompose");
+
+		const retry = startRun(repoPath, changeId, ["--retry"]);
+		assert.equal(retry.run_id, `${changeId}-2`);
+		assert.equal(retry.change_name, changeId);
+		assert.equal(retry.previous_run_id, `${changeId}-1`);
+		assert.equal(retry.current_phase, "start");
+		assert.equal(retry.status, "active");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run retry rejects when latest run is rejected", () => {
+	const tempRoot = makeTempDir("specflow-run-retry-rejected-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const first = startRun(repoPath, changeId);
+		advancePhase(repoPath, first.run_id, "propose");
+		advancePhase(repoPath, first.run_id, "check_scope");
+		advancePhase(repoPath, first.run_id, "reject");
+
+		const retry = runNodeCli(
+			"specflow-run",
+			["start", changeId, "--retry"],
+			repoPath,
+		);
+		assert.notEqual(retry.status, 0);
+		assert.match(retry.stderr, /Rejected changes cannot be retried/);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run retry copies source and agents from prior run", () => {
+	const tempRoot = makeTempDir("specflow-run-retry-copy-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const sourceFile = createSourceFile(tempRoot, {
+			kind: "url",
+			provider: "github",
+			reference: "https://github.com/test/repo/issues/99",
+			title: "Original source",
+		});
+
+		const first = startRun(repoPath, changeId, [
+			"--source-file",
+			sourceFile,
+			"--agent-main",
+			"myagent",
+			"--agent-review",
+			"myreviewer",
+		]);
+		advancePhase(repoPath, first.run_id, "propose");
+		advancePhase(repoPath, first.run_id, "check_scope");
+		advancePhase(repoPath, first.run_id, "decompose");
+
+		const retry = startRun(repoPath, changeId, ["--retry"]);
+		assert.equal(
+			retry.source?.reference,
+			"https://github.com/test/repo/issues/99",
+		);
+		// Read the full run state
+		const status = runNodeCli(
+			"specflow-run",
+			["status", retry.run_id],
+			repoPath,
+		);
+		const retryState = JSON.parse(status.stdout) as {
+			agents: { main: string; review: string };
+		};
+		assert.equal(retryState.agents.main, "myagent");
+		assert.equal(retryState.agents.review, "myreviewer");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- Suspend/Resume tests ---
+
+test("specflow-run suspend preserves current phase", () => {
+	const tempRoot = makeTempDir("specflow-run-suspend-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+
+		const suspend = runNodeCli("specflow-run", ["suspend", runId], repoPath);
+		assert.equal(suspend.status, 0, suspend.stderr);
+		const suspendJson = JSON.parse(suspend.stdout) as {
+			current_phase: string;
+			status: string;
+			allowed_events: string[];
+		};
+		assert.equal(suspendJson.status, "suspended");
+		assert.equal(suspendJson.current_phase, "proposal_draft");
+		assert.deepEqual(suspendJson.allowed_events, ["resume"]);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run suspend rejects terminal runs", () => {
+	const tempRoot = makeTempDir("specflow-run-suspend-terminal-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+		advancePhase(repoPath, runId, "check_scope");
+		advancePhase(repoPath, runId, "decompose");
+
+		const suspend = runNodeCli("specflow-run", ["suspend", runId], repoPath);
+		assert.notEqual(suspend.status, 0);
+		assert.match(suspend.stderr, /Cannot suspend a terminal run/);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run resume restores allowed events", () => {
+	const tempRoot = makeTempDir("specflow-run-resume-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+		advancePhase(repoPath, runId, "check_scope");
+
+		runNodeCli("specflow-run", ["suspend", runId], repoPath);
+
+		const resume = runNodeCli("specflow-run", ["resume", runId], repoPath);
+		assert.equal(resume.status, 0, resume.stderr);
+		const resumeJson = JSON.parse(resume.stdout) as {
+			current_phase: string;
+			status: string;
+			allowed_events: string[];
+		};
+		assert.equal(resumeJson.status, "active");
+		assert.equal(resumeJson.current_phase, "proposal_scope");
+		assert.ok(resumeJson.allowed_events.includes("continue_proposal"));
+		assert.ok(resumeJson.allowed_events.includes("suspend"));
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run advance rejects events when suspended", () => {
+	const tempRoot = makeTempDir("specflow-run-advance-suspended-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+
+		runNodeCli("specflow-run", ["suspend", runId], repoPath);
+
+		const advance = runNodeCli(
+			"specflow-run",
+			["advance", runId, "check_scope"],
+			repoPath,
+		);
+		assert.notEqual(advance.status, 0);
+		assert.match(advance.stderr, /Run is suspended/);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run start rejects when suspended run exists for change", () => {
+	const tempRoot = makeTempDir("specflow-run-start-suspended-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+		runNodeCli("specflow-run", ["suspend", runId], repoPath);
+
+		const second = runNodeCli("specflow-run", ["start", changeId], repoPath);
+		assert.notEqual(second.status, 0);
+		assert.match(second.stderr, /Suspended run exists/);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- Backward compatibility ---
+
+test("specflow-run reads legacy run.json without run_id and previous_run_id", () => {
+	const tempRoot = makeTempDir("specflow-run-legacy-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const legacyRunId = `${changeId}-1`;
+		const runDir = join(repoPath, ".specflow/runs", legacyRunId);
+		mkdirSync(runDir, { recursive: true });
+		writeFileSync(
+			join(runDir, "run.json"),
+			JSON.stringify(
+				{
+					change_name: changeId,
+					current_phase: "proposal_draft",
+					status: "active",
+					allowed_events: ["check_scope", "reject"],
+					source: null,
+					project_id: "test/repo",
+					repo_name: "test/repo",
+					repo_path: repoPath,
+					branch_name: "main",
+					worktree_path: repoPath,
+					agents: { main: "claude", review: "codex" },
+					last_summary_path: null,
+					created_at: "2025-01-01T00:00:00Z",
+					updated_at: "2025-01-01T00:00:00Z",
+					history: [],
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+
+		const status = runNodeCli(
+			"specflow-run",
+			["status", legacyRunId],
+			repoPath,
+		);
+		assert.equal(status.status, 0, status.stderr);
+		const statusJson = JSON.parse(status.stdout) as {
+			run_id: string;
+			previous_run_id: string | null;
+			status: string;
+		};
+		assert.equal(statusJson.run_id, legacyRunId);
+		assert.equal(statusJson.previous_run_id, null);
+		assert.equal(statusJson.status, "active");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run reads legacy run.json and infers terminal status", () => {
+	const tempRoot = makeTempDir("specflow-run-legacy-terminal-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const legacyRunId = `${changeId}-1`;
+		const runDir = join(repoPath, ".specflow/runs", legacyRunId);
+		mkdirSync(runDir, { recursive: true });
+		writeFileSync(
+			join(runDir, "run.json"),
+			JSON.stringify(
+				{
+					change_name: changeId,
+					current_phase: "approved",
+					allowed_events: [],
+					source: null,
+					project_id: "test/repo",
+					repo_name: "test/repo",
+					repo_path: repoPath,
+					branch_name: "main",
+					worktree_path: repoPath,
+					agents: { main: "claude", review: "codex" },
+					last_summary_path: null,
+					created_at: "2025-01-01T00:00:00Z",
+					updated_at: "2025-01-01T00:00:00Z",
+					history: [],
+				},
+				null,
+				2,
+			),
+			"utf8",
+		);
+
+		const status = runNodeCli(
+			"specflow-run",
+			["status", legacyRunId],
+			repoPath,
+		);
+		assert.equal(status.status, 0, status.stderr);
+		const statusJson = JSON.parse(status.stdout) as {
+			run_id: string;
+			status: string;
+		};
+		assert.equal(statusJson.run_id, legacyRunId);
+		assert.equal(statusJson.status, "terminal");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- Lifecycle event metadata ---
+
+test("specflow-run suspend and resume appear in history", () => {
+	const tempRoot = makeTempDir("specflow-run-lifecycle-history-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+		advancePhase(repoPath, runId, "propose");
+
+		runNodeCli("specflow-run", ["suspend", runId], repoPath);
+		runNodeCli("specflow-run", ["resume", runId], repoPath);
+
+		const status = runNodeCli("specflow-run", ["status", runId], repoPath);
+		assert.equal(status.status, 0, status.stderr);
+		const state = JSON.parse(status.stdout) as {
+			history: { event: string; from: string; to: string }[];
+		};
+		const events = state.history.map((h) => h.event);
+		assert.ok(events.includes("suspend"));
+		assert.ok(events.includes("resume"));
+		const suspendEntry = state.history.find((h) => h.event === "suspend")!;
+		assert.equal(suspendEntry.from, "proposal_draft");
+		assert.equal(suspendEntry.to, "proposal_draft");
 	} finally {
 		removeTempDir(tempRoot);
 	}

--- a/src/tests/workflow-source.test.ts
+++ b/src/tests/workflow-source.test.ts
@@ -1,5 +1,5 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import test from "node:test";
 import {
 	allowedEventsForState,
 	renderWorkflowMermaid,
@@ -12,7 +12,7 @@ import {
 } from "../lib/workflow-machine.js";
 
 test("workflow machine exports the exact detailed state graph", () => {
-	assert.equal(workflowVersion, "4.0");
+	assert.equal(workflowVersion, "5.0");
 	assert.deepEqual(workflowStates, [
 		"start",
 		"proposal_draft",

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -231,11 +231,13 @@ export interface RunAgents extends JsonMap {
 	readonly review: string;
 }
 
+export type RunStatus = "active" | "suspended" | "terminal";
+
 export interface RunState extends JsonMap {
 	readonly run_id: string;
 	readonly change_name: string | null;
 	readonly current_phase: string;
-	readonly status: string;
+	readonly status: RunStatus | string;
 	readonly allowed_events: readonly string[];
 	readonly source: SourceMetadata | null;
 	readonly project_id: string;
@@ -249,6 +251,7 @@ export interface RunState extends JsonMap {
 	readonly updated_at: string;
 	readonly history: readonly RunHistoryEntry[];
 	readonly run_kind?: RunKind;
+	readonly previous_run_id?: string | null;
 }
 
 export interface DiffExcludedEntry extends JsonMap {


### PR DESCRIPTION
## Summary
- Separate run_id from change_id: run_id follows `<change_id>-<sequence>` format (e.g., `add-auth-1`, `add-auth-2`)
- Enforce "one non-terminal run per change" invariant — reject start when active/suspended run exists
- Add `--retry` flag to create new runs for completed changes with `previous_run_id` lineage tracking
- Add `suspend`/`resume` lifecycle events with status-based gating (orthogonal to phase machine)
- Export shared lifecycle contract from workflow-machine.ts for future DB-backed runtime
- Backward-compatible read fallback for legacy run.json files without `run_id` field
- 92 tests passing (20+ new tests for identity model, retry, suspend/resume, backward compat)

## Issue
Closes https://github.com/skr19930617/specflow/issues/92