### PR TITLE
docs: position bundled local mode as canonical reference implementation (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@
 
 GitHub issue URL またはインライン仕様記述を入力にして、Claude + Codex による proposal → clarify → spec → validate → design → implement → review のワークフローを Claude Code 内でインタラクティブに回すツール。
 
+## 位置づけ — Reference Implementation
+
+このリポジトリに同梱されている **slash-command + file-backed + git-backed のローカル実行モード**（`/specflow*` スラッシュコマンド、`specflow-*` CLI、`.specflow/runs/` の file-backed RunStore、`openspec/changes/` の git-backed ArtifactStore）は、workflow core contract の **canonical reference implementation（正式な参照実装）** である。
+
+- **Conformance target** — 他の runtime が core contract を実装する際の挙動の基準は、このローカルモードの挙動である。
+- **Replaceability** — DB-backed runtime や server-backed runtime など、workflow core contract に準拠する外部 runtime はこのローカルモードを置き換え可能。
+- **Contract mapping** — 各 bundled adapter（CLI entrypoints / file-backed RunStore / git-backed ArtifactStore）がどの core contract surface を実装しているかは [docs/architecture.md → Repository Scope](docs/architecture.md#repository-scope) と [Workflow Core Contract Surface (Inventory)](docs/architecture.md#workflow-core-contract-surface-inventory) を参照。
+
+> **Source of truth.** この README が、bundled local reference implementation の外部向けポジショニング（外部の読者・コントリビューター・runtime 実装者に対する "これは何か" の説明）の **source of truth** である。GitHub repo description や issue templates 等の隣接サーフェスで矛盾する記述があった場合は、README の記述に合わせて更新する。
+
 ## セットアップ
 
 ### 1. 前提ツール
@@ -431,6 +441,16 @@ npm run check
 # English
 
 An interactive tool that runs the full proposal → clarify → spec → validate → design → implement → review workflow inside Claude Code from either GitHub issue URLs or inline source text, using Claude + Codex.
+
+## Positioning — Reference Implementation
+
+The **slash-command + file-backed + git-backed local execution mode** bundled in this repository (the `/specflow*` slash commands, the `specflow-*` CLI, the file-backed RunStore under `.specflow/runs/`, and the git-backed ArtifactStore under `openspec/changes/`) is the **canonical reference implementation** of the workflow core contract.
+
+- **Conformance target** — any other runtime claiming to implement the workflow core contract is expected to behave the same as this local mode for the surfaces it covers.
+- **Replaceability** — external runtimes that conform to the workflow core contract (e.g., DB-backed, server-backed) can substitute this local mode without changes to the core.
+- **Contract mapping** — see [docs/architecture.md → Repository Scope](docs/architecture.md#repository-scope) and [Workflow Core Contract Surface (Inventory)](docs/architecture.md#workflow-core-contract-surface-inventory) for the per-adapter mapping (CLI entrypoints, file-backed RunStore, git-backed ArtifactStore) to the core contract surface each implements.
+
+> **Source of truth.** This README is the source of truth for the external-facing positioning of the bundled local reference implementation. If adjacent surfaces (GitHub repo description, issue templates, etc.) contain wording that conflicts, align them to the README.
 
 ## Quick Start
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,11 +57,21 @@ The previous Bash implementation is archived at git tag `legacy-v1-final`. Activ
   - State machine definition (`src/lib/workflow-machine.ts` and rendered `state-machine.json`)
   - Run-state management (persisted run-state JSON lifecycle)
   - Review orchestration (proposal, design, and apply review protocols)
-- **Bundled local reference implementation** — a complete, file-system-based execution environment shipped with this repository:
-  - `specflow-*` CLI tools (specflow-run, specflow-analyze, specflow-review-proposal, etc.)
-  - Slash command guides (generated from command contracts)
-  - Templates and installer assets
-  - This implementation is bundled but replaceable: any external runtime that conforms to the workflow core contract can substitute it
+- **Bundled local reference implementation** — the **canonical reference implementation** of the workflow core contract: a complete, file-system-based execution environment shipped with this repository.
+  - **Constituent adapters and surfaces:**
+    - `specflow-*` CLI tools (specflow-run, specflow-analyze, specflow-review-proposal, etc.)
+    - Slash command guides (generated from command contracts)
+    - Templates and installer assets
+  - **Framing properties** (these three properties together define what "reference implementation" means in this repo and are the testable acceptance criteria for any docs that re-state this positioning):
+    1. **Conformance target.** The bundled local mode is the canonical conformance target for the workflow core contract. Any other runtime claiming to implement the contract is expected to behave the same as this implementation for the contract surfaces it covers.
+    2. **Replaceability.** The bundled local mode is replaceable. Any external runtime (e.g., a DB-backed runtime, a server-backed runtime) that conforms to the workflow core contract can substitute it without changes to the core.
+    3. **Contract mapping.** Each bundled adapter maps to a specific workflow core contract surface:
+
+       | Bundled adapter | Source location | Workflow core contract surface implemented |
+       |-----------------|-----------------|---------------------------------------------|
+       | CLI entrypoints | `src/bin/specflow-*.ts` | Bundled-adapter surface only — exposes the workflow core (state machine schema and run-state JSON structure) to the local execution environment via `specflow-run` and related entrypoints. The CLI surface itself is not a core contract surface (consistent with the "Excluded from core contract" listing in the inventory below). |
+       | File-backed RunStore | `.specflow/runs/<run_id>/run.json` (file layout) backed by `src/lib/fs.ts`, `src/lib/paths.ts` | Persistence of the run-state JSON structure. The persistence mechanism (filesystem layout, atomic write semantics) is bundled-adapter surface; the run-state JSON shape itself is core contract surface. |
+       | Git-backed ArtifactStore | `openspec/changes/<CHANGE_ID>/` artifacts backed by `src/lib/git.ts` | Persistence and review-orchestration interaction for change artifacts (proposal, design, tasks, specs deltas). Bundled-adapter surface — the review protocol payloads exchanged with reviewers are core contract surface; the on-disk + git layout is not. |
 
 ### This repo does not own
 
@@ -97,7 +107,11 @@ The workflow core contract comprises:
 | Run-state JSON structure | `src/types/contracts.ts` (`RunState`) | Persisted run-state shape including phase, history, agents, and metadata | **Not yet supported** — `RunState` mixes core and local-adapter fields; field-level split deferred. `specflow-run` remains the current local implementation of this contract surface. |
 | Review protocol interface | `specflow-review-*` orchestrators | Review request/response schema, ledger structure, finding format | **Not yet supported** — canonical transport contract deferred |
 
-**Excluded from core contract:** CLI entry-point contracts (command names, argument signatures, output format) are implementation details of the bundled local reference. External runtimes conform to the workflow core contract only — they are not required to replicate the CLI surface.
+**Excluded from core contract (bundled-adapter surface):** The following are implementation details of the bundled local reference, not part of the workflow core contract surface. External runtimes conform to the workflow core contract only — they are not required to replicate any of these adapter surfaces.
+
+- **CLI entrypoints** (`src/bin/specflow-*.ts`) — command names, argument signatures, exit codes, and output format. Bundled-adapter surface, **not** core contract surface.
+- **File-backed RunStore** (`.specflow/runs/<run_id>/run.json` file layout, atomic-write semantics, on-disk persistence backed by `src/lib/fs.ts`) — the persistence *mechanism* is bundled-adapter surface; the run-state JSON *shape* is core contract surface and lives in the row above.
+- **Git-backed ArtifactStore** (`openspec/changes/<CHANGE_ID>/` directory layout, file naming, and git-history coupling backed by `src/lib/git.ts`) — the *storage* of change artifacts is bundled-adapter surface, **not** core contract surface. The review protocol payloads exchanged between core and reviewers remain core contract surface, separately listed above.
 
 ## Actor / Surface Model
 

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/approval-summary.md
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/approval-summary.md
@@ -1,0 +1,81 @@
+# Approval Summary: keep-file-backed-local-mode-as-reference-implementation
+
+**Generated**: 2026-04-13T07:34Z
+**Branch**: keep-file-backed-local-mode-as-reference-implementation
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+```
+ README.md            | 20 ++++++++++++++++++++
+ docs/architecture.md | 26 ++++++++++++++++++++------
+ 2 files changed, 40 insertions(+), 6 deletions(-)
+```
+
+## Files Touched
+
+```
+README.md
+docs/architecture.md
+```
+
+(Plus OpenSpec planning artifacts under `openspec/changes/keep-file-backed-local-mode-as-reference-implementation/` — proposal, design, tasks, spec delta, ledgers — to be archived to `openspec/changes/archive/`.)
+
+## Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+### Impl Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 2     |
+
+(Round 1 surfaced 1 medium + 1 low finding; Round 2 — after auto-fix — both resolved.)
+
+## Proposal Coverage
+
+Mapping `repo-responsibility` spec delta scenarios (in `openspec/changes/keep-file-backed-local-mode-as-reference-implementation/specs/repo-responsibility/spec.md`) to the changed files:
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | MODIFIED — bundled local mode listed in "This repo owns" with "canonical reference implementation" + replaceability | Yes | docs/architecture.md |
+| 2 | ADDED framing #1 — conformance target present in Repository Scope | Yes | docs/architecture.md |
+| 3 | ADDED framing #2 — replaceability present in Repository Scope | Yes | docs/architecture.md |
+| 4 | ADDED framing #3 — contract mapping (per-adapter table) in Repository Scope | Yes | docs/architecture.md |
+| 5 | ADDED README positioning paragraph identifying bundled local mode as canonical reference implementation | Yes | README.md |
+| 6 | ADDED README references three framing properties (directly or by link) and identifies itself as source of truth | Yes | README.md |
+| 7 | ADDED slash-command guides do not contradict the framing | Yes | (sweep result: no contradictions found in `.claude/commands/`, `.claude/skills/`, `openspec/README.md`, or `openspec/specs/`) |
+| 8 | ADDED core/adapter surface wording tightened — CLI, file-backed RunStore, git-backed ArtifactStore are bundled-adapter surface, not core contract surface | Yes | docs/architecture.md |
+
+**Coverage Rate**: 8/8 (100%)
+
+## Remaining Risks
+
+- ⚠️ Follow-up issue (post-merge, recorded in tasks.md 6.2): align external surfaces (GitHub repo description, issue templates, adjacent project descriptions) with the new README positioning. README is declared as the source of truth; the inconsistency is bounded and discoverable until the follow-up lands.
+- ⚠️ The reference-implementation framing is enforced by content-presence scenarios in the spec, not by a docs lint test. Future drift in `docs/architecture.md` or `README.md` wording could pass `openspec validate` as long as the structural sections remain — caught only by human review (accepted trade-off per design D3 / R2).
+- ⚠️ The tightened core/adapter surface distinction is a docs-only requirement; future code changes that violate the distinction (e.g., a new core import from `src/bin/` or a concrete store implementation) would not break any existing test (accepted per design R3, mitigated by the `core-dependency-boundary` change already tracking architectural test work).
+
+(No deterministic open/new medium-or-high findings remain in `review-ledger.json` — all resolved in Round 2.)
+
+(No newly added files outside `openspec/changes/<feature>/` per the apply diff — only modifications to `README.md` and `docs/architecture.md`.)
+
+## Human Checkpoints
+
+- [ ] Open `docs/architecture.md` and visually confirm that the three framing properties (conformance target / replaceability / contract mapping) read as a coherent paragraph under "Bundled local reference implementation", and that the contract-mapping table renders as intended in GitHub markdown.
+- [ ] Open `README.md` (Japanese section) and `README.md` (English section) and confirm the positioning paragraphs match in substance — i.e., a JP-only or EN-only reader should reach the same conclusion about what the bundled local mode is and that the README is the source of truth.
+- [ ] Confirm that the "Excluded from core contract (bundled-adapter surface)" subsection in `docs/architecture.md` reads consistently with the contract-mapping table above it (no row implies CLI/RunStore/ArtifactStore are core contract surface).
+- [ ] After merge, file the follow-up issue described in `tasks.md` 6.2 ("Align external surfaces with README positioning of the bundled local reference implementation") and link it back to issue #99.
+- [ ] Verify that the GitHub repo description and any pinned external mentions of specflow's positioning are noted in the follow-up issue's description so the alignment work has a discoverable scope.

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/current-phase.md
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/current-phase.md
@@ -1,0 +1,14 @@
+# Current Phase: keep-file-backed-local-mode-as-reference-implementation
+
+- Phase: fix-review
+- Round: 2
+- Status: all_resolved
+- Open High Findings: 0 件
+- Actionable Findings: 0
+- Accepted Risks: none
+- Latest Changes:
+  - b3effa9 refactor: split specflow-run into core runtime + local CLI wiring (#98)
+  - 5c49050 refactor: replace ls openspec/ probe with openspec list --json (#120, #121)
+  - 3455518 fix: deliver stdin input to child in tryExec
+  - 35c0165 refactor: remove unused MCP integration and narrow lint scope
+- Next Recommended Action: /specflow.approve

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/design.md
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/design.md
@@ -1,0 +1,132 @@
+## Context
+
+The repository ships two layered concerns:
+
+- **Workflow core** under `src/core/` — pure runtime (state machine, run-state, review orchestration) intended to be replaceable.
+- **Bundled local mode** — the `specflow-*` CLI entrypoints (`src/bin/`), the file-backed RunStore, the git-backed ArtifactStore, the slash-command guides, and the templates that together provide a working, end-to-end local workflow on top of the core.
+
+The recent refactor (PR #98) split `specflow-run` into a core runtime plus local CLI wiring, making the core/adapter boundary visible at the source level. However, public-facing docs (`docs/architecture.md`, `README.md`) and the `repo-responsibility` spec describe the bundled local mode using soft language ("bundled but replaceable") that does not commit to its role as the **canonical reference implementation** of the core contract.
+
+The current `repo-responsibility` spec already declares that this repo owns the bundled local reference implementation and that it is replaceable, but:
+
+1. There is no explicit "canonical" / "reference implementation" framing in the docs.
+2. The three framing properties (conformance target, replaceability, contract mapping) are not all present and discoverable.
+3. README is silent on this positioning.
+4. The core contract surface inventory does not unambiguously distinguish core surface from bundled-adapter surface.
+
+This change closes those gaps via additive docs work plus a `repo-responsibility` spec delta that turns the framing into testable requirements.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `docs/architecture.md` document the bundled local mode as the canonical reference implementation of the workflow core contract, with all three framing properties (conformance target, replaceability, contract mapping) present and discoverable.
+- Add a `README.md` positioning paragraph that labels the bundled local mode as the canonical reference implementation, with the three framing properties stated directly or by reference, and that explicitly identifies `README.md` as the source of truth for external-facing positioning.
+- Update slash-command guide docs (under `.claude/commands/` and `openspec/` guide surfaces) so that any wording referencing local execution mode, bundled adapters, or runtime substitution is consistent with the reference-implementation framing.
+- Tighten the wording of the workflow core contract surface inventory in `docs/architecture.md` so that CLI entrypoints, file-backed RunStore, and git-backed ArtifactStore are unambiguously described as bundled-adapter surface, not core contract surface.
+- Confirm that current code already satisfies the tightened spec wording. If a gap is found, fix it as part of this change rather than deferring.
+- Keep `bun test` and `openspec validate` green throughout.
+
+**Non-Goals:**
+
+- No runtime behavior changes to the workflow core, file-backed RunStore, git-backed ArtifactStore, or any `specflow-*` CLI command.
+- No changes to public CLI flags, file layouts, run-state schema, or state-machine transitions.
+- No new spec capabilities. The change is delta-only on `repo-responsibility`.
+- No alignment of GitHub repo description, issue templates, or other external-facing surfaces. README is the source of truth; aligning adjacent surfaces is logged as a follow-up task.
+- No new automated docs lint test (e.g., grep-based shell test). Verification relies on `openspec validate` (covering the framing-property requirements via spec scenarios) plus human PR review.
+
+## Decisions
+
+### D1 — Reference-implementation framing as three explicit properties
+
+Decision: Codify "reference-implementation framing" as exactly three testable properties — (1) conformance target, (2) replaceability, (3) contract mapping — and require all three to be discoverable in the Repository Scope section of `docs/architecture.md`. Mirror the same three properties in `README.md` either directly or by reference.
+
+Why: Without enumerated properties, "framing" is subjective and reviewers cannot tell when the change is done. Three properties match the actual structure of what readers need: *what is this?* (conformance target), *can I replace it?* (replaceability), *which adapter implements which contract?* (contract mapping).
+
+Alternatives considered:
+
+- *Two properties (replaceability + contract mapping)*: simpler but loses the explicit "this is the canonical conformance target" framing, which is the whole point of issue #99.
+- *Author judgment with no enumerated properties*: rejected — re-introduces the original ambiguity.
+
+### D2 — README is the source of truth for external-facing positioning
+
+Decision: Treat `README.md` as the source of truth for the bundled-local-mode positioning visible to external readers. README must contain the positioning paragraph; aligning the GitHub repo description, issue templates, and other adjacent surfaces is recorded as a follow-up task in `tasks.md` but is **not** part of this change's acceptance.
+
+Why: A single source of truth keeps the framing coherent and avoids drift between surfaces. README is the natural anchor because it is the first artifact most external readers see and because it lives in-repo, where spec requirements can enforce its content.
+
+Alternatives considered:
+
+- *Update GitHub repo description in the same change*: rejected because repo description is not a versioned in-repo artifact — it cannot be enforced by `openspec validate`, and editing it via `gh repo edit` introduces a side effect outside the change's scope.
+- *No README update*: rejected — leaves the most-read external surface inconsistent with `docs/architecture.md`.
+
+### D3 — Verification: spec requirements + openspec validate + human review
+
+Decision: Verify the framing change through three layers: (a) `openspec validate` enforces that the spec's framing requirements are structurally well-formed, (b) the spec scenarios act as a checklist for human PR review of the docs, and (c) `bun test` continues to prove behavior is unchanged.
+
+Why: The framing outcome is content, not behavior — automation alone cannot judge whether wording communicates the intended framing. The spec requirements give reviewers a concrete checklist (each scenario maps to a check), which is more reliable than free-form review while staying lightweight.
+
+Alternatives considered:
+
+- *Add a grep-based docs lint test*: rejected — brittle (keyword presence ≠ correct framing), and would create a new automated check unique to this change rather than reusing the existing `openspec validate` discipline.
+- *Human review only*: rejected — gives no enforcement against future regressions in `docs/architecture.md` or `README.md`.
+
+### D4 — Spec tightening discipline: confirm code conformance during design
+
+Decision: During the design phase (i.e., as part of this document), explicitly inspect the current code and confirm that the planned tightened spec wording — "CLI entrypoints, file-backed RunStore, and git-backed ArtifactStore are bundled-adapter surface, not core contract surface" — is already satisfied by the current implementation. If a gap is found, the fix is added to `tasks.md` of this change.
+
+Why: A spec delta that tightens wording can retroactively make existing code non-conformant. Catching this at design time avoids surprising the apply phase. Per user choice during reclarify, the fix lives in this change's `tasks.md`, not a follow-up.
+
+**Inspection result:** The recent refactor (PR #98 — "split specflow-run into core runtime + local CLI wiring") already separates pure core logic (`src/core/start.ts`, `src/core/advance.ts`, `src/core/run-core.ts`, etc.) from local CLI wiring (`src/bin/specflow-run.ts`). The file-backed RunStore lives behind the `RunStore` interface used by core; the git-backed ArtifactStore is similarly a bundled adapter behind a core-defined interface. The core contract surface (state machine schema, run-state JSON shape, review protocol) does not import from `src/bin/`, the file-backed store implementation, or the git-backed store implementation. Therefore the tightened spec wording is satisfied by the current code. No code adjustment is required for the spec tightening; tasks.md will only contain docs/spec work.
+
+Alternatives considered:
+
+- *Defer the gap check to apply phase*: rejected — makes apply unpredictable (could discover a code change is needed after design is locked).
+- *Forbid all spec tightening in this change*: rejected — leaves the existing soft wording in place, which is the very ambiguity the issue asks to fix.
+
+### D5 — Slash-command guide updates: consistency check, not full rewrite
+
+Decision: The slash-command guide updates are limited to *consistency* — any wording in `.claude/commands/` or `openspec/` guide docs that references local execution mode, bundled adapters, or runtime substitution must not contradict the reference-implementation framing. There is no requirement to introduce reference-implementation language into guides that do not already discuss these topics.
+
+Why: A blanket "label everything as reference implementation" approach would bloat unrelated guide docs and dilute the framing. Consistency is the achievable, valuable bar.
+
+Alternatives considered:
+
+- *Add reference-implementation framing to every slash-command guide*: rejected — most guides describe per-command behavior and do not naturally discuss core/adapter substitution.
+- *Exclude slash-command guides entirely*: rejected — user opted in during reclarify because guides are part of the local surface and contradictions there would undermine the framing.
+
+### D6 — Spec delta shape: 1 MODIFIED + 4 ADDED requirements
+
+Decision: Implement the spec delta as one MODIFIED requirement (tightening "Bundled local reference implementation ownership is defined" to add the canonical-reference-implementation language) plus four ADDED requirements covering (a) the three framing properties in `docs/architecture.md`, (b) `README.md` positioning, (c) slash-command guide consistency, and (d) tightened core/adapter surface distinction.
+
+Why: This shape keeps each requirement single-purpose and testable via a small set of scenarios. ADDED for new framing properties avoids loss of detail at archive time; MODIFIED for the existing ownership requirement preserves the requirement's identity while strengthening its wording.
+
+Alternatives considered:
+
+- *Single mega-requirement covering all framing*: rejected — harder to map scenarios to checks and harder to evolve incrementally.
+- *MODIFIED for everything*: rejected — would require rewriting requirements that are functionally new additions, losing structural clarity.
+
+## Risks / Trade-offs
+
+- **[R1] Wording drift between `docs/architecture.md` and `README.md`** → Mitigation: The spec scenario for README explicitly allows the README to delegate the three framing properties to `docs/architecture.md` by reference, so the architecture doc is the single content source; README only needs to *point* to it. PR review applies the same scenario checklist to both surfaces.
+- **[R2] Spec scenarios judge content presence, not content quality** → Mitigation: Accepted trade-off. `openspec validate` confirms structural presence; PR review judges quality. Adding a quality-of-prose check is out of scope.
+- **[R3] Future code refactors could violate the tightened core/adapter surface distinction without breaking any test** → Mitigation: Accepted for now. The `repo-responsibility` spec scenarios describe expected wording in `docs/architecture.md`, not source-code structure. A future change can add an architectural test if drift becomes an issue. Documenting this as a known limitation in `docs/architecture.md` is *not* required by the spec delta.
+- **[R4] External surfaces (GitHub repo description, issue templates) remain inconsistent until follow-up is done** → Mitigation: Recorded as a follow-up task in `tasks.md`. README is declared as source of truth, so the inconsistency is bounded and discoverable.
+- **[R5] The slash-command guide consistency requirement is fuzzy** → Mitigation: Scoped to "do not contradict" rather than "must contain". Reviewers only need to flag contradictions, not validate framing wording everywhere.
+
+## Migration Plan
+
+This change is docs-only, so there is no runtime migration. Deployment is the merge of the PR. Rollback is `git revert` of the same PR; no data, schema, or interface changes need to be undone.
+
+Sequencing within the apply phase:
+
+1. Update `docs/architecture.md` (Repository Scope additions + tightened core/adapter wording).
+2. Update `README.md` (positioning paragraph).
+3. Sweep slash-command guide docs for any wording that contradicts the framing; fix only the contradictions found.
+4. Run `openspec validate keep-file-backed-local-mode-as-reference-implementation --type change`.
+5. Run `bun test` to confirm no behavior regression.
+6. Open the PR; reference issue #99.
+7. After merge, file the follow-up issue for aligning external surfaces (GitHub repo description, etc.).
+
+## Open Questions
+
+None. All five challenge points (C1–C5) were resolved during reclarify and are reflected in this design.

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/proposal.md
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+This repository ships both a workflow core and a local slash-command + file-backed + git-backed execution mode. The local mode is currently the only working reference implementation of the core contract, but docs do not clearly label it as such — readers risk conflating the local mode with the core itself, and the responsibilities between `core`, `adapters`, and the `local surface` are blurry.
+
+We want to formally position the local mode as the **canonical reference implementation** of the workflow core contract, so that:
+
+- New contributors understand what is core (replaceable-by-contract) vs. what is bundled (reference implementation).
+- Future runtimes (DB-backed, server-backed, etc.) have a clear conformance target.
+- The existing local workflow keeps working unchanged — this is a docs/positioning change, not a behavior change.
+
+Source: https://github.com/skr19930617/specflow/issues/99
+
+## What Changes
+
+- Document the local slash-command + file-backed + git-backed mode as the **reference implementation** of the workflow core contract in `docs/architecture.md`.
+- Update `README.md` so the project's first-impression positioning also labels the bundled local mode as the reference implementation of the core contract. `README.md` is the **source of truth** for external-facing positioning; aligning adjacent surfaces (GitHub repo description, issue templates, etc.) is tracked as a follow-up task, not part of this change's acceptance.
+- Sweep slash-command guide docs (under `.claude/commands/` and `openspec/` guide surfaces) for any wording that would contradict the reference-implementation framing, and fix only the contradictions found. Adding new framing wording to guides that do not already discuss local execution mode, bundled adapters, or runtime substitution is **explicitly out of scope** for this change — `docs/architecture.md` and `README.md` remain the authoritative surfaces for the framing itself. If the sweep finds no contradictions, this scope is satisfied with no edits to those guide surfaces.
+- Clarify the responsibility split between:
+  - **Core** (`src/core/`) — state machine, run-state, review orchestration contracts
+  - **Bundled adapters** (`src/bin/` CLI wiring + file-backed RunStore + git-backed ArtifactStore) — the thin glue that exposes core to a particular surface
+  - **Local surface** — the slash-command / `specflow-*` CLI user experience
+- Organize the bundled adapter docs so that each adapter (CLI entrypoint, file store, git store) is traceable to the core contract it implements.
+- Preserve existing local workflow behavior; no CLI flags, file layouts, or state transitions change. The existing test suite (`bun test` + `openspec validate`) must remain green as the evidence that local workflow is maintained.
+
+### Reference-implementation framing: minimum required properties
+
+To qualify as sufficient "reference implementation" framing, the updated docs SHALL cover all three of the following properties. These properties become testable requirements in the `repo-responsibility` spec delta (see Step 7).
+
+1. **Conformance target** — docs explicitly state that the bundled local mode is the canonical conformance target for the workflow core contract.
+2. **Replaceability** — docs explicitly state that the local mode is replaceable by external runtimes (DB-backed, server-backed, etc.) conforming to the workflow core contract.
+3. **Contract mapping** — docs map each bundled adapter (CLI entrypoints, file-backed RunStore, git-backed ArtifactStore) to the core contract surface it implements.
+
+### Spec tightening discipline
+
+The `repo-responsibility` spec delta will tighten the wording that distinguishes core contract surface from bundled-adapter surface. Before approving the spec delta, design must confirm that the current code already satisfies the tightened wording. If any gap is found, the adjustment SHALL be added as a task in `tasks.md` within this change (not split into a follow-up change).
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `repo-responsibility`: Extend the "This repo owns" / "Boundary Decision Rules" sections of `docs/architecture.md` to explicitly call out the bundled local mode as the reference implementation of the core contract, require the three framing properties (conformance target, replaceability, contract mapping) to be present in both `docs/architecture.md` and `README.md`, and tighten the wording that distinguishes core contract surface from bundled-adapter surface.
+
+## Impact
+
+- Docs: `docs/architecture.md` (Repository Scope section — additive wording only) and `README.md` (positioning paragraph — additive wording only). Slash-command guide docs under `.claude/commands/` and `openspec/` guide surfaces are swept for contradictions only; no new framing wording is introduced into those guides as part of this change (see "What Changes" for the explicit out-of-scope note). **Sweep result (recorded in `tasks.md` 3.1 and 3.2): no contradictions found in `.claude/commands/` (only `opsx/` openspec helper commands present, none of which discuss local execution mode, bundled adapters, or runtime substitution) or in `openspec/` guide surfaces; therefore no edits to those guide files appear in the diff, consistent with the "fix only the contradictions found" scope.**
+- Specs: `openspec/specs/repo-responsibility/` (requirement delta to reinforce reference-implementation framing, to require the three framing properties, and to cover the `README.md` positioning surface).
+- Code: No runtime behavior changes expected. Existing `specflow-*` CLI, slash command guides, file-backed RunStore, and git-backed ArtifactStore paths remain untouched. If design finds the current code fails the tightened spec wording, minimal adjustments will be tracked in `tasks.md`.
+- Verification:
+  - `openspec validate "<CHANGE_ID>" --type change` passes, covering the three framing-property requirements.
+  - Existing `bun test` runs stay green as the acceptance signal that local workflow is preserved.
+  - Human PR review confirms the wording of the three framing properties.
+- Follow-up (out of scope): Aligning external surfaces (GitHub repo description, issue templates, other adjacent project descriptions) with the new `README.md` positioning is tracked as a follow-up issue recorded in `tasks.md`.
+- Consumers: External-runtime authors gain a clearer target to conform to; local users are unaffected.

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/review-ledger-design.json
@@ -1,0 +1,19 @@
+{
+  "feature_id": "keep-file-backed-local-mode-as-reference-implementation",
+  "phase": "design",
+  "current_round": 1,
+  "status": "all_resolved",
+  "max_finding_id": 0,
+  "findings": [],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 0,
+      "open": 0,
+      "new": 0,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/review-ledger.json
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/review-ledger.json
@@ -1,0 +1,62 @@
+{
+  "feature_id": "keep-file-backed-local-mode-as-reference-implementation",
+  "phase": "impl",
+  "current_round": 2,
+  "status": "all_resolved",
+  "max_finding_id": 2,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "medium",
+      "category": "completeness",
+      "file": ".claude/commands/, openspec/ guide surfaces",
+      "title": "Slash-command guide docs not updated",
+      "detail": "The proposal explicitly lists 'Update the slash-command guide docs (under `.claude/commands/` and `openspec/` guide surfaces) to reinforce the same reference-implementation framing' as part of What Changes, and Impact reiterates this. The diff only touches README.md and docs/architecture.md — no slash-command guide files are updated. Either add the framing to those guide surfaces or revise the proposal/tasks scope to defer them explicitly.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "low",
+      "category": "quality",
+      "file": "docs/architecture.md",
+      "title": "CLI entrypoint mapping wording is self-contradictory",
+      "detail": "In the new contract-mapping table, the CLI entrypoints row says 'Local execution surface for the workflow core ... Not part of the core contract surface.' Calling it a 'workflow core contract surface implemented' column entry while simultaneously stating it is not part of the core contract surface is confusing. Consider rephrasing as 'Bundled-adapter surface only — exposes the core via specflow-run; not itself a core contract surface' for consistency with the Excluded section below.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "low": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 2,
+      "open": 0,
+      "new": 0,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/review-ledger.json.bak
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/review-ledger.json.bak
@@ -1,0 +1,51 @@
+{
+  "feature_id": "keep-file-backed-local-mode-as-reference-implementation",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "in_progress",
+  "max_finding_id": 2,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "medium",
+      "category": "completeness",
+      "file": ".claude/commands/, openspec/ guide surfaces",
+      "title": "Slash-command guide docs not updated",
+      "detail": "The proposal explicitly lists 'Update the slash-command guide docs (under `.claude/commands/` and `openspec/` guide surfaces) to reinforce the same reference-implementation framing' as part of What Changes, and Impact reiterates this. The diff only touches README.md and docs/architecture.md — no slash-command guide files are updated. Either add the framing to those guide surfaces or revise the proposal/tasks scope to defer them explicitly.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "low",
+      "category": "quality",
+      "file": "docs/architecture.md",
+      "title": "CLI entrypoint mapping wording is self-contradictory",
+      "detail": "In the new contract-mapping table, the CLI entrypoints row says 'Local execution surface for the workflow core ... Not part of the core contract surface.' Calling it a 'workflow core contract surface implemented' column entry while simultaneously stating it is not part of the core contract surface is confusing. Consider rephrasing as 'Bundled-adapter surface only — exposes the core via specflow-run; not itself a core contract surface' for consistency with the Excluded section below.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "low": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/specs/repo-responsibility/spec.md
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/specs/repo-responsibility/spec.md
@@ -1,21 +1,4 @@
-# repo-responsibility Specification
-
-## Purpose
-TBD - created by archiving change repo-responsibility-nongoals. Update Purpose after archive.
-## Requirements
-### Requirement: Repository scope definition exists in docs/architecture.md
-The existing `docs/architecture.md` SHALL contain a "Repository Scope" section that defines what this repository owns and does not own. The section SHALL be appended to the existing document without modifying existing sections.
-
-#### Scenario: Repository Scope section is present
-- **WHEN** a contributor reads `docs/architecture.md`
-- **THEN** a "Repository Scope" section exists containing subsections for "This repo owns", "This repo does not own", and "Boundary Decision Rules"
-
-### Requirement: Workflow core ownership is defined
-The "This repo owns" subsection SHALL list workflow core as a responsibility, including state machine definition, run-state management, and review orchestration.
-
-#### Scenario: Workflow core listed as owned
-- **WHEN** a contributor checks the "This repo owns" subsection
-- **THEN** workflow core is listed with state machine definition, run-state management, and review orchestration as constituent parts
+## MODIFIED Requirements
 
 ### Requirement: Bundled local reference implementation ownership is defined
 The "This repo owns" subsection of `docs/architecture.md` SHALL list the bundled local reference implementation as a responsibility, including specflow-* CLI tools, slash command guides, and templates. The section SHALL state that the local implementation is the **canonical reference implementation** of the workflow core contract, and that it is bundled but replaceable by external runtimes (DB-backed, server-backed, etc.) conforming to the workflow core contract.
@@ -26,35 +9,7 @@ The "This repo owns" subsection of `docs/architecture.md` SHALL list the bundled
 - **THEN** the section explicitly labels the bundled local mode as the "canonical reference implementation" of the workflow core contract
 - **THEN** the section states the implementation is replaceable by external runtimes conforming to the workflow core contract
 
-### Requirement: Non-goals are explicitly listed
-The "This repo does not own" subsection SHALL explicitly list DB-backed runtime, server PoC, and external runtime adapters as out of scope.
-
-#### Scenario: Non-goals are present
-- **WHEN** a contributor checks the "This repo does not own" subsection
-- **THEN** DB-backed runtime, server PoC, and external runtime adapters are each listed as out of scope
-
-### Requirement: Boundary decision rules with examples
-The "Boundary Decision Rules" subsection SHALL provide actionable rules for classifying borderline components, with at least three concrete examples covering shared interfaces, external-runtime-specific artifacts, and contract conformance testing.
-
-#### Scenario: Decision rules include concrete examples
-- **WHEN** a contributor evaluates whether a new component belongs in this repo
-- **THEN** the boundary decision rules provide at least three examples: one for a component that belongs (shared interface definitions), one that does not belong (DB migration scripts), and one for contract conformance test suites
-
-### Requirement: Workflow core contract surface inventory
-The document SHALL include a non-normative inventory of the workflow core contract surface, listing state machine schema, run-state JSON structure, and review protocol interface. CLI entry-points SHALL NOT be listed as part of the core contract.
-
-#### Scenario: Contract inventory is non-normative and excludes CLI
-- **WHEN** a contributor reads the contract surface inventory
-- **THEN** the inventory lists state machine schema, run-state JSON structure, and review protocol interface
-- **THEN** the inventory explicitly states it is a non-normative inventory, not the authoritative specification
-- **THEN** CLI entry-point contracts are not listed as core contract surface
-
-### Requirement: Contract normative specification is deferred
-The document SHALL state that the authoritative normative specification for each contract surface, including versioning and change management, is deferred to a follow-up proposal.
-
-#### Scenario: Follow-up proposal is referenced
-- **WHEN** a contributor reads the contract surface inventory
-- **THEN** the section states that normative contract specification, versioning, and change ownership are deferred to a separate future proposal
+## ADDED Requirements
 
 ### Requirement: Reference-implementation framing properties are present in docs/architecture.md
 The Repository Scope section of `docs/architecture.md` SHALL document the bundled local mode using three framing properties: (1) conformance target, (2) replaceability, and (3) contract mapping. All three properties SHALL be present and discoverable from the Repository Scope section.
@@ -97,4 +52,3 @@ The wording of the workflow core contract surface inventory in `docs/architectur
 - **WHEN** a contributor reads the workflow core contract surface inventory
 - **THEN** CLI entrypoints, the file-backed RunStore, and the git-backed ArtifactStore are unambiguously described as bundled-adapter surface
 - **THEN** none of those three are listed as part of the core contract surface
-

--- a/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/tasks.md
+++ b/openspec/changes/archive/2026-04-13-keep-file-backed-local-mode-as-reference-implementation/tasks.md
@@ -1,0 +1,38 @@
+## 1. docs/architecture.md updates
+
+- [x] 1.1 In the "Repository Scope" → "This repo owns" subsection, update the bundled-local-mode entry to explicitly label it as the **canonical reference implementation** of the workflow core contract (satisfies MODIFIED requirement "Bundled local reference implementation ownership is defined").
+- [x] 1.2 Add wording (in Repository Scope, contiguous with the bundled-local-mode entry) covering framing property #1 — **conformance target**: state that the bundled local mode is the canonical conformance target for the workflow core contract.
+- [x] 1.3 Add wording covering framing property #2 — **replaceability**: state that the local mode is replaceable by external runtimes (e.g., DB-backed, server-backed) conforming to the workflow core contract.
+- [x] 1.4 Add wording covering framing property #3 — **contract mapping**: map each bundled adapter — CLI entrypoints under `src/bin/`, the file-backed RunStore, and the git-backed ArtifactStore — to the workflow core contract surface it implements.
+- [x] 1.5 Tighten the wording of the "Workflow core contract surface inventory" section so that CLI entrypoints, the file-backed RunStore, and the git-backed ArtifactStore are unambiguously described as bundled-adapter surface (not core contract surface).
+
+## 2. README.md updates
+
+- [x] 2.1 Add a positioning paragraph (or extend an existing top-level section) that labels the bundled local slash-command + file-backed + git-backed mode as the canonical reference implementation of the workflow core contract.
+- [x] 2.2 In the same paragraph, state the three framing properties (conformance target, replaceability, contract mapping) directly **or** link to the Repository Scope section of `docs/architecture.md` for the details.
+- [x] 2.3 Explicitly identify `README.md` as the source of truth for external-facing positioning of the bundled local mode (e.g., a one-line note adjacent to the positioning paragraph).
+
+## 3. Slash-command guide consistency sweep
+
+- [x] 3.1 Sweep `.claude/commands/` for wording that references local execution mode, bundled adapters, or runtime substitution; flag and fix any wording that contradicts the reference-implementation framing established in `docs/architecture.md` and `README.md`. **Result:** No mentions of local execution mode, bundled adapters, RunStore/ArtifactStore, conformance, or runtime substitution in `.claude/commands/` (only `opsx/` openspec helper commands present); no contradictions to fix.
+- [x] 3.2 Sweep `openspec/` guide surfaces (e.g., guide files referenced by slash commands such as the `/specflow*` skill prompts) for the same contradictions; fix only the contradictions found. Do not introduce reference-implementation language into guides that do not already discuss these topics. **Result:** `openspec/README.md` contains directory convention only — no framing-relevant wording. `openspec/specs/` references (`bundled`, `replaceable`, `external runtime`, `conformance`) are consistent with the new framing or already updated by this change's spec delta. No contradictions to fix.
+
+## 4. Spec-tightening conformance check (no code change expected)
+
+- [x] 4.1 Re-confirm at apply time the design's D4 finding: `src/core/` does not import from `src/bin/`, the file-backed RunStore implementation, or the git-backed ArtifactStore implementation. If a violation is found, add a follow-up task in this section to remove the import; otherwise mark this task done with no code change. **Result:** All `src/core/*.ts` imports verified — only `../lib/artifact-store.ts` (interface, no I/O), `../lib/run-store-ops.ts` (store-backed ops on the interface), `../lib/workspace-context.ts` (VCS-neutral interface), `../lib/artifact-types.ts` (types), `../lib/workflow-machine.ts` (core logic), `../types/contracts.ts` (types), and intra-core `./` imports. **No imports from `src/bin/` or any concrete file/git store implementation.** D4 satisfied; no code change required.
+
+## 5. Verification
+
+- [x] 5.1 Run `openspec validate keep-file-backed-local-mode-as-reference-implementation --type change` and confirm `valid: true`. **Result:** `valid: true`, 0 issues.
+- [x] 5.2 Run `bun test` and confirm all existing tests still pass (no behavior regression). **Note:** This repo's actual verification command is `npm test` (which builds and runs `node --test dist/tests/*.test.js`); `bun test` was an erroneous reference in the original task. **Result:** `npm test` — 223 tests pass, 0 fail.
+- [x] 5.3 Manually walk the spec scenarios for `repo-responsibility` against the updated `docs/architecture.md`, `README.md`, and slash-command guide docs as a self-review checklist before opening the PR. **Result:**
+  - MODIFIED "Bundled local reference implementation ownership is defined" — `docs/architecture.md` now labels the bundled local mode as the "**canonical reference implementation**" and retains the replaceability statement. ✓
+  - ADDED "Reference-implementation framing properties are present in docs/architecture.md" — all three properties (conformance target, replaceability, contract mapping with adapter→contract table) appear contiguous in the Repository Scope section. ✓
+  - ADDED "README.md positions the bundled local mode as the reference implementation" — new "## 位置づけ — Reference Implementation" section in JP and "## Positioning — Reference Implementation" in EN, with the three properties stated directly + linking to docs/architecture.md, plus an explicit "Source of truth" note. ✓
+  - ADDED "Slash-command guide docs reinforce reference-implementation framing" — sweep found no contradictions in `.claude/commands/`, `.claude/skills/`, `openspec/README.md`, or `openspec/specs/`. ✓
+  - ADDED "Core contract surface and bundled-adapter surface wording are distinguished" — "Excluded from core contract (bundled-adapter surface)" subsection explicitly lists CLI entrypoints, file-backed RunStore, and git-backed ArtifactStore as bundled-adapter surface, not core contract surface. ✓
+
+## 6. PR + follow-up
+
+- [ ] 6.1 Open the PR; reference issue #99 in the PR body.
+- [ ] 6.2 After merge, file a follow-up GitHub issue titled "Align external surfaces with README positioning of the bundled local reference implementation" covering the GitHub repo description, issue templates, and any other adjacent project descriptions. Link this follow-up issue back to issue #99.


### PR DESCRIPTION
## Summary

- Reframe the bundled slash-command + file-backed + git-backed local mode as the **canonical reference implementation** of the workflow core contract in `docs/architecture.md` (Repository Scope) and `README.md` (JP + EN positioning section).
- Codify the three framing properties — **conformance target**, **replaceability**, and **contract mapping** — so readers can distinguish core contract surface from bundled-adapter surface at a glance.
- Add a per-adapter contract-mapping table (CLI entrypoints / file-backed RunStore / git-backed ArtifactStore → core contract surface) and tighten the "Excluded from core contract (bundled-adapter surface)" subsection to remove ambiguity about what is and is not core contract surface.
- Update `repo-responsibility` spec: 1 MODIFIED + 4 ADDED requirements (framing properties in architecture.md, README positioning + source-of-truth, slash-command guide consistency, core/adapter surface distinction) — all enforced by `openspec validate`.
- **No runtime / test / code behavior change.** `npm test` stays green (223/223); `openspec validate` passes.

## Issue

Closes https://github.com/skr19930617/specflow/issues/99