### PR TITLE
feat: adapt multi-agent review/fix pipeline with switchable drivers

### DIFF
--- a/assets/template/.specflow/config.env
+++ b/assets/template/.specflow/config.env
@@ -1,9 +1,20 @@
 # specflow configuration
-# このファイルは specflow 実行時に source される
 # プロジェクト固有の環境変数をここに追加する
 
-# 例: Codex のモデルを変更する場合
-# export CODEX_MODEL="gpt-5.4"
+# --- Agent Configuration ---
+# Main agent: 実装・fix (コード修正) を担当するエージェント
+# 選択肢: claude, codex, copilot
+SPECFLOW_MAIN_AGENT=claude
+
+# Review agent: コードレビューを担当するエージェント (構造化 JSON 出力が必要)
+# 選択肢: codex, claude
+SPECFLOW_REVIEW_AGENT=codex
+
+# --- Agent Command Overrides ---
+# エージェントの実行コマンドをカスタムパスに変更する場合
+# SPECFLOW_CODEX=/usr/local/bin/codex
+# SPECFLOW_CLAUDE=/usr/local/bin/claude
+# SPECFLOW_COPILOT=/usr/local/bin/copilot
 
 # Diff filter: colon-separated glob patterns to exclude from review
 # Example: DIFF_EXCLUDE_PATTERNS="*.lock:generated/**:vendor/**"

--- a/src/bin/specflow-init.ts
+++ b/src/bin/specflow-init.ts
@@ -25,8 +25,8 @@ import {
 import type { InitProjectResult, Manifest } from "../types/contracts.js";
 
 const CONFIG_DIR = resolve(process.env.HOME ?? "", ".config/specflow");
-const MAIN_AGENTS = ["claude"];
-const REVIEW_AGENTS = ["codex"];
+const MAIN_AGENTS = ["claude", "codex", "copilot"];
+const REVIEW_AGENTS = ["codex", "claude"];
 
 function log(message: string): void {
 	process.stderr.write(`${message}\n`);

--- a/src/bin/specflow-review-apply.ts
+++ b/src/bin/specflow-review-apply.ts
@@ -25,13 +25,19 @@ import {
 } from "../lib/review-ledger.js";
 import {
 	buildPrompt,
-	callCodex,
+	callMainAgent,
+	callReviewAgent,
 	diffWarningSummary,
 	errorJson,
+	loadConfigEnv,
+	type MainAgentName,
+	type ReviewAgentName,
 	readPrompt,
 	readProposalFromStore,
 	readReviewConfig,
 	renderCurrentPhaseToStore,
+	resolveMainAgent,
+	resolveReviewAgent,
 	unresolvedHighCount,
 	validateChangeFromStore,
 } from "../lib/review-runtime.js";
@@ -209,6 +215,8 @@ function runReviewPipeline(
 	changeId: string,
 	rereviewMode: boolean,
 	skipDiffCheck: boolean,
+	reviewAgent: ReviewAgentName,
+	mainAgent: MainAgentName,
 ): ReviewResult {
 	process.stderr.write("Running diff filter...\n");
 	const rawDiff = diffFilter(runtimeRoot, projectRoot);
@@ -251,7 +259,7 @@ function runReviewPipeline(
 	}
 
 	if (rereviewMode) {
-		process.stderr.write("Applying fixes via Codex...\n");
+		process.stderr.write(`Applying fixes via ${mainAgent}...\n`);
 		const beforeFix = readLedgerFromStore(
 			changeStore,
 			changeId,
@@ -261,7 +269,8 @@ function runReviewPipeline(
 			const status = String(finding.status ?? "");
 			return status === "new" || status === "open";
 		});
-		void callCodex(
+		void callMainAgent(
+			mainAgent,
 			projectRoot,
 			buildFixPrompt(changeStore, changeId, diff, fixFindings),
 		);
@@ -279,7 +288,7 @@ function runReviewPipeline(
 		diffSummary = diffWarningSummary(rerun.summary, config.diffWarnThreshold);
 	}
 
-	process.stderr.write("Calling Codex for review...\n");
+	process.stderr.write(`Calling ${reviewAgent} for review...\n`);
 	const prompt = rereviewMode
 		? (() => {
 				const priorLedger = readLedgerFromStore(
@@ -300,7 +309,11 @@ function runReviewPipeline(
 				);
 			})()
 		: buildReviewPrompt(runtimeRoot, changeStore, changeId, diff);
-	const codexResult = callCodex<Record<string, unknown>>(projectRoot, prompt);
+	const reviewResult = callReviewAgent<Record<string, unknown>>(
+		reviewAgent,
+		projectRoot,
+		prompt,
+	);
 
 	let parseError = false;
 	let rawResponse = "";
@@ -310,10 +323,14 @@ function runReviewPipeline(
 		summary: "parse failed",
 	};
 
-	if (!codexResult.ok) {
-		if (codexResult.exitCode) {
+	if (!reviewResult.ok) {
+		if (reviewResult.exitCode) {
 			return {
-				...errorJson(action, changeId, `codex_exit_${codexResult.exitCode}`),
+				...errorJson(
+					action,
+					changeId,
+					`review_agent_exit_${reviewResult.exitCode}`,
+				),
 				review: null,
 				ledger: null,
 				autofix: null,
@@ -321,9 +338,9 @@ function runReviewPipeline(
 			};
 		}
 		parseError = true;
-		rawResponse = codexResult.rawResponse;
-	} else if (codexResult.payload) {
-		reviewJson = codexResult.payload;
+		rawResponse = reviewResult.rawResponse;
+	} else if (reviewResult.payload) {
+		reviewJson = reviewResult.payload;
 	}
 
 	const ledgerRead = readLedgerFromStore(
@@ -406,6 +423,8 @@ function runAutofixLoop(
 	changeStore: ChangeArtifactStore,
 	changeId: string,
 	maxRounds: number,
+	reviewAgent: ReviewAgentName,
+	mainAgent: MainAgentName,
 ): ReviewResult {
 	let ledger = readLedgerFromStore(
 		changeStore,
@@ -436,7 +455,8 @@ function runAutofixLoop(
 			const status = String(finding.status ?? "");
 			return status === "new" || status === "open";
 		});
-		const fixResult = callCodex(
+		const fixResult = callMainAgent(
+			mainAgent,
 			projectRoot,
 			buildFixPrompt(
 				changeStore,
@@ -465,6 +485,8 @@ function runAutofixLoop(
 			changeId,
 			true,
 			true,
+			reviewAgent,
+			mainAgent,
 		);
 		if (reviewResult.status === "error" || reviewResult.review?.parse_error) {
 			consecutiveFailures += 1;
@@ -585,6 +607,8 @@ function cmdReview(
 	projectRoot: string,
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
+	reviewAgent: ReviewAgentName,
+	mainAgent: MainAgentName,
 ): ReviewResult {
 	let changeId = "";
 	let skipDiffCheck = false;
@@ -592,6 +616,10 @@ function cmdReview(
 		const arg = args[index];
 		if (arg === "--skip-diff-check") {
 			skipDiffCheck = true;
+			continue;
+		}
+		if (arg === "--review-agent") {
+			index += 1;
 			continue;
 		}
 		if (arg.startsWith("-")) {
@@ -615,6 +643,8 @@ function cmdReview(
 		changeId,
 		false,
 		skipDiffCheck,
+		reviewAgent,
+		mainAgent,
 	);
 }
 
@@ -623,6 +653,8 @@ function cmdFixReview(
 	projectRoot: string,
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
+	reviewAgent: ReviewAgentName,
+	mainAgent: MainAgentName,
 ): ReviewResult {
 	let changeId = "";
 	let skipDiffCheck = false;
@@ -633,6 +665,10 @@ function cmdFixReview(
 		}
 		if (arg === "--skip-diff-check") {
 			skipDiffCheck = true;
+			continue;
+		}
+		if (arg === "--review-agent") {
+			index += 1;
 			continue;
 		}
 		if (arg.startsWith("-")) {
@@ -658,6 +694,8 @@ function cmdFixReview(
 		changeId,
 		true,
 		skipDiffCheck,
+		reviewAgent,
+		mainAgent,
 	);
 }
 
@@ -666,6 +704,8 @@ function cmdAutofixLoop(
 	projectRoot: string,
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
+	reviewAgent: ReviewAgentName,
+	mainAgent: MainAgentName,
 ): ReviewResult {
 	let changeId = "";
 	let maxRounds = "";
@@ -674,6 +714,10 @@ function cmdAutofixLoop(
 		if (arg === "--max-rounds") {
 			maxRounds =
 				args[index + 1] ?? die("Error: --max-rounds requires a value");
+			index += 1;
+			continue;
+		}
+		if (arg === "--review-agent") {
 			index += 1;
 			continue;
 		}
@@ -706,24 +750,59 @@ function cmdAutofixLoop(
 		changeStore,
 		changeId,
 		rounds,
+		reviewAgent,
+		mainAgent,
 	);
+}
+
+function parseReviewAgentFlag(args: readonly string[]): string | undefined {
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] === "--review-agent") {
+			return args[index + 1];
+		}
+	}
+	return undefined;
 }
 
 function main(): void {
 	const projectRoot = ensureGitRepo();
+	loadConfigEnv(projectRoot);
 	const changeStore = createLocalFsChangeArtifactStore(projectRoot);
 	const runtimeRoot = moduleRepoRoot(import.meta.url);
 	const [subcommand = "", ...args] = process.argv.slice(2);
+	const reviewAgent = resolveReviewAgent(parseReviewAgentFlag(args));
+	const mainAgent = resolveMainAgent();
 	let result: ReviewResult;
 	switch (subcommand) {
 		case "review":
-			result = cmdReview(runtimeRoot, projectRoot, changeStore, args);
+			result = cmdReview(
+				runtimeRoot,
+				projectRoot,
+				changeStore,
+				args,
+				reviewAgent,
+				mainAgent,
+			);
 			break;
 		case "fix-review":
-			result = cmdFixReview(runtimeRoot, projectRoot, changeStore, args);
+			result = cmdFixReview(
+				runtimeRoot,
+				projectRoot,
+				changeStore,
+				args,
+				reviewAgent,
+				mainAgent,
+			);
 			break;
 		case "autofix-loop":
-			result = cmdAutofixLoop(runtimeRoot, projectRoot, changeStore, args);
+			result = cmdAutofixLoop(
+				runtimeRoot,
+				projectRoot,
+				changeStore,
+				args,
+				reviewAgent,
+				mainAgent,
+			);
 			break;
 		case "":
 			die(

--- a/src/bin/specflow-review-design.ts
+++ b/src/bin/specflow-review-design.ts
@@ -30,13 +30,19 @@ import {
 } from "../lib/review-ledger.js";
 import {
 	buildPrompt,
-	callCodex,
+	callMainAgent,
+	callReviewAgent,
 	contentHash,
 	errorJson,
+	loadConfigEnv,
+	type MainAgentName,
+	type ReviewAgentName,
 	readDesignArtifactsFromStore,
 	readPrompt,
 	readReviewConfig,
 	renderCurrentPhaseToStore,
+	resolveMainAgent,
+	resolveReviewAgent,
 	unresolvedHighCount,
 	validateChangeFromStore,
 } from "../lib/review-runtime.js";
@@ -216,6 +222,7 @@ function runReviewPipeline(
 	action: string,
 	changeId: string,
 	rereviewMode: boolean,
+	reviewAgent: ReviewAgentName,
 ): ReviewResult {
 	process.stderr.write("Reading artifacts...\n");
 	if (!readDesignArtifactsFromStore(changeStore, changeId)) {
@@ -228,7 +235,7 @@ function runReviewPipeline(
 		};
 	}
 
-	process.stderr.write("Calling Codex for design review...\n");
+	process.stderr.write(`Calling ${reviewAgent} for design review...\n`);
 	const prompt = rereviewMode
 		? (() => {
 				const priorLedger = readLedgerFromStore(
@@ -248,7 +255,11 @@ function runReviewPipeline(
 				);
 			})()
 		: buildReviewPrompt(runtimeRoot, changeStore, changeId);
-	const codexResult = callCodex<Record<string, unknown>>(projectRoot, prompt);
+	const reviewAgentResult = callReviewAgent<Record<string, unknown>>(
+		reviewAgent,
+		projectRoot,
+		prompt,
+	);
 
 	let parseError = false;
 	let rawResponse = "";
@@ -258,10 +269,14 @@ function runReviewPipeline(
 		summary: "parse failed",
 	};
 
-	if (!codexResult.ok) {
-		if (codexResult.exitCode) {
+	if (!reviewAgentResult.ok) {
+		if (reviewAgentResult.exitCode) {
 			return {
-				...errorJson(action, changeId, `codex_exit_${codexResult.exitCode}`),
+				...errorJson(
+					action,
+					changeId,
+					`review_agent_exit_${reviewAgentResult.exitCode}`,
+				),
 				review: null,
 				ledger: null,
 				autofix: null,
@@ -269,9 +284,9 @@ function runReviewPipeline(
 			};
 		}
 		parseError = true;
-		rawResponse = codexResult.rawResponse;
-	} else if (codexResult.payload) {
-		reviewJson = codexResult.payload;
+		rawResponse = reviewAgentResult.rawResponse;
+	} else if (reviewAgentResult.payload) {
+		reviewJson = reviewAgentResult.payload;
 	}
 
 	const ledgerRead = readLedgerFromStore(
@@ -382,6 +397,8 @@ function runAutofixLoop(
 	changeStore: ChangeArtifactStore,
 	changeId: string,
 	maxRounds: number,
+	reviewAgent: ReviewAgentName,
+	mainAgent: MainAgentName,
 ): ReviewResult {
 	if (!readDesignArtifactsFromStore(changeStore, changeId)) {
 		return {
@@ -429,7 +446,8 @@ function runAutofixLoop(
 		const preFixHash =
 			artifactHash(changeStore, changeId, ChangeArtifactType.Design) +
 			artifactHash(changeStore, changeId, ChangeArtifactType.Tasks);
-		const fixResult = callCodex(
+		const fixResult = callMainAgent(
+			mainAgent,
 			projectRoot,
 			buildFixPrompt(runtimeRoot, changeStore, changeId, actionableFindings),
 		);
@@ -467,6 +485,7 @@ function runAutofixLoop(
 			"fix_review",
 			changeId,
 			true,
+			reviewAgent,
 		);
 		if (reviewResult.status === "error" || reviewResult.review?.parse_error) {
 			consecutiveFailures += 1;
@@ -579,6 +598,7 @@ function cmdReview(
 	projectRoot: string,
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
+	reviewAgent: ReviewAgentName,
 ): ReviewResult {
 	const changeId = args[0];
 	if (!changeId) {
@@ -607,6 +627,7 @@ function cmdReview(
 		"review",
 		changeId,
 		false,
+		reviewAgent,
 	);
 }
 
@@ -615,6 +636,7 @@ function cmdFixReview(
 	projectRoot: string,
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
+	reviewAgent: ReviewAgentName,
 ): ReviewResult {
 	const changeId = args[0];
 	if (!changeId) {
@@ -645,6 +667,7 @@ function cmdFixReview(
 		"fix_review",
 		changeId,
 		true,
+		reviewAgent,
 	);
 }
 
@@ -653,6 +676,8 @@ function cmdAutofixLoop(
 	projectRoot: string,
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
+	reviewAgent: ReviewAgentName,
+	mainAgent: MainAgentName,
 ): ReviewResult {
 	const changeId = args[0];
 	if (!changeId) {
@@ -680,14 +705,28 @@ function cmdAutofixLoop(
 		changeStore,
 		changeId,
 		rounds,
+		reviewAgent,
+		mainAgent,
 	);
+}
+
+function parseReviewAgentFlag(args: readonly string[]): string | undefined {
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] === "--review-agent") {
+			return args[index + 1];
+		}
+	}
+	return undefined;
 }
 
 function main(): void {
 	const projectRoot = ensureGitRepo();
+	loadConfigEnv(projectRoot);
 	const runtimeRoot = moduleRepoRoot(import.meta.url);
 	const changeStore = createLocalFsChangeArtifactStore(projectRoot);
 	const [subcommand, ...args] = process.argv.slice(2);
+	const reviewAgent = resolveReviewAgent(parseReviewAgentFlag(args));
+	const mainAgent = resolveMainAgent();
 	if (!subcommand) {
 		process.stderr.write(`Usage: specflow-review-design <subcommand> <CHANGE_ID> [options]
 
@@ -703,13 +742,32 @@ Subcommands:
 	let result: ReviewResult;
 	switch (subcommand) {
 		case "review":
-			result = cmdReview(runtimeRoot, projectRoot, changeStore, args);
+			result = cmdReview(
+				runtimeRoot,
+				projectRoot,
+				changeStore,
+				args,
+				reviewAgent,
+			);
 			break;
 		case "fix-review":
-			result = cmdFixReview(runtimeRoot, projectRoot, changeStore, args);
+			result = cmdFixReview(
+				runtimeRoot,
+				projectRoot,
+				changeStore,
+				args,
+				reviewAgent,
+			);
 			break;
 		case "autofix-loop":
-			result = cmdAutofixLoop(runtimeRoot, projectRoot, changeStore, args);
+			result = cmdAutofixLoop(
+				runtimeRoot,
+				projectRoot,
+				changeStore,
+				args,
+				reviewAgent,
+				mainAgent,
+			);
 			break;
 		default:
 			die(

--- a/src/bin/specflow-review-proposal.ts
+++ b/src/bin/specflow-review-proposal.ts
@@ -29,12 +29,15 @@ import {
 } from "../lib/review-ledger.js";
 import {
 	buildPrompt,
-	callCodex,
+	callReviewAgent,
 	errorJson,
+	loadConfigEnv,
+	type ReviewAgentName,
 	readPrompt,
 	readProposalFromStore,
 	readReviewConfig,
 	renderCurrentPhaseToStore,
+	resolveReviewAgent,
 	validateChangeFromStore,
 } from "../lib/review-runtime.js";
 import type {
@@ -352,6 +355,7 @@ function runReviewPipeline(
 	action: string,
 	changeId: string,
 	rereviewMode: boolean,
+	agent: ReviewAgentName,
 ): ReviewResult {
 	process.stderr.write("Reading proposal...\n");
 	const proposalRef = changeRef(changeId, ChangeArtifactType.Proposal);
@@ -430,7 +434,7 @@ function runReviewPipeline(
 		}
 	}
 
-	process.stderr.write("Calling Codex for proposal review...\n");
+	process.stderr.write(`Calling ${agent} for proposal review...\n`);
 	const prompt = rereviewMode
 		? buildRereviewPrompt(
 				runtimeRoot,
@@ -442,7 +446,11 @@ function runReviewPipeline(
 				Number(ledger.max_finding_id ?? 0),
 			)
 		: buildReviewPrompt(runtimeRoot, changeStore, changeId);
-	const codexResult = callCodex<Record<string, unknown>>(projectRoot, prompt);
+	const reviewAgentResult = callReviewAgent<Record<string, unknown>>(
+		agent,
+		projectRoot,
+		prompt,
+	);
 
 	let parseError = false;
 	let rawResponse = "";
@@ -452,10 +460,14 @@ function runReviewPipeline(
 		summary: "parse failed",
 	};
 
-	if (!codexResult.ok) {
-		if (codexResult.exitCode) {
+	if (!reviewAgentResult.ok) {
+		if (reviewAgentResult.exitCode) {
 			return {
-				...errorJson(action, changeId, `codex_exit_${codexResult.exitCode}`),
+				...errorJson(
+					action,
+					changeId,
+					`review_agent_exit_${reviewAgentResult.exitCode}`,
+				),
 				review: null,
 				ledger: null,
 				autofix: null,
@@ -463,9 +475,9 @@ function runReviewPipeline(
 			};
 		}
 		parseError = true;
-		rawResponse = codexResult.rawResponse;
-	} else if (codexResult.payload) {
-		reviewJson = codexResult.payload;
+		rawResponse = reviewAgentResult.rawResponse;
+	} else if (reviewAgentResult.payload) {
+		reviewJson = reviewAgentResult.payload;
 	}
 
 	let rereviewClassification: {
@@ -618,6 +630,7 @@ function cmdReview(
 	projectRoot: string,
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
+	agent: ReviewAgentName,
 ): ReviewResult {
 	const changeId = args[0];
 	if (!changeId) {
@@ -634,6 +647,7 @@ function cmdReview(
 		"review",
 		changeId,
 		false,
+		agent,
 	);
 }
 
@@ -642,6 +656,7 @@ function cmdFixReview(
 	projectRoot: string,
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
+	agent: ReviewAgentName,
 ): ReviewResult {
 	const changeId = args[0];
 	if (!changeId) {
@@ -660,21 +675,33 @@ function cmdFixReview(
 		"fix_review",
 		changeId,
 		true,
+		agent,
 	);
+}
+
+function parseReviewAgentFlag(args: readonly string[]): string | undefined {
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] === "--review-agent") {
+			return args[index + 1];
+		}
+	}
+	return undefined;
 }
 
 function main(): void {
 	const projectRoot = ensureGitRepo();
+	loadConfigEnv(projectRoot);
 	const changeStore = createLocalFsChangeArtifactStore(projectRoot);
 	const runtimeRoot = moduleRepoRoot(import.meta.url);
 	const [subcommand = "", ...args] = process.argv.slice(2);
+	const agent = resolveReviewAgent(parseReviewAgentFlag(args));
 	let result: ReviewResult;
 	switch (subcommand) {
 		case "review":
-			result = cmdReview(runtimeRoot, projectRoot, changeStore, args);
+			result = cmdReview(runtimeRoot, projectRoot, changeStore, args, agent);
 			break;
 		case "fix-review":
-			result = cmdFixReview(runtimeRoot, projectRoot, changeStore, args);
+			result = cmdFixReview(runtimeRoot, projectRoot, changeStore, args, agent);
 			break;
 		case "":
 			die(

--- a/src/contracts/command-bodies.ts
+++ b/src/contracts/command-bodies.ts
@@ -3,7 +3,7 @@ import type { CommandBody } from "../types/contracts.js";
 export const commandBodies: Record<string, CommandBody> = {
 	"specflow.apply": {
 		frontmatter: {
-			description: "specflow で実装を適用し、Codex で実装レビュー",
+			description: "specflow で実装を適用し、実装レビューを実行",
 		},
 		sections: [
 			{
@@ -190,7 +190,7 @@ export const commandBodies: Record<string, CommandBody> = {
 	"specflow.design": {
 		frontmatter: {
 			description:
-				"specflow で design/tasks artifacts を生成し、Codex でレビュー",
+				"specflow で design/tasks artifacts を生成し、レビューを実行",
 		},
 		sections: [
 			{
@@ -272,7 +272,7 @@ export const commandBodies: Record<string, CommandBody> = {
 	},
 	"specflow.fix_apply": {
 		frontmatter: {
-			description: "レビュー指摘を修正し、再度 Codex review を実行",
+			description: "レビュー指摘を修正し、再度レビューを実行",
 		},
 		sections: [
 			{
@@ -312,7 +312,7 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Step 4: Display Review Results",
 				content:
-					'\n### Re-review Classification (if RESULT_JSON.review.rereview_mode == true)\n\nIf the review was a re-review, display the classified results before the standard findings table:\n\n```\n### Re-review Classification\n\n**Resolved** ({count}):\n| ID | Note |\n|----|------|\n| R1-F01 | fixed null check |\n\n**Still Open** ({count}):\n| ID | Severity | Note |\n|----|----------|------|\n| R1-F02 | high | still unresolved |\n\n**New Findings** ({count}):\n| ID | Severity | File | Title |\n|----|----------|------|-------|\n| F3 | medium | src/foo.ts | missing test |\n```\n\n### Review Findings\n\nIf `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.\n\nOtherwise display:\n```\nCodex Implementation Review (after fix)\n\n**Decision:** <RESULT_JSON.review.decision>\n**Summary:** <RESULT_JSON.review.summary>\n\n| # | Severity | File | Title | Detail |\n|---|----------|------|-------|--------|\n| F1 | high | src/foo.ts | ... | ... |\n```\n\n### Ledger Summary Display\n\nUse `RESULT_JSON.ledger` to display:\n```\nReview Ledger: Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved\n```\n\nIf `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:\n```\n| Round | Total | Open | New | Resolved | Overridden |\n|-------|-------|------|-----|----------|------------|\n| 1     | 5     | 0    | 0   | 3        | 2          |\n| 2     | 7     | 2    | 2   | 3        | 2          |\n```\nThen show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`',
+					'\n### Re-review Classification (if RESULT_JSON.review.rereview_mode == true)\n\nIf the review was a re-review, display the classified results before the standard findings table:\n\n```\n### Re-review Classification\n\n**Resolved** ({count}):\n| ID | Note |\n|----|------|\n| R1-F01 | fixed null check |\n\n**Still Open** ({count}):\n| ID | Severity | Note |\n|----|----------|------|\n| R1-F02 | high | still unresolved |\n\n**New Findings** ({count}):\n| ID | Severity | File | Title |\n|----|----------|------|-------|\n| F3 | medium | src/foo.ts | missing test |\n```\n\n### Review Findings\n\nIf `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.\n\nOtherwise display:\n```\nImplementation Review (after fix)\n\n**Decision:** <RESULT_JSON.review.decision>\n**Summary:** <RESULT_JSON.review.summary>\n\n| # | Severity | File | Title | Detail |\n|---|----------|------|-------|--------|\n| F1 | high | src/foo.ts | ... | ... |\n```\n\n### Ledger Summary Display\n\nUse `RESULT_JSON.ledger` to display:\n```\nReview Ledger: Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved\n```\n\nIf `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:\n```\n| Round | Total | Open | New | Resolved | Overridden |\n|-------|-------|------|-----|----------|------------|\n| 1     | 5     | 0    | 0   | 3        | 2          |\n| 2     | 7     | 2    | 2   | 3        | 2          |\n```\nThen show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`',
 			},
 			{
 				title: "Step 5: Handoff",
@@ -322,14 +322,13 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Important Rules",
 				content:
-					"\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, review-ledger, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- ALL control flow logic (fix application, diff filtering, Codex invocation, ledger detection/update, finding matching, current-phase generation) is handled by the `specflow-review-apply fix-review` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.",
+					"\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, review-ledger, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- ALL control flow logic (fix application, diff filtering, review agent invocation, ledger detection/update, finding matching, current-phase generation) is handled by the `specflow-review-apply fix-review` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.",
 			},
 		],
 	},
 	"specflow.fix_design": {
 		frontmatter: {
-			description:
-				"Design/Tasks のレビュー指摘を修正し、再度 Codex review を実行",
+			description: "Design/Tasks のレビュー指摘を修正し、再度レビューを実行",
 		},
 		sections: [
 			{
@@ -369,7 +368,7 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Step 5: Display Review Results",
 				content:
-					'\n### Re-review Classification (if RESULT_JSON.rereview_classification is not null)\n\nDisplay the classified results before the standard findings table:\n\n```\n### Re-review Classification\n\n**Resolved** ({count of RESULT_JSON.rereview_classification.resolved}):\n| ID | Note |\n|----|------|\n| R1-F01 | fixed ordering issue |\n\n**Still Open** ({count of RESULT_JSON.rereview_classification.still_open}):\n| ID | Severity | Note |\n|----|----------|------|\n| R1-F02 | high | still unresolved |\n\n**New Findings** ({count of RESULT_JSON.rereview_classification.new_findings}):\n| ID | Severity | Category | Title |\n|----|----------|----------|-------|\n| F3 | medium | completeness | missing test coverage |\n```\n\n### Review Findings\n\nIf `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.\n\nOtherwise display:\n```\nCodex Design/Tasks Review (after fix)\n\n**Decision:** <RESULT_JSON.review.decision>\n**Summary:** <RESULT_JSON.review.summary>\n\n| # | Severity | Category | Title | Detail |\n|---|----------|----------|-------|--------|\n| P1 | high | completeness | ... | ... |\n```\n\n### Ledger Summary Display\n\nUse `RESULT_JSON.ledger` to display:\n```\nReview Ledger (Plan): Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved\n```\n\nIf `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:\n```\n| Round | Total | Open | New | Resolved | Overridden |\n|-------|-------|------|-----|----------|------------|\n| 1     | 5     | 0    | 0   | 3        | 2          |\n| 2     | 7     | 2    | 2   | 3        | 2          |\n```\nThen show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`\n\nReport: `current-phase.md updated` (the orchestrator generates this automatically).',
+					'\n### Re-review Classification (if RESULT_JSON.rereview_classification is not null)\n\nDisplay the classified results before the standard findings table:\n\n```\n### Re-review Classification\n\n**Resolved** ({count of RESULT_JSON.rereview_classification.resolved}):\n| ID | Note |\n|----|------|\n| R1-F01 | fixed ordering issue |\n\n**Still Open** ({count of RESULT_JSON.rereview_classification.still_open}):\n| ID | Severity | Note |\n|----|----------|------|\n| R1-F02 | high | still unresolved |\n\n**New Findings** ({count of RESULT_JSON.rereview_classification.new_findings}):\n| ID | Severity | Category | Title |\n|----|----------|----------|-------|\n| F3 | medium | completeness | missing test coverage |\n```\n\n### Review Findings\n\nIf `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.\n\nOtherwise display:\n```\nDesign/Tasks Review (after fix)\n\n**Decision:** <RESULT_JSON.review.decision>\n**Summary:** <RESULT_JSON.review.summary>\n\n| # | Severity | Category | Title | Detail |\n|---|----------|----------|-------|--------|\n| P1 | high | completeness | ... | ... |\n```\n\n### Ledger Summary Display\n\nUse `RESULT_JSON.ledger` to display:\n```\nReview Ledger (Plan): Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved\n```\n\nIf `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:\n```\n| Round | Total | Open | New | Resolved | Overridden |\n|-------|-------|------|-----|----------|------------|\n| 1     | 5     | 0    | 0   | 3        | 2          |\n| 2     | 7     | 2    | 2   | 3        | 2          |\n```\nThen show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`\n\nReport: `current-phase.md updated` (the orchestrator generates this automatically).',
 			},
 			{
 				title: "Handoff: 次のアクション選択",
@@ -379,7 +378,7 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Important Rules",
 				content:
-					"\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, design, tasks, review-ledger-design, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- ALL control flow logic (Codex invocation, ledger detection/CRUD, finding matching, current-phase generation) is handled by the `specflow-review-design fix-review` orchestrator. This slash command applies fixes (LLM), then calls the orchestrator for re-review, parses its JSON output, and displays UI.",
+					"\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, design, tasks, review-ledger-design, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- ALL control flow logic (review agent invocation, ledger detection/CRUD, finding matching, current-phase generation) is handled by the `specflow-review-design fix-review` orchestrator. This slash command applies fixes (LLM), then calls the orchestrator for re-review, parses its JSON output, and displays UI.",
 			},
 		],
 	},
@@ -585,7 +584,7 @@ export const commandBodies: Record<string, CommandBody> = {
 	"specflow.review_apply": {
 		frontmatter: {
 			description:
-				"Codex impl review を実行し、ledger 更新・auto-fix loop・handoff を管理",
+				"実装レビューを実行し、ledger 更新・auto-fix loop・handoff を管理",
 		},
 		sections: [
 			{
@@ -620,12 +619,12 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Step 3: Handle Diff Warning",
 				content:
-					'\nIf `RESULT_JSON.diff_summary.diff_warning == true`:\n\nDual-Display Fallback Pattern に従う:\n\n**テキストプロンプト（AskUserQuestion の前に必ず表示）**:\n```\n⚠ Diff size warning — {RESULT_JSON.diff_summary.total_lines} lines (threshold: {RESULT_JSON.diff_summary.threshold})\n\n続行しますか？（テキスト入力またはボタンで回答）:\n- **続行** → continue\n- **中止** → abort\n```\n\n**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:\n```\nAskUserQuestion:\n  question: "フィルタリング後の diff が {total_lines} 行あります。Codex がスタックする可能性があります。続行しますか？"\n  options:\n    - label: "続行"\n      description: "このまま Codex レビューを実行"\n    - label: "中止"\n      description: "レビューをスキップ"\n```\n\n**入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。\n\nIf "中止" → **STOP**.\n\nIf "続行": re-run the orchestrator with diff warning bypass enabled and replace `RESULT_JSON` with the new output.\n```bash\nspecflow-review-apply review <CHANGE_ID> --skip-diff-check\n```\nCapture stdout again as `RESULT_JSON`. If the command fails (non-zero exit), display the error and **STOP**. Parse the new `RESULT_JSON` as JSON before proceeding.',
+					'\nIf `RESULT_JSON.diff_summary.diff_warning == true`:\n\nDual-Display Fallback Pattern に従う:\n\n**テキストプロンプト（AskUserQuestion の前に必ず表示）**:\n```\n⚠ Diff size warning — {RESULT_JSON.diff_summary.total_lines} lines (threshold: {RESULT_JSON.diff_summary.threshold})\n\n続行しますか？（テキスト入力またはボタンで回答）:\n- **続行** → continue\n- **中止** → abort\n```\n\n**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:\n```\nAskUserQuestion:\n  question: "フィルタリング後の diff が {total_lines} 行あります。レビューエージェントがスタックする可能性があります。続行しますか？"\n  options:\n    - label: "続行"\n      description: "このままレビューを実行"\n    - label: "中止"\n      description: "レビューをスキップ"\n```\n\n**入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。\n\nIf "中止" → **STOP**.\n\nIf "続行": re-run the orchestrator with diff warning bypass enabled and replace `RESULT_JSON` with the new output.\n```bash\nspecflow-review-apply review <CHANGE_ID> --skip-diff-check\n```\nCapture stdout again as `RESULT_JSON`. If the command fails (non-zero exit), display the error and **STOP**. Parse the new `RESULT_JSON` as JSON before proceeding.',
 			},
 			{
 				title: "Step 4: Display Review Results",
 				content:
-					'\n### Review Findings\n\nPresent the Codex review from `RESULT_JSON.review`:\n\nIf `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.\n\nOtherwise display:\n```\nCodex Implementation Review\n\n**Decision:** <RESULT_JSON.review.decision>\n**Summary:** <RESULT_JSON.review.summary>\n\n| # | Severity | File | Title | Detail |\n|---|----------|------|-------|--------|\n| F1 | high | src/foo.ts | ... | ... |\n| F2 | medium | src/bar.ts | ... | ... |\n```\n\n### Ledger Summary Display\n\nUse `RESULT_JSON.ledger` to display:\n```\nReview Ledger: Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved\n```\n\nIf `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:\n```\n| Round | Total | Open | New | Resolved | Overridden |\n|-------|-------|------|-----|----------|------------|\n| 1     | 5     | 0    | 0   | 3        | 2          |\n| 2     | 7     | 2    | 2   | 3        | 2          |\n```\nThen show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`',
+					'\n### Review Findings\n\nPresent the review from `RESULT_JSON.review`:\n\nIf `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.\n\nOtherwise display:\n```\nImplementation Review\n\n**Decision:** <RESULT_JSON.review.decision>\n**Summary:** <RESULT_JSON.review.summary>\n\n| # | Severity | File | Title | Detail |\n|---|----------|------|-------|--------|\n| F1 | high | src/foo.ts | ... | ... |\n| F2 | medium | src/bar.ts | ... | ... |\n```\n\n### Ledger Summary Display\n\nUse `RESULT_JSON.ledger` to display:\n```\nReview Ledger: Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved\n```\n\nIf `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:\n```\n| Round | Total | Open | New | Resolved | Overridden |\n|-------|-------|------|-----|----------|------------|\n| 1     | 5     | 0    | 0   | 3        | 2          |\n| 2     | 7     | 2    | 2   | 3        | 2          |\n```\nThen show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`',
 			},
 			{
 				title: "Step 5: Handoff (based on RESULT_JSON.handoff.state)",
@@ -640,14 +639,14 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Important Rules",
 				content:
-					"\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, review-ledger, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- ALL control flow logic (diff filtering, Codex invocation, ledger update, finding matching, current-phase generation) is handled by the `specflow-review-apply` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.",
+					"\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, review-ledger, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- ALL control flow logic (diff filtering, review agent invocation, ledger update, finding matching, current-phase generation) is handled by the `specflow-review-apply` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.",
 			},
 		],
 	},
 	"specflow.review_design": {
 		frontmatter: {
 			description:
-				"Codex design/tasks review を実行し、ledger 更新・auto-fix loop・handoff を管理",
+				"Design/tasks レビューを実行し、ledger 更新・auto-fix loop・handoff を管理",
 		},
 		sections: [
 			{
@@ -682,7 +681,7 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Step 4: Display Review Results",
 				content:
-					'\n### Review Findings\n\nPresent the Codex review from `RESULT_JSON.review`:\n\nIf `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.\n\nOtherwise display:\n```\nCodex Design/Tasks Review\n\n**Decision:** <RESULT_JSON.review.decision>\n**Summary:** <RESULT_JSON.review.summary>\n\n| # | Severity | File | Category | Title | Detail |\n|---|----------|------|----------|-------|--------|\n| P1 | high | design.md | completeness | ... | ... |\n| P2 | medium | tasks.md | ordering | ... | ... |\n```\n\n### Ledger Summary Display\n\nUse `RESULT_JSON.ledger` to display:\n```\nReview Ledger (Plan): Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved\n```\n\nIf `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:\n```\n| Round | Total | Open | New | Resolved | Overridden |\n|-------|-------|------|-----|----------|------------|\n| 1     | 5     | 0    | 0   | 3        | 2          |\n| 2     | 7     | 2    | 2   | 3        | 2          |\n```\nThen show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`',
+					'\n### Review Findings\n\nPresent the review from `RESULT_JSON.review`:\n\nIf `RESULT_JSON.review.parse_error` is true, display raw response from `RESULT_JSON.review.raw_response` instead of the structured table, then proceed to handoff.\n\nOtherwise display:\n```\nDesign/Tasks Review\n\n**Decision:** <RESULT_JSON.review.decision>\n**Summary:** <RESULT_JSON.review.summary>\n\n| # | Severity | File | Category | Title | Detail |\n|---|----------|------|----------|-------|--------|\n| P1 | high | design.md | completeness | ... | ... |\n| P2 | medium | tasks.md | ordering | ... | ... |\n```\n\n### Ledger Summary Display\n\nUse `RESULT_JSON.ledger` to display:\n```\nReview Ledger (Plan): Round {RESULT_JSON.ledger.round} | Status: {RESULT_JSON.ledger.status} | Findings: {RESULT_JSON.ledger.counts.new} new, {RESULT_JSON.ledger.counts.open} open, {RESULT_JSON.ledger.counts.resolved} resolved\n```\n\nIf `RESULT_JSON.ledger.round_summaries` has more than 1 entry, show a compact progress table:\n```\n| Round | Total | Open | New | Resolved | Overridden |\n|-------|-------|------|-----|----------|------------|\n| 1     | 5     | 0    | 0   | 3        | 2          |\n| 2     | 7     | 2    | 2   | 3        | 2          |\n```\nThen show round-over-round diff: `"Round {n}: +{new} new, {resolved_this_round} resolved, {open} remaining"`',
 			},
 			{
 				title: "Step 5: Handoff (based on RESULT_JSON.handoff.state)",
@@ -697,7 +696,7 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Important Rules",
 				content:
-					'\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, design, tasks, review-ledger-design, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- Ledger file is `FEATURE_DIR/review-ledger-design.json` (NOT `review-ledger.json`).\n- Phase is `"design"` in ledger JSON.\n- Auto-fix loop calls `specflow-review-design autofix-loop` (NOT `specflow.fix_apply`).\n- ALL control flow logic (Codex invocation, ledger CRUD, finding matching, score computation, current-phase generation) is handled by the `specflow-review-design` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.',
+					'\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, design, tasks, review-ledger-design, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- Ledger file is `FEATURE_DIR/review-ledger-design.json` (NOT `review-ledger.json`).\n- Phase is `"design"` in ledger JSON.\n- Auto-fix loop calls `specflow-review-design autofix-loop` (NOT `specflow.fix_apply`).\n- ALL control flow logic (review agent invocation, ledger CRUD, finding matching, score computation, current-phase generation) is handled by the `specflow-review-design` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.',
 			},
 		],
 	},

--- a/src/lib/review-ledger.ts
+++ b/src/lib/review-ledger.ts
@@ -232,13 +232,13 @@ export function incrementRound(ledger: ReviewLedger): ReviewLedger {
 
 export function matchFindings(
 	ledger: ReviewLedger,
-	codexFindings: readonly ReviewFinding[],
+	incomingFindings: readonly ReviewFinding[],
 	currentRound: number,
 ): ReviewLedger {
-	const codex = normalizeFindings(codexFindings);
+	const incoming = normalizeFindings(incomingFindings);
 	const existing = normalizeFindings(ledger.findings);
 
-	if (codex.length === 0) {
+	if (incoming.length === 0) {
 		return {
 			...ledger,
 			findings: existing.map((finding) => {
@@ -260,11 +260,11 @@ export function matchFindings(
 		(finding) => !isActive(finding) && !isOverride(finding),
 	);
 
-	const matchedCodex = new Set<number>();
+	const matchedIncoming = new Set<number>();
 	const matchedExisting = new Set<string>();
 	const step1Results: ReviewFinding[] = [];
 
-	for (const [index, finding] of codex.entries()) {
+	for (const [index, finding] of incoming.entries()) {
 		const match = [...active, ...overrides].find((candidate) => {
 			const id = findingId(candidate);
 			return (
@@ -276,7 +276,7 @@ export function matchFindings(
 		if (!match) {
 			continue;
 		}
-		matchedCodex.add(index);
+		matchedIncoming.add(index);
 		matchedExisting.add(findingId(match));
 		if (isOverride(match)) {
 			step1Results.push({
@@ -299,8 +299,8 @@ export function matchFindings(
 	const step2New: ReviewFinding[] = [];
 	let seq = 1;
 
-	for (const [index, finding] of codex.entries()) {
-		if (matchedCodex.has(index)) {
+	for (const [index, finding] of incoming.entries()) {
+		if (matchedIncoming.has(index)) {
 			continue;
 		}
 		const match = [...active, ...overrides].find((candidate) => {
@@ -316,7 +316,7 @@ export function matchFindings(
 			continue;
 		}
 		matchedExistingStep2.add(findingId(match));
-		matchedCodex.add(index);
+		matchedIncoming.add(index);
 		step2Resolved.push({
 			...match,
 			status: "resolved",
@@ -338,8 +338,8 @@ export function matchFindings(
 
 	const allMatchedIds = new Set([...matchedExisting, ...matchedExistingStep2]);
 	const step3New: ReviewFinding[] = [];
-	for (const [index, finding] of codex.entries()) {
-		if (matchedCodex.has(index)) {
+	for (const [index, finding] of incoming.entries()) {
+		if (matchedIncoming.has(index)) {
 			continue;
 		}
 		step3New.push(

--- a/src/lib/review-runtime.ts
+++ b/src/lib/review-runtime.ts
@@ -22,7 +22,24 @@ export interface ReviewConfig {
 	readonly maxAutofixRounds: number;
 }
 
-export interface CodexCallResult<T> {
+export type ReviewAgentName = "codex" | "claude";
+
+export const REVIEW_AGENTS: readonly ReviewAgentName[] = ["codex", "claude"];
+
+export type MainAgentName = "claude" | "codex" | "copilot";
+
+export const MAIN_AGENTS: readonly MainAgentName[] = [
+	"claude",
+	"codex",
+	"copilot",
+];
+
+export interface MainAgentResult {
+	readonly ok: boolean;
+	readonly exitCode?: number;
+}
+
+export interface ReviewCallResult<T> {
 	readonly ok: boolean;
 	readonly exitCode?: number;
 	readonly payload?: T;
@@ -137,10 +154,10 @@ export function buildPrompt(parts: readonly [string, string][]): string {
 		.join("\n\n");
 }
 
-export function callCodex<T>(
+function callCodexDriver<T>(
 	cwd: string,
 	promptContent: string,
-): CodexCallResult<T> {
+): ReviewCallResult<T> {
 	const codex = resolveCommand("SPECFLOW_CODEX", "codex");
 	const outputPath = join(
 		tmpdir(),
@@ -156,10 +173,27 @@ export function callCodex<T>(
 		rawOutput = readFileSync(outputPath, "utf8");
 		rmSync(outputPath, { force: true });
 	}
-	if (result.status !== 0) {
+	return parseRawOutput(result.status, rawOutput);
+}
+
+function callClaudeReviewDriver<T>(
+	cwd: string,
+	promptContent: string,
+): ReviewCallResult<T> {
+	const claude = resolveCommand("SPECFLOW_CLAUDE", "claude");
+	const args = ["-p", "--output-format", "text", "--no-session-persistence"];
+	const result = tryExec(claude, args, cwd, undefined, promptContent);
+	return parseRawOutput(result.status, result.stdout);
+}
+
+function parseRawOutput<T>(
+	status: number,
+	rawOutput: string,
+): ReviewCallResult<T> {
+	if (status !== 0) {
 		return {
 			ok: false,
-			exitCode: result.status,
+			exitCode: status,
 			rawResponse: rawOutput,
 		};
 	}
@@ -181,6 +215,104 @@ export function callCodex<T>(
 		payload: parsed,
 		rawResponse: rawOutput.trim(),
 	};
+}
+
+export function callReviewAgent<T>(
+	agent: ReviewAgentName,
+	cwd: string,
+	promptContent: string,
+): ReviewCallResult<T> {
+	switch (agent) {
+		case "codex":
+			return callCodexDriver<T>(cwd, promptContent);
+		case "claude":
+			return callClaudeReviewDriver<T>(cwd, promptContent);
+	}
+}
+
+export function loadConfigEnv(projectRoot: string): void {
+	const configPath = resolve(projectRoot, ".specflow/config.env");
+	if (!existsSync(configPath)) {
+		return;
+	}
+	const content = readFileSync(configPath, "utf8");
+	for (const line of content.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0 || trimmed.startsWith("#")) {
+			continue;
+		}
+		const eqIndex = trimmed.indexOf("=");
+		if (eqIndex === -1) {
+			continue;
+		}
+		const key = trimmed.slice(0, eqIndex);
+		const value = trimmed.slice(eqIndex + 1);
+		if (!(key in process.env)) {
+			process.env[key] = value;
+		}
+	}
+}
+
+export function resolveReviewAgent(flagValue?: string): ReviewAgentName {
+	const raw = flagValue ?? process.env.SPECFLOW_REVIEW_AGENT ?? "codex";
+	if (raw === "codex" || raw === "claude") {
+		return raw;
+	}
+	process.stderr.write(
+		`Warning: unknown review agent '${raw}', falling back to 'codex'\n`,
+	);
+	return "codex";
+}
+
+export function resolveMainAgent(flagValue?: string): MainAgentName {
+	const raw = flagValue ?? process.env.SPECFLOW_MAIN_AGENT ?? "claude";
+	if (raw === "claude" || raw === "codex" || raw === "copilot") {
+		return raw;
+	}
+	process.stderr.write(
+		`Warning: unknown main agent '${raw}', falling back to 'claude'\n`,
+	);
+	return "claude";
+}
+
+export function callMainAgent(
+	agent: MainAgentName,
+	cwd: string,
+	promptContent: string,
+): MainAgentResult {
+	switch (agent) {
+		case "codex": {
+			const codex = resolveCommand("SPECFLOW_CODEX", "codex");
+			const result = tryExec(
+				codex,
+				["exec", "--full-auto", "--ephemeral", promptContent],
+				cwd,
+			);
+			return { ok: result.status === 0, exitCode: result.status || undefined };
+		}
+		case "claude": {
+			const claude = resolveCommand("SPECFLOW_CLAUDE", "claude");
+			const result = tryExec(
+				claude,
+				["-p", "--dangerously-skip-permissions", "--no-session-persistence"],
+				cwd,
+				undefined,
+				promptContent,
+			);
+			return { ok: result.status === 0, exitCode: result.status || undefined };
+		}
+		case "copilot": {
+			const copilot = resolveCommand("SPECFLOW_COPILOT", "copilot");
+			const result = tryExec(
+				copilot,
+				["-p", "--allow-all-tools", "-s"],
+				cwd,
+				undefined,
+				promptContent,
+			);
+			return { ok: result.status === 0, exitCode: result.status || undefined };
+		}
+	}
 }
 
 export function renderCurrentPhase(

--- a/src/tests/review-cli.test.ts
+++ b/src/tests/review-cli.test.ts
@@ -6,6 +6,7 @@ import {
 	addDesignArtifacts,
 	addImplementationDiff,
 	createBareHome,
+	createClaudeStub,
 	createCodexStub,
 	createFixtureRepo,
 	createInstalledHome,
@@ -27,6 +28,24 @@ function createCodexEnv(root: string, responses: unknown[]) {
 			HOME: createInstalledHome(root),
 			SPECFLOW_TEST_CODEX_RESPONSES: responsesPath,
 			SPECFLOW_TEST_CODEX_STATE: statePath,
+			SPECFLOW_MAIN_AGENT: "codex",
+		},
+		stubDir,
+	);
+}
+
+function createClaudeEnv(root: string, responses: unknown[]) {
+	const stubDir = createClaudeStub(root);
+	const responsesPath = join(root, "claude-responses.json");
+	const statePath = join(root, "claude-state.txt");
+	writeFileSync(responsesPath, JSON.stringify(responses), "utf8");
+	writeFileSync(statePath, "0", "utf8");
+	return prependPath(
+		{
+			HOME: createInstalledHome(root),
+			SPECFLOW_TEST_CLAUDE_RESPONSES: responsesPath,
+			SPECFLOW_TEST_CLAUDE_STATE: statePath,
+			SPECFLOW_REVIEW_AGENT: "claude",
 		},
 		stubDir,
 	);
@@ -402,6 +421,107 @@ test("specflow-review-design falls back to module-local prompts when no installe
 		};
 		assert.equal(json.status, "success");
 		assert.equal(json.review.summary, "done");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- Claude agent tests ---
+
+test("specflow-review-apply works with claude as review agent via --review-agent flag", () => {
+	const tempRoot = makeTempDir("review-apply-claude-flag-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		addImplementationDiff(repoPath);
+		const env = createClaudeEnv(tempRoot, [
+			{
+				exitCode: 0,
+				output: JSON.stringify({
+					decision: "APPROVE",
+					findings: [],
+					summary: "all good via claude",
+				}),
+			},
+		]);
+		const result = runNodeCli(
+			"specflow-review-apply",
+			["review", changeId, "--review-agent", "claude"],
+			repoPath,
+			env,
+		);
+		assert.equal(result.status, 0, result.stderr);
+		const json = JSON.parse(result.stdout) as {
+			status: string;
+			review: { summary: string };
+		};
+		assert.equal(json.status, "success");
+		assert.equal(json.review.summary, "all good via claude");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-review-apply works with claude as review agent via env var", () => {
+	const tempRoot = makeTempDir("review-apply-claude-env-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		addImplementationDiff(repoPath);
+		const env = createClaudeEnv(tempRoot, [
+			{
+				exitCode: 0,
+				output: JSON.stringify({
+					decision: "APPROVE",
+					findings: [],
+					summary: "all good via claude env",
+				}),
+			},
+		]);
+		const result = runNodeCli(
+			"specflow-review-apply",
+			["review", changeId],
+			repoPath,
+			env,
+		);
+		assert.equal(result.status, 0, result.stderr);
+		const json = JSON.parse(result.stdout) as {
+			status: string;
+			review: { summary: string };
+		};
+		assert.equal(json.status, "success");
+		assert.equal(json.review.summary, "all good via claude env");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-review-design works with claude as review agent", () => {
+	const tempRoot = makeTempDir("review-design-claude-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		addDesignArtifacts(repoPath, changeId);
+		const env = createClaudeEnv(tempRoot, [
+			{
+				exitCode: 0,
+				output: JSON.stringify({
+					decision: "OK",
+					findings: [],
+					summary: "design ok via claude",
+				}),
+			},
+		]);
+		const result = runNodeCli(
+			"specflow-review-design",
+			["review", changeId, "--review-agent", "claude"],
+			repoPath,
+			env,
+		);
+		assert.equal(result.status, 0, result.stderr);
+		const json = JSON.parse(result.stdout) as {
+			status: string;
+			review: { summary: string };
+		};
+		assert.equal(json.status, "success");
+		assert.equal(json.review.summary, "design ok via claude");
 	} finally {
 		removeTempDir(tempRoot);
 	}

--- a/src/tests/review-proposal-cli.test.ts
+++ b/src/tests/review-proposal-cli.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { validateSchemaValue } from "../lib/schemas.js";
 import {
+	createClaudeStub,
 	createCodexStub,
 	createFixtureRepo,
 	createInstalledHome,
@@ -26,6 +27,24 @@ function createCodexEnv(root: string, responses: unknown[]) {
 			HOME: createInstalledHome(root),
 			SPECFLOW_TEST_CODEX_RESPONSES: responsesPath,
 			SPECFLOW_TEST_CODEX_STATE: statePath,
+			SPECFLOW_MAIN_AGENT: "codex",
+		},
+		stubDir,
+	);
+}
+
+function createClaudeEnv(root: string, responses: unknown[]) {
+	const stubDir = createClaudeStub(root);
+	const responsesPath = join(root, "claude-responses.json");
+	const statePath = join(root, "claude-state.txt");
+	writeFileSync(responsesPath, JSON.stringify(responses), "utf8");
+	writeFileSync(statePath, "0", "utf8");
+	return prependPath(
+		{
+			HOME: createInstalledHome(root),
+			SPECFLOW_TEST_CLAUDE_RESPONSES: responsesPath,
+			SPECFLOW_TEST_CLAUDE_STATE: statePath,
+			SPECFLOW_REVIEW_AGENT: "claude",
 		},
 		stubDir,
 	);
@@ -584,6 +603,42 @@ test("specflow-review-proposal surfaces parse errors without mutating ledger", (
 			),
 			false,
 		);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- Claude agent tests ---
+
+test("specflow-review-proposal works with claude as review agent", () => {
+	const tempRoot = makeTempDir("review-proposal-claude-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const env = createClaudeEnv(tempRoot, [
+			{
+				exitCode: 0,
+				output: JSON.stringify({
+					decision: "APPROVE",
+					findings: [],
+					summary: "proposal ok via claude",
+				}),
+			},
+		]);
+		const result = runNodeCli(
+			"specflow-review-proposal",
+			["review", changeId, "--review-agent", "claude"],
+			repoPath,
+			env,
+		);
+		assert.equal(result.status, 0, result.stderr);
+		const json = JSON.parse(result.stdout) as {
+			status: string;
+			review: { summary: string };
+			handoff: { state: string };
+		};
+		assert.equal(json.status, "success");
+		assert.equal(json.review.summary, "proposal ok via claude");
+		assert.equal(json.handoff.state, "review_approved");
 	} finally {
 		removeTempDir(tempRoot);
 	}

--- a/src/tests/test-helpers.ts
+++ b/src/tests/test-helpers.ts
@@ -298,6 +298,29 @@ export function createCodexStub(root: string): string {
 	return stubDir;
 }
 
+export function createClaudeStub(root: string): string {
+	const stubDir = createStubDir(root);
+	const path = join(stubDir, "claude");
+	writeExecutable(
+		path,
+		[
+			"#!/usr/bin/env node",
+			"const fs = require('node:fs');",
+			"const responsesPath = process.env.SPECFLOW_TEST_CLAUDE_RESPONSES;",
+			"const statePath = process.env.SPECFLOW_TEST_CLAUDE_STATE;",
+			"const responses = responsesPath ? JSON.parse(fs.readFileSync(responsesPath, 'utf8')) : [];",
+			"let index = 0;",
+			"if (statePath && fs.existsSync(statePath)) index = Number(fs.readFileSync(statePath, 'utf8') || '0');",
+			"const response = responses[index] || responses[responses.length - 1] || { exitCode: 0, output: '{}' };",
+			"if (statePath) fs.writeFileSync(statePath, String(index + 1));",
+			"if (response.output !== undefined) process.stdout.write(String(response.output));",
+			"process.exit(Number(response.exitCode || 0));",
+			"",
+		].join("\n"),
+	);
+	return stubDir;
+}
+
 export function prependPath(
 	env: NodeJS.ProcessEnv,
 	stubDir: string,


### PR DESCRIPTION
Separate review and fix responsibilities into distinct agent roles:
- Review agent (codex/claude): executes code review with structured JSON output
- Main agent (claude/codex/copilot): executes implementation and fix operations

Key changes:
- Add callMainAgent() dispatcher with codex/claude/copilot drivers
- Add callReviewAgent() dispatcher with codex/claude drivers
- Add resolveMainAgent()/resolveReviewAgent() with env var + flag resolution
- Add loadConfigEnv() to read .specflow/config.env at runtime
- Add --review-agent CLI flag to all review commands
- Rename CodexCallResult→ReviewCallResult, codexFindings→incomingFindings
- Expand MAIN_AGENTS to [claude, codex, copilot], REVIEW_AGENTS to [codex, claude]
- Remove hardcoded "Codex" references from command-bodies display text
- Update config.env template with agent selection docs