### PR TITLE
feat: add deterministic PhaseRouter for server orchestration (#132)

### DIFF
--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/approval-summary.md
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/approval-summary.md
@@ -1,0 +1,111 @@
+# Approval Summary: feat-deterministic-phase-router-for-server-orchestration
+
+**Generated**: 2026-04-14T09:45:00Z
+**Branch**: feat-deterministic-phase-router-for-server-orchestration
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+```
+ .../.openspec.yaml                                 |   2 +
+ .../current-phase.md                               |  15 +
+ .../design.md                                      | 308 ++++++++
+ .../proposal.md                                    | 153 ++++
+ .../review-ledger-design.json                      |  19 +
+ .../review-ledger.json                             |  85 ++
+ .../specs/phase-router/spec.md                     | 196 +++++
+ .../tasks.md                                       |  61 ++
+ src/lib/phase-router/derive-action.ts              | 159 ++++
+ src/lib/phase-router/errors.ts                     |  50 ++
+ src/lib/phase-router/index.ts                      |  24 +
+ src/lib/phase-router/router.ts                     | 217 +++++
+ src/lib/phase-router/types.ts                      |  74 ++
+ src/tests/phase-router.test.ts                     | 871 +++++++++++++++++++++
+```
+
+## Files Touched
+
+- openspec/changes/feat-deterministic-phase-router-for-server-orchestration/.openspec.yaml
+- openspec/changes/feat-deterministic-phase-router-for-server-orchestration/current-phase.md
+- openspec/changes/feat-deterministic-phase-router-for-server-orchestration/design.md
+- openspec/changes/feat-deterministic-phase-router-for-server-orchestration/proposal.md
+- openspec/changes/feat-deterministic-phase-router-for-server-orchestration/review-ledger-design.json
+- openspec/changes/feat-deterministic-phase-router-for-server-orchestration/review-ledger.json
+- openspec/changes/feat-deterministic-phase-router-for-server-orchestration/specs/phase-router/spec.md
+- openspec/changes/feat-deterministic-phase-router-for-server-orchestration/tasks.md
+- src/lib/phase-router/derive-action.ts
+- src/lib/phase-router/errors.ts
+- src/lib/phase-router/index.ts
+- src/lib/phase-router/router.ts
+- src/lib/phase-router/types.ts
+- src/tests/phase-router.test.ts
+
+## Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+### Impl Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 2     |
+
+## Proposal Coverage
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | currentPhase returns the run's phase contract | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 2 | nextAction returns a PhaseAction discriminated union | Yes | src/lib/phase-router/router.ts, src/lib/phase-router/types.ts, src/tests/phase-router.test.ts |
+| 3 | Determinism across repeated calls | Yes | src/lib/phase-router/router.ts, src/lib/phase-router/derive-action.ts, src/tests/phase-router.test.ts |
+| 4 | Adding a phase requires no router code change | Yes | src/lib/phase-router/derive-action.ts |
+| 5 | Terminal phases derive terminal action from contract | Yes | src/lib/phase-router/derive-action.ts, src/tests/phase-router.test.ts |
+| 6 | Event emitted synchronously before await_user | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 7 | Caller does not emit the event itself | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 8 | Repeated nextAction in same gated state emits once | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 9 | Re-entering a gated phase emits again | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 10 | advance does not mutate the store | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 11 | advance carries the next event name | Yes | src/lib/phase-router/derive-action.ts, src/tests/phase-router.test.ts |
+| 12 | Missing PhaseContract throws | Yes | src/lib/phase-router/router.ts, src/lib/phase-router/errors.ts, src/tests/phase-router.test.ts |
+| 13 | Malformed contract throws | Yes | src/lib/phase-router/derive-action.ts, src/tests/phase-router.test.ts |
+| 14 | Inconsistent run state throws | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 15 | No locking inside router | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 16 | Router constructed with injected dependencies | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 17 | Router does not import filesystem APIs directly | Yes | src/lib/phase-router/router.ts, src/tests/phase-router.test.ts |
+| 18 | No CLI command imports PhaseRouter | Yes | src/tests/phase-router.test.ts |
+| 19 | Router is exported and unit-tested | Yes | src/lib/phase-router/index.ts, src/tests/phase-router.test.ts |
+
+**Coverage Rate**: 19/19 (100%)
+
+## Remaining Risks
+
+### Deterministic risks (from review-ledger)
+
+_No open or new medium/high findings._
+
+### Untested new files
+
+_All new .ts files are covered by the test suite in src/tests/phase-router.test.ts. No .sh or .md new files outside openspec/changes/ require review coverage._
+
+### Uncovered criteria
+
+_None. All 19 scenarios are mapped to implementation files._
+
+## Human Checkpoints
+
+- [ ] Confirm that the local `PhaseContract`, `SurfaceEvent`, and `SurfaceEventSink` type definitions in `src/lib/phase-router/types.ts` are acceptable as placeholders until #129 (Phase Contract) and #100 (Surface event contract) land, and that the follow-up CLI rewire change will migrate them.
+- [ ] Confirm that the in-memory dedup (per-process) is an acceptable scope for this change, with R2 (restart causes re-emit) accepted as an orchestrator concern until the CLI/server wiring lands.
+- [ ] Confirm the registry-driven safety net in `phase-router.test.ts` (asserting one fixture per `PhaseNextAction`) is sufficient until a production `PhaseContractRegistry` exists, at which point #129's follow-up should replace the fixture-based coverage with registry coverage.
+- [ ] Confirm the "no-CLI-imports" grep test correctly covers every current CLI surface (`src/bin`, `src/core`, `src/contracts`, `src/generators`) and that any future CLI directory added to the repo is either added to this allowlist or intentionally excluded.
+- [ ] Confirm OQ1 (error metadata for orchestrator UI) and OQ2 (advance action payload shape) are acceptable to resolve during the follow-up wiring change rather than in this change.

--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/current-phase.md
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/current-phase.md
@@ -1,0 +1,15 @@
+# Current Phase: feat-deterministic-phase-router-for-server-orchestration
+
+- Phase: fix-review
+- Round: 2
+- Status: all_resolved
+- Open High Findings: 0 件
+- Actionable Findings: 0
+- Accepted Risks: none
+- Latest Changes:
+  - 45ede7a fix: use <RUN_ID> instead of <CHANGE_ID> in specflow-run command guides (#125)
+  - e4fb38f docs: position bundled local mode as canonical reference implementation (#99)
+  - b3effa9 refactor: split specflow-run into core runtime + local CLI wiring (#98)
+  - 5c49050 refactor: replace ls openspec/ probe with openspec list --json (#120, #121)
+  - 3455518 fix: deliver stdin input to child in tryExec
+- Next Recommended Action: /specflow.approve

--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/design.md
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/design.md
@@ -1,0 +1,308 @@
+## Context
+
+Workflow orchestration today is driven by Claude reading slash-command
+guides and deciding autonomously what to do next at each phase. For a
+server-side specflow runtime to be reproducible, auditable, and
+AI-independent, the per-phase routing decision must move into
+deterministic program code.
+
+The `workflow-run-state` capability already owns the authoritative
+phase graph and transitions. The forthcoming Phase Contract (#129) will
+attach structured metadata (`next_action`, `gated`, `terminal`, …) to
+each phase. The Surface event contract (#100) defines the event schema
+that surfaces (CLI, server, future UIs) observe.
+
+What is missing is a **pure decision layer** that, given a run's
+current phase, returns the next action the runtime should take, and
+emits the gated surface event at decision points. That layer is the
+`PhaseRouter` introduced by this change.
+
+This change ships the router **dormant** — it is exported and
+exhaustively unit-tested but is not wired into any CLI command path.
+Local CLI mode remains the reference implementation, untouched.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a `PhaseRouter` interface with `currentPhase` and
+  `nextAction` operations that are deterministic for identical
+  `(runId, store snapshot)` input and AI-free.
+- Derive every routing decision from `PhaseContract` metadata; do not
+  maintain a parallel phase→action mapping table.
+- Emit gated surface events synchronously **before** returning
+  `await_user`, with deduplication keyed by
+  `(runId, phase-entry, event_kind)`.
+- Treat the router as **read-only with respect to `RunArtifactStore`**;
+  the only permitted side effect is gated event emission.
+- Fail fast on any contract gap, parse error, or inconsistent run
+  state — no silent fallbacks.
+- Cover every phase (mainline, terminal, utility) and every transition
+  path with unit tests, including the determinism, dedup, and
+  fail-fast properties.
+
+**Non-Goals:**
+
+- Wiring the router into any CLI command. CLI rewiring is a separate,
+  follow-up change.
+- Defining the `PhaseContract` itself. That is owned by #129; this
+  change consumes the contract type.
+- Defining the Surface event schema. That is owned by #100; this
+  change emits events conforming to it.
+- Cross-process or cross-restart durable dedup. Single-writer per
+  `runId` is the orchestrator's invariant; persistent dedup is out of
+  scope.
+- Concurrency control. The router holds no per-`runId` locks.
+
+## Decisions
+
+### D1. Pure-function core, thin adapter shell
+
+Implement `PhaseRouter` as a small class whose constructor takes
+`{ store: RunArtifactStore, eventSink: SurfaceEventSink, contracts:
+PhaseContractRegistry }`. All decision logic lives in pure helper
+functions (`deriveAction(contract): PhaseAction`,
+`isGated(contract): boolean`, …) that take only the inputs they need
+and return values; the class methods are thin adapters that load
+`run.json`, look up the contract, call the helpers, and (for gated
+phases) emit before returning.
+
+**Why:** Pure functions make determinism trivial to assert in tests
+and decouple the routing rules from I/O. The adapter shell isolates
+the only side effects (store reads, event emission) into testable
+seams.
+
+**Alternative considered:** Putting all logic on the class. Rejected
+because it would require constructing the class to test routing rules
+and would tangle I/O with logic.
+
+### D2. Action derivation from contract metadata, no parallel table
+
+`deriveAction(contract)` reads `contract.next_action`,
+`contract.gated`, and `contract.terminal` to produce a `PhaseAction`.
+There is no `phaseName → action` switch statement anywhere in the
+router. The full mapping is:
+
+| Contract state                            | PhaseAction          |
+|-------------------------------------------|----------------------|
+| `terminal == true`                        | `{ kind: "terminal", reason }` |
+| `gated == true`                           | `{ kind: "await_user", event_kind }` (after sync emit) |
+| `next_action == "invoke_agent"`           | `{ kind: "invoke_agent", agent }` |
+| `next_action == "advance"`                | `{ kind: "advance", event }` |
+| anything else                             | **throws** `MalformedContractError` |
+
+**Why:** Adding a phase or changing its semantics becomes a contract
+change (and a contract test), not a router change. This is the core
+reason the router is "deterministic by construction" — it has no
+hidden state to drift from the contract.
+
+**Alternative considered:** Keep an explicit table inside the router.
+Rejected because it duplicates the contract and creates two sources of
+truth.
+
+### D3. Gated emit happens synchronously before `await_user` returns
+
+For a gated phase, `nextAction` performs the following sequence
+in order:
+
+1. Compute `event_kind` from the contract.
+2. Check the dedup cache (D5). If already emitted for this entry,
+   skip step 3.
+3. `await eventSink.emit({ run_id, phase, event_kind, … })` — and
+   only proceed once the sink call resolves.
+4. Record the emission in the dedup cache.
+5. Return `{ kind: "await_user", event_kind }`.
+
+**Why:** Callers must be able to assume that observing `await_user`
+implies the corresponding event has already been published. Reversing
+the order or making emission concurrent would force every caller to
+write its own synchronization.
+
+**Alternative considered:** Fire-and-forget emit. Rejected because it
+breaks the observability guarantee and complicates testing.
+
+### D4. `advance` is a pure intent; the orchestrator writes
+
+When a phase's contract says `next_action == "advance"`, the router
+returns `{ kind: "advance", event }` without touching the store. The
+caller (orchestrator) is responsible for invoking
+`store.advance(runId, event)` to materialize the transition.
+
+**Why:** Keeping the router's only side effect to event emission makes
+its behavior trivial to reason about and to test (a "no-write" store
+double can assert this). It also lets the orchestrator interleave
+other concerns (logging, metrics, transactional boundaries) around the
+store write.
+
+**Alternative considered:** Have the router perform `store.advance`
+itself when returning `advance`. Rejected because it spreads
+write responsibility, complicates the read-only invariant, and tangles
+two concerns (deciding the next event vs. committing it).
+
+### D5. Dedup keyed by `(runId, currentPhaseEntryAt, event_kind)`
+
+The router maintains an in-memory `Map<runId, { entryAt: string,
+emitted: Set<string> }>`. `entryAt` is the ISO timestamp of the
+**most recent transition into the current phase**, taken from
+`run.history`. On each `nextAction` call:
+
+- Look up the entry. If `entryAt` differs from the run's current
+  entry timestamp, replace the record (the run has re-entered or
+  moved to a new phase).
+- Check `emitted.has(event_kind)`. If true, skip emission.
+- Otherwise emit, then `emitted.add(event_kind)`.
+
+**Why:** Using the phase-entry timestamp as the dedup key naturally
+resets when the run re-enters the same gated phase (a distinct entry
+in `history`), satisfying the "re-entry emits again" scenario in the
+spec, while still dedup'ing repeated `nextAction` calls within the
+same entry. Pure in-memory keeps the router free of store writes.
+
+**Alternative considered:** Persisting a `lastEmitted` field in
+`run.json`. Rejected because it would require the router to write to
+the store, violating D4's invariant. **Alternative considered:** Sink-
+side dedup. Rejected because it would push semantic responsibility
+out of the router and require every sink implementation to repeat the
+same logic.
+
+**Restart implication:** Dedup is per-process. If the server restarts
+while a run sits in a gated state, the next `nextAction` call will
+re-emit. This is the orchestrator's problem to handle (sinks should
+be idempotent, or the orchestrator should not re-call `nextAction`
+without an external trigger). Captured as a risk (R2).
+
+### D6. Fail-fast error model
+
+The router throws typed errors for every off-happy-path situation:
+
+- `MissingContractError` — no `PhaseContract` registered for the run's
+  current phase.
+- `MalformedContractError` — contract present but missing required
+  metadata (`next_action`, `gated`, `terminal`) or carrying an
+  unrecognized `next_action`.
+- `RunReadError` — `run.json` cannot be read or parsed (wraps the
+  underlying store error).
+- `InconsistentRunStateError` — e.g. terminal contract paired with a
+  pending gated marker, or a `current_phase` not present in the
+  registered contract set during a sanity check.
+
+These apply uniformly to `currentPhase` and `nextAction`. The router
+**does not emit any event** when throwing.
+
+**Why:** Silent fallbacks (defaulting to `await_user`, swallowing,
+returning `terminal('errored')`) hide real bugs and make the
+deterministic guarantee meaningless. Letting the orchestrator catch
+and mark `errored` keeps the failure surface visible.
+
+### D7. Single-writer per `runId`; no internal locking
+
+The router documents — and tests assert — that callers must serialize
+`nextAction` calls per `runId`. The router itself does not acquire
+mutexes, locks, or use atomics. The dedup cache from D5 provides
+defense-in-depth: even if two calls slip through within the same
+entry, the second one will see the cache populated and skip emission.
+
+**Why:** In a server orchestrator there is already a per-run executor
+(one task at a time per run). Pushing locking into the router would
+either duplicate that mechanism or pretend to handle a contention
+case the router cannot actually serialize across processes.
+
+### D8. Exhaustive transition tests driven by the contract registry
+
+Tests iterate the `PhaseContractRegistry` and assert, per phase:
+
+- `nextAction` returns the contract-derived action shape.
+- For gated phases: emission happens once, before `await_user` returns,
+  and is deduped on the second call within the same entry.
+- For terminal phases: returns `{ kind: "terminal", reason }`.
+- For mainline `invoke_agent`/`advance`: store is never written
+  (verified with an `AssertNoWriteStore` double).
+- Determinism: two back-to-back calls with the same store snapshot
+  produce deeply-equal results.
+
+Plus dedicated tests for D6 errors (each thrown type) and D7
+(single-writer documentation/contract).
+
+**Why:** Iterating the registry — rather than hard-coding a phase
+list — guarantees that adding a phase to the contract set
+automatically expands test coverage. Forgetting to test a new phase
+becomes structurally impossible.
+
+### D9. Module location and exports
+
+New module at `src/lib/phase-router/`:
+
+- `index.ts` — re-exports `PhaseRouter`, `PhaseAction`, error classes.
+- `router.ts` — the `PhaseRouter` class.
+- `derive-action.ts` — pure helpers (`deriveAction`, `isGated`, …).
+- `errors.ts` — typed error classes.
+- `types.ts` — `PhaseAction` discriminated union and supporting types.
+
+The module imports type-only from `workflow-run-state` (for
+`RunArtifactStore`), `actor-surface-model` (for `SurfaceEventSink`),
+and the `PhaseContract` types (provided by #129). It does not import
+any CLI code.
+
+## Risks / Trade-offs
+
+- **R1. Hard dependency on Phase Contract (#129).** If #129's contract
+  shape changes, the router's `deriveAction` must be updated.
+  → **Mitigation:** Keep `deriveAction` small and table-shaped; depend
+  on the contract types from #129 directly so type checking flags any
+  shape drift.
+
+- **R2. In-memory dedup does not survive restart.** A server restart
+  while a run is in a gated state can cause the next `nextAction` call
+  to re-emit the gated event. → **Mitigation:** Document this as an
+  orchestrator concern in the README of the new module; recommend
+  idempotent sinks. A future change can add persisted dedup if the
+  operational pain materializes.
+
+- **R3. Single-writer-per-runId is an unenforced precondition.** If
+  violated, the dedup cache provides only a best-effort safety net.
+  → **Mitigation:** Document the invariant on the `PhaseRouter` type;
+  add a test that demonstrates dedup works under repeated calls but
+  also a comment explaining it is not a concurrency primitive.
+
+- **R4. Test growth scales with the workflow machine.** As phases are
+  added, the registry-driven tests automatically run more cases.
+  → **Trade-off:** Accepted. This is the desired safety net; the
+  alternative (forgetting to test new phases) is worse. Tests are
+  pure-function unit tests, so wall-clock cost is negligible.
+
+- **R5. Dormant-by-design code ships unused.** Unused code can rot.
+  → **Mitigation:** The follow-up CLI/server-orchestrator wiring
+  change is the intended consumer; tracking is via Epic #127. Tests
+  give the module continuous exercise even while dormant.
+
+- **R6. `PhaseAction` discriminated union grows over time.** Adding a
+  new kind requires updating both the contract and consumers.
+  → **Trade-off:** Accepted; the union is the API contract surface
+  and changes there should be deliberate. Use exhaustive `switch` in
+  the router so TypeScript flags missed kinds at compile time.
+
+## Migration Plan
+
+This change introduces a new module that no existing code calls. There
+is no runtime migration. Steps to deploy:
+
+1. Land this change with the new `src/lib/phase-router/` module and
+   tests.
+2. Verify CI is green (existing CLI behavior unchanged because nothing
+   imports the new module).
+3. The follow-up CLI/server-orchestrator change consumes the router.
+
+**Rollback:** Revert this change. No data, runtime state, or external
+contract is touched, so rollback is a code-only revert.
+
+## Open Questions
+
+- **OQ1.** Should `MissingContractError` and `MalformedContractError`
+  carry enough metadata for the orchestrator to render an actionable
+  error to the user (e.g. phase name + missing field name)? Likely
+  yes; resolve during implementation by examining what the
+  orchestrator's error UI needs.
+- **OQ2.** Should `PhaseAction.advance` carry the `PhaseContract`
+  itself, or just the event name? Lean toward just the event name for
+  minimal coupling, but defer until the consumer (follow-up change)
+  exercises the API.

--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/proposal.md
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/proposal.md
@@ -1,0 +1,153 @@
+## Why
+
+Workflow orchestration today is driven by Claude reading slash-command guides
+and deciding autonomously what to do next at each phase. For a server-side
+specflow runtime that must be reproducible, auditable, and AI-independent,
+this control flow needs to be moved into deterministic program code.
+
+A `PhaseRouter` provides that deterministic decision layer: given a run's
+current phase, it returns the single next action the runtime should take —
+with no model calls, and identical output for identical input.
+
+Source: Issue [skr19930617/specflow#132](https://github.com/skr19930617/specflow/issues/132)
+(Epic #127; related #100, #101).
+
+## What Changes
+
+- **NEW**: `PhaseRouter` interface exposing:
+  - `currentPhase(runId)` → returns the `PhaseContract` for the run's current
+    workflow state.
+  - `nextAction(runId)` → returns a `PhaseAction` discriminated union:
+    `invoke_agent` | `await_user` | `advance` | `terminal`.
+- **NEW**: `PhaseAction` is **derived from `PhaseContract`**. The contract
+  for each phase carries the metadata (e.g. `next_action`, `gated`,
+  `terminal`) the router needs; the router does not maintain its own
+  parallel mapping table. This keeps the routing decision a pure function
+  of the contract, so adding a phase or changing its semantics is a
+  contract change, not a router change.
+- **NEW**: `PhaseRouter` takes the `RunArtifactStore` interface via
+  constructor injection to read `run.json` and resolve `current_phase`.
+  Tests inject in-memory mocks; production wires the real store.
+- **NEW**: A single `PhaseRouter` covers **every phase** in the workflow
+  machine, including:
+  - mainline phases (`proposal_draft` → `approved`),
+  - terminal phases (`approved`, `rejected`, `decomposed`) → `terminal`,
+  - utility branches (`explore`, `spec_bootstrap`) — same router, same
+    contract-derived rules.
+- **NEW**: `PhaseAction.advance` is a **pure intent** — it names the
+  next event to fire but the router never mutates `RunArtifactStore`
+  itself. The orchestrator (caller) is responsible for calling
+  `store.advance(...)`. The router's only side effect is event emission
+  for gated decisions.
+- **NEW**: Error-path policy — when the `PhaseContract` for a phase is
+  missing, malformed, or omits required metadata (`next_action`,
+  `gated`, `terminal`); when `run.json` cannot be parsed; or when the
+  run is in an inconsistent state (e.g. terminal phase with a pending
+  gated decision), the router **fails fast by throwing**. There is no
+  silent fallback. The orchestrator is expected to mark the run as
+  `errored` and escalate. This applies uniformly to `currentPhase` and
+  `nextAction`.
+- **NEW**: Concurrency model — the router assumes **single-writer per
+  `runId`** as an invariant of the calling orchestrator. The router
+  itself holds no per-`runId` locks; serialization is the orchestrator's
+  responsibility. Emission deduplication is keyed by
+  `(runId, phase, event_kind)` so that even under unintended repeated
+  calls within the same gated state, no duplicate event is emitted.
+- **NEW**: For gated decisions (approve / reject / clarify waits) the
+  router returns `await_user` and **emits the corresponding surface event
+  internally** to the injected event sink, so the caller simply observes
+  `await_user` and goes idle. Event emission is not the caller's
+  responsibility. Emission happens **synchronously before** `await_user`
+  is returned, guaranteeing that whenever a caller observes the event,
+  the matching `await_user` return has either already happened or is
+  about to. Emission is **deduplicated** by `(runId, phase, event_kind)`
+  so repeated `nextAction` calls in the same gated state never re-emit.
+- **NEW**: Event emission aligned with the Surface event contract (#100)
+  so that surfaces (CLI, server, future UIs) can observe and drive the
+  run.
+- **NEW**: Exhaustive transition-path tests covering every phase in the
+  workflow machine, asserting the returned `PhaseAction` and the events
+  emitted at gated decisions. Determinism is asserted explicitly:
+  identical `(runId, store snapshot)` input produces identical output
+  across repeated calls.
+
+## Capabilities
+
+### New Capabilities
+
+- `phase-router`: Deterministic phase-to-action router for server-side
+  workflow orchestration. Owns the `PhaseRouter` interface, the routing
+  rules from `PhaseContract` to `PhaseAction`, and the emission of
+  surface events at gated decisions (approve/reject/clarify). Contains
+  no AI calls and is fully reproducible.
+
+### Modified Capabilities
+
+- None. This change depends on but does not modify:
+  - `workflow-run-state` — consumed as the authoritative phase graph.
+  - `actor-surface-model` — consumed for actor/surface taxonomy and event
+    surface semantics (linked to #100).
+  - Phase Contract (#129) — separate change; this router assumes a
+    structured `PhaseContract` is available to read phase metadata from.
+
+## Impact
+
+- **Code**: New module (e.g. `src/lib/phase-router/`) implementing
+  `PhaseRouter`, the contract-derivation logic (no parallel routing table),
+  and event emission. Pure-function core with a thin adapter over the
+  injected `RunArtifactStore` and surface event sink.
+- **APIs**: New `PhaseRouter` and `PhaseAction` types exported from the
+  server orchestration surface. No changes to existing CLI contracts in
+  this change; the CLI continues to work as-is until a subsequent change
+  rewires it on top of the router. The router ships **dormant** — it is
+  exported and fully tested in isolation but is **not wired into any
+  CLI command path** in this change. CLI rewiring is deferred to a
+  follow-up change so that this change's blast radius is limited to
+  new code only.
+- **Dependencies**:
+  - #129 (Phase Contract) — router reads structured phase metadata.
+  - #100 (Surface event contract) — event schema the router emits against.
+  - #101 (Approval / clarify semantics) — defines which decisions are
+    gated and therefore suspend the run.
+- **Systems**: Prepares for a server orchestration mode where Claude's
+  slash-command-guide-driven flow is replaced by deterministic routing.
+  Local CLI mode remains the reference implementation and is not
+  disrupted by this change.
+- **Testing**: New unit tests per phase and per transition path; no
+  existing suites need to change in this scope. Tests must cover:
+  - the fail-fast error path for missing/malformed contracts and
+    corrupt/inconsistent run state,
+  - that gated events are emitted exactly once per
+    `(runId, phase, event_kind)` even across repeated `nextAction`
+    calls,
+  - that emission completes synchronously before `await_user` returns,
+  - that the router never mutates `RunArtifactStore` (verified with a
+    read-only / assert-no-write store double),
+  - determinism under identical `(runId, store snapshot)` input.
+
+## Clarifications
+
+Decisions captured during proposal challenge + reclarify (Step 6):
+
+- **Missing/malformed `PhaseContract`** → router **throws (fail-fast)**.
+  No silent default. The orchestrator marks the run `errored` and
+  escalates. Same policy for unknown phases, corrupt `run.json`, and
+  inconsistent run state.
+- **Gated event emission timing** → **synchronous before** `await_user`
+  is returned. When a caller observes the event, the matching
+  `await_user` return is guaranteed to follow (or have already
+  occurred).
+- **Repeated `nextAction` in the same gated state** → events are
+  **deduplicated** by `(runId, phase, event_kind)`. The router behaves
+  as a pure function from the caller's point of view; no double emit.
+- **`PhaseAction.advance` semantics** → the router is **read-only with
+  respect to `RunArtifactStore`**. `advance` is a pure intent value
+  naming the next event; the orchestrator (caller) is responsible for
+  invoking `store.advance(...)`.
+- **CLI integration scope** → the router ships **dormant** in this
+  change. No CLI command is rewired onto it. A follow-up change will
+  perform the CLI rewire.
+- **Concurrency model** → **single-writer per `runId`** is an invariant
+  the orchestrator must enforce. The router holds no per-`runId`
+  locks; emission dedup keying provides defense-in-depth against
+  unintended repeated calls in the same state.

--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/review-ledger-design.json
@@ -1,0 +1,19 @@
+{
+  "feature_id": "feat-deterministic-phase-router-for-server-orchestration",
+  "phase": "design",
+  "current_round": 1,
+  "status": "all_resolved",
+  "max_finding_id": 0,
+  "findings": [],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 0,
+      "open": 0,
+      "new": 0,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/review-ledger.json
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/review-ledger.json
@@ -1,0 +1,61 @@
+{
+  "feature_id": "feat-deterministic-phase-router-for-server-orchestration",
+  "phase": "impl",
+  "current_round": 2,
+  "status": "all_resolved",
+  "max_finding_id": 2,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "low",
+      "category": "quality",
+      "file": "src/lib/phase-router/derive-action.ts",
+      "title": "Defensive throws after narrowing could be unreachable",
+      "detail": "The `switch (contract.next_action)` cases for `await_user` and `terminal` are unreachable after the preceding terminal/gated guards consumed those states. The throws are harmless and defensive, but a comment noting they are belt-and-suspenders (for when flags lie) would aid future readers. No functional change needed.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "low",
+      "category": "quality",
+      "file": "src/lib/phase-router/router.ts",
+      "title": "readRun does not validate history entry shape",
+      "detail": "`readRun` checks `Array.isArray(run.history)` but does not validate each entry has `to`/`timestamp` strings. `currentEntryAt` accesses `entry.to` and `entry.timestamp` without runtime checks. If a malformed history entry slips through, the router would silently skip or return undefined rather than throwing `RunReadError`. Consider validating entry shape in `readRun`, or narrowing in `currentEntryAt`. Not a blocker since this module operates behind trusted stores.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "low": 2
+      }
+    },
+    {
+      "round": 2,
+      "total": 2,
+      "open": 0,
+      "new": 0,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/specs/phase-router/spec.md
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/specs/phase-router/spec.md
@@ -1,0 +1,196 @@
+## ADDED Requirements
+
+### Requirement: PhaseRouter exposes deterministic phase introspection and next-action selection
+
+The system SHALL provide a `PhaseRouter` interface with two operations:
+
+- `currentPhase(runId)` MUST return the `PhaseContract` corresponding to
+  the run's current workflow phase, read from the injected
+  `RunArtifactStore`.
+- `nextAction(runId)` MUST return a `PhaseAction` value drawn from the
+  discriminated union `invoke_agent | await_user | advance | terminal`.
+
+Both operations MUST be deterministic: for an identical
+`(runId, store snapshot)`, repeated invocations MUST return values that
+are deeply equal. Neither operation MUST invoke any AI/LLM call.
+
+#### Scenario: currentPhase returns the run's phase contract
+- **WHEN** the store reports `current_phase = "design_review"` for `runId`
+- **THEN** `currentPhase(runId)` returns the `PhaseContract` for
+  `design_review`
+
+#### Scenario: nextAction returns a PhaseAction discriminated union
+- **WHEN** `nextAction(runId)` is invoked for any valid phase
+- **THEN** the returned value's `kind` is one of `invoke_agent`,
+  `await_user`, `advance`, or `terminal`
+
+#### Scenario: Determinism across repeated calls
+- **WHEN** `nextAction(runId)` is called twice with no change to the
+  store snapshot in between
+- **THEN** the two returned values are deeply equal
+
+### Requirement: PhaseAction is derived purely from PhaseContract
+
+The router MUST derive each `PhaseAction` from metadata carried by the
+`PhaseContract` for the relevant phase (e.g. `next_action`, `gated`,
+`terminal`). The router MUST NOT maintain a parallel mapping table from
+phase name to action. Adding a phase or changing a phase's semantics
+MUST be expressible as a contract change alone, with no edit to the
+router.
+
+#### Scenario: Adding a phase requires no router code change
+- **WHEN** a new `PhaseContract` is registered with `next_action =
+  "invoke_agent"` and the run's `current_phase` matches
+- **THEN** `nextAction(runId)` returns an `invoke_agent` action without
+  any modification to router code
+
+#### Scenario: Terminal phases derive terminal action from contract
+- **WHEN** the `PhaseContract.terminal` flag is true for the run's
+  current phase
+- **THEN** `nextAction(runId)` returns a `terminal` action
+
+### Requirement: Gated decisions emit a surface event before returning await_user
+
+For phases whose `PhaseContract.gated` is true, the router MUST:
+
+1. Synchronously emit the corresponding surface event to the injected
+   event sink **before** returning.
+2. Return `await_user` from `nextAction(runId)`.
+
+Emission MUST complete (the sink call MUST return) prior to
+`nextAction` returning. The event schema MUST conform to the Surface
+event contract (#100).
+
+#### Scenario: Event emitted synchronously before await_user
+- **WHEN** the run is in a gated phase and `nextAction(runId)` is
+  invoked
+- **THEN** the event sink receives the gated event, AND `nextAction`
+  returns `await_user` only after the sink call has completed
+
+#### Scenario: Caller does not emit the event itself
+- **WHEN** a caller observes `await_user` returned by `nextAction`
+- **THEN** no additional event emission by the caller is required for
+  surfaces (CLI, server, future UIs) to observe the gated decision
+
+### Requirement: Gated event emission is deduplicated per (runId, phase, event_kind)
+
+The router MUST emit each gated surface event at most once per
+`(runId, phase, event_kind)` tuple. Repeated invocations of
+`nextAction(runId)` while the run remains in the same gated phase MUST
+NOT re-emit the event. From the caller's perspective the router MUST
+behave as a pure function of the store snapshot, even though emission
+is a side effect.
+
+#### Scenario: Repeated nextAction in same gated state emits once
+- **WHEN** `nextAction(runId)` is called twice with no change to the
+  store snapshot for a gated phase
+- **THEN** the event sink receives the gated event exactly once across
+  the two calls
+
+#### Scenario: Re-entering a gated phase emits again
+- **WHEN** the run leaves and later re-enters the same gated phase
+  (distinct entries) and `nextAction` is called in each entry
+- **THEN** the event sink receives the gated event once per entry
+
+### Requirement: PhaseAction.advance is a read-only intent
+
+The router MUST NOT mutate `RunArtifactStore` when returning an
+`advance` action. The action MUST carry the name of the next event to
+fire as a pure value, and the orchestrator (caller) is responsible for
+invoking `store.advance(runId, event)` to materialize the transition.
+
+The router's only permitted side effect across the entire `PhaseRouter`
+surface is emission of gated surface events.
+
+#### Scenario: advance does not mutate the store
+- **WHEN** `nextAction(runId)` returns an `advance` action
+- **THEN** `RunArtifactStore.advance` is not invoked by the router and
+  the store snapshot is unchanged
+
+#### Scenario: advance carries the next event name
+- **WHEN** an `advance` action is returned for a phase whose
+  `PhaseContract.next_action` names event `E`
+- **THEN** the returned action exposes `E` as the event the caller
+  should fire
+
+### Requirement: Router fails fast on missing/malformed contract or inconsistent state
+
+The router MUST throw an error (no silent fallback) when:
+
+- the `PhaseContract` for the run's current phase is missing,
+- the contract omits any required metadata field (`next_action`,
+  `gated`, `terminal`) needed to derive a `PhaseAction`,
+- `run.json` cannot be read or parsed,
+- the run is in an inconsistent state (e.g. a phase whose contract is
+  `terminal` but the run also carries a pending gated decision).
+
+This policy MUST apply uniformly to `currentPhase` and `nextAction`.
+The orchestrator is responsible for catching the error, marking the
+run as `errored`, and escalating.
+
+#### Scenario: Missing PhaseContract throws
+- **WHEN** `nextAction(runId)` is invoked for a run whose current phase
+  has no registered `PhaseContract`
+- **THEN** the call throws an error and emits no event
+
+#### Scenario: Malformed contract throws
+- **WHEN** the `PhaseContract` for the run's current phase lacks
+  `next_action`
+- **THEN** the call throws an error identifying the missing field and
+  emits no event
+
+#### Scenario: Inconsistent run state throws
+- **WHEN** the run's current phase contract is `terminal` but the run
+  also carries pending gated-decision metadata
+- **THEN** the call throws an error and emits no event
+
+### Requirement: PhaseRouter assumes single-writer per runId
+
+The router MUST be safe to use under the precondition that **at most
+one writer per `runId`** invokes its operations at any time. The router
+itself MUST NOT acquire per-`runId` locks; serialization is the
+orchestrator's responsibility. Emission deduplication
+(`(runId, phase, event_kind)`) provides defense-in-depth so that
+unintended repeated calls within the same gated state do not produce
+duplicate events.
+
+#### Scenario: No locking inside router
+- **WHEN** `nextAction(runId)` is invoked
+- **THEN** the router does not acquire or hold any per-`runId` lock
+  for the duration of the call
+
+### Requirement: PhaseRouter uses constructor-injected RunArtifactStore and event sink
+
+The `PhaseRouter` MUST receive its `RunArtifactStore` and surface event
+sink via constructor injection. Tests MUST be able to inject in-memory
+mocks (including a read-only / assert-no-write store double) without
+touching the filesystem. Production wiring uses the real store and the
+real event sink.
+
+#### Scenario: Router constructed with injected dependencies
+- **WHEN** `new PhaseRouter({ store, eventSink })` is called
+- **THEN** subsequent `currentPhase` / `nextAction` calls read from
+  `store` and emit through `eventSink` exclusively
+
+#### Scenario: Router does not import filesystem APIs directly
+- **WHEN** the `PhaseRouter` module is loaded
+- **THEN** it does not depend on `node:fs` or any other filesystem
+  module; all I/O flows through injected interfaces
+
+### Requirement: PhaseRouter ships dormant in this change
+
+The `PhaseRouter` and `PhaseAction` types MUST be exported from the
+server orchestration surface in this change. No existing CLI command
+or runtime code path MUST be rewired onto the router in this change.
+CLI rewiring is deferred to a follow-up change.
+
+#### Scenario: No CLI command imports PhaseRouter
+- **WHEN** the change lands
+- **THEN** no file under the existing CLI command path imports
+  `PhaseRouter` or `PhaseAction`
+
+#### Scenario: Router is exported and unit-tested
+- **WHEN** the change lands
+- **THEN** `PhaseRouter` is reachable from the server orchestration
+  surface's public exports and is covered by unit tests for every
+  phase in the workflow machine

--- a/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/tasks.md
+++ b/openspec/changes/archive/2026-04-14-feat-deterministic-phase-router-for-server-orchestration/tasks.md
@@ -1,0 +1,61 @@
+## 1. Module scaffolding
+
+- [x] 1.1 Create `src/lib/phase-router/` directory with empty `index.ts`, `router.ts`, `derive-action.ts`, `errors.ts`, `types.ts`
+- [x] 1.2 Wire `src/lib/phase-router/index.ts` into the server orchestration surface's public exports (no consumer yet — dormant by design per D9 / proposal)
+- [x] 1.3 Confirm no existing CLI command imports the new module (grep gate enforced by test in 4.7)
+
+## 2. Types and errors
+
+- [x] 2.1 Define `PhaseAction` discriminated union in `types.ts` with kinds `invoke_agent | await_user | advance | terminal` and the per-kind payload (agent, event_kind, event, reason)
+- [x] 2.2 Define typed error classes in `errors.ts`: `MissingContractError`, `MalformedContractError`, `RunReadError`, `InconsistentRunStateError` — each carrying enough metadata to render an actionable orchestrator error (phase name, missing field, underlying cause)
+- [x] 2.3 Re-export `PhaseAction`, `PhaseRouter`, and the error classes from `index.ts`
+
+## 3. Pure decision core (`derive-action.ts`)
+
+- [x] 3.1 Implement `deriveAction(contract: PhaseContract): PhaseAction` covering the contract→action table from design D2 (terminal → terminal; gated → await_user; invoke_agent → invoke_agent; advance → advance)
+- [x] 3.2 Make `deriveAction` throw `MalformedContractError` when required metadata (`next_action`, `gated`, `terminal`) is missing or `next_action` is unrecognized
+- [x] 3.3 Implement `isGated(contract): boolean` and `isTerminal(contract): boolean` helpers used by the router shell
+- [x] 3.4 Use an exhaustive `switch` so TypeScript flags any new `next_action` kind at compile time (per D6 / R6)
+
+## 4. Router shell (`router.ts`)
+
+- [x] 4.1 Implement `PhaseRouter` class with constructor `({ store, eventSink, contracts })` taking `RunArtifactStore`, `SurfaceEventSink`, and `PhaseContractRegistry` via injection (D1)
+- [x] 4.2 Implement `currentPhase(runId)`: read `run.json` via `store`, look up the contract in `contracts`, throw `MissingContractError` / `RunReadError` / `InconsistentRunStateError` per D6
+- [x] 4.3 Implement `nextAction(runId)`: load run + contract, call `deriveAction`, and for gated phases run the synchronous emit-then-return sequence from D3 step list
+- [x] 4.4 Implement the in-memory dedup map keyed by `(runId, currentPhaseEntryAt, event_kind)` per D5; derive `currentPhaseEntryAt` from the latest matching entry in `run.history`
+- [x] 4.5 Ensure `nextAction` and `currentPhase` never call `store.advance` or any other write method (the router's only side effect is event emission)
+- [x] 4.6 Throw all four error types from D6 from both `currentPhase` and `nextAction`; never emit when throwing
+- [x] 4.7 Add a unit test that grep-asserts no file under the existing CLI command path imports `PhaseRouter` or `PhaseAction` (proves dormant per spec scenario)
+
+## 5. Test doubles and fixtures
+
+- [x] 5.1 Implement an in-memory `RunArtifactStore` test double with controllable snapshots and `history` entries
+- [x] 5.2 Implement an `AssertNoWriteStore` double that throws if any write method is invoked (used to prove D4 / spec "advance does not mutate the store")
+- [x] 5.3 Implement an in-memory `SurfaceEventSink` test double that records every emission with timestamps
+- [x] 5.4 Build a `PhaseContractRegistry` fixture covering one example per kind (mainline invoke_agent, mainline advance, gated, terminal) plus malformed/missing variants for error tests
+
+## 6. Spec-driven unit tests
+
+- [x] 6.1 Test: `currentPhase` returns the contract for the run's phase (spec scenario)
+- [x] 6.2 Test: `nextAction` returns a value whose `kind` is in the `PhaseAction` union for every contract in the registry (registry-driven, per D8)
+- [x] 6.3 Test: determinism — two back-to-back `nextAction` calls with an unchanged store snapshot return deeply-equal values for every phase
+- [x] 6.4 Test: gated phase emits the event synchronously before `await_user` returns (assert sink call order using the recording sink)
+- [x] 6.5 Test: repeated `nextAction` in the same gated entry emits exactly once (dedup within entry)
+- [x] 6.6 Test: re-entering the same gated phase (new `history` entry) emits again (dedup resets per entry)
+- [x] 6.7 Test: caller does not need to emit — sink receives the event from the router only (no double-source)
+- [x] 6.8 Test: `advance` action does not invoke any write on `RunArtifactStore` (use `AssertNoWriteStore`)
+- [x] 6.9 Test: `advance` action carries the event name from `contract.next_action`
+- [x] 6.10 Test: terminal phase returns `{ kind: "terminal", reason }` (registry-driven over all terminal contracts)
+- [x] 6.11 Test: `MissingContractError` is thrown when `current_phase` has no registered contract — and no event is emitted
+- [x] 6.12 Test: `MalformedContractError` is thrown when contract lacks `next_action` (and per other required fields) — and no event is emitted
+- [x] 6.13 Test: `RunReadError` is thrown when the store's read fails or returns unparseable data
+- [x] 6.14 Test: `InconsistentRunStateError` is thrown when terminal contract pairs with pending gated metadata
+- [x] 6.15 Test: router does not acquire any lock and does not import `node:fs` or any filesystem module (static import check)
+- [x] 6.16 Test: every phase in the production `PhaseContractRegistry` is reachable in the registry-driven test loop (catches accidental skips)
+
+## 7. Verification
+
+- [x] 7.1 Run repository formatter and linter on the new module and tests
+- [x] 7.2 Run repository type checker; fix any violations in the new module
+- [x] 7.3 Run the full test suite; confirm only the new tests are added and existing tests still pass
+- [x] 7.4 Run repository build; confirm the new module is included in the built output and no consumer pulls it in

--- a/openspec/specs/phase-router/spec.md
+++ b/openspec/specs/phase-router/spec.md
@@ -1,0 +1,200 @@
+# phase-router Specification
+
+## Purpose
+TBD - created by archiving change feat-deterministic-phase-router-for-server-orchestration. Update Purpose after archive.
+## Requirements
+### Requirement: PhaseRouter exposes deterministic phase introspection and next-action selection
+
+The system SHALL provide a `PhaseRouter` interface with two operations:
+
+- `currentPhase(runId)` MUST return the `PhaseContract` corresponding to
+  the run's current workflow phase, read from the injected
+  `RunArtifactStore`.
+- `nextAction(runId)` MUST return a `PhaseAction` value drawn from the
+  discriminated union `invoke_agent | await_user | advance | terminal`.
+
+Both operations MUST be deterministic: for an identical
+`(runId, store snapshot)`, repeated invocations MUST return values that
+are deeply equal. Neither operation MUST invoke any AI/LLM call.
+
+#### Scenario: currentPhase returns the run's phase contract
+- **WHEN** the store reports `current_phase = "design_review"` for `runId`
+- **THEN** `currentPhase(runId)` returns the `PhaseContract` for
+  `design_review`
+
+#### Scenario: nextAction returns a PhaseAction discriminated union
+- **WHEN** `nextAction(runId)` is invoked for any valid phase
+- **THEN** the returned value's `kind` is one of `invoke_agent`,
+  `await_user`, `advance`, or `terminal`
+
+#### Scenario: Determinism across repeated calls
+- **WHEN** `nextAction(runId)` is called twice with no change to the
+  store snapshot in between
+- **THEN** the two returned values are deeply equal
+
+### Requirement: PhaseAction is derived purely from PhaseContract
+
+The router MUST derive each `PhaseAction` from metadata carried by the
+`PhaseContract` for the relevant phase (e.g. `next_action`, `gated`,
+`terminal`). The router MUST NOT maintain a parallel mapping table from
+phase name to action. Adding a phase or changing a phase's semantics
+MUST be expressible as a contract change alone, with no edit to the
+router.
+
+#### Scenario: Adding a phase requires no router code change
+- **WHEN** a new `PhaseContract` is registered with `next_action =
+  "invoke_agent"` and the run's `current_phase` matches
+- **THEN** `nextAction(runId)` returns an `invoke_agent` action without
+  any modification to router code
+
+#### Scenario: Terminal phases derive terminal action from contract
+- **WHEN** the `PhaseContract.terminal` flag is true for the run's
+  current phase
+- **THEN** `nextAction(runId)` returns a `terminal` action
+
+### Requirement: Gated decisions emit a surface event before returning await_user
+
+For phases whose `PhaseContract.gated` is true, the router MUST:
+
+1. Synchronously emit the corresponding surface event to the injected
+   event sink **before** returning.
+2. Return `await_user` from `nextAction(runId)`.
+
+Emission MUST complete (the sink call MUST return) prior to
+`nextAction` returning. The event schema MUST conform to the Surface
+event contract (#100).
+
+#### Scenario: Event emitted synchronously before await_user
+- **WHEN** the run is in a gated phase and `nextAction(runId)` is
+  invoked
+- **THEN** the event sink receives the gated event, AND `nextAction`
+  returns `await_user` only after the sink call has completed
+
+#### Scenario: Caller does not emit the event itself
+- **WHEN** a caller observes `await_user` returned by `nextAction`
+- **THEN** no additional event emission by the caller is required for
+  surfaces (CLI, server, future UIs) to observe the gated decision
+
+### Requirement: Gated event emission is deduplicated per (runId, phase, event_kind)
+
+The router MUST emit each gated surface event at most once per
+`(runId, phase, event_kind)` tuple. Repeated invocations of
+`nextAction(runId)` while the run remains in the same gated phase MUST
+NOT re-emit the event. From the caller's perspective the router MUST
+behave as a pure function of the store snapshot, even though emission
+is a side effect.
+
+#### Scenario: Repeated nextAction in same gated state emits once
+- **WHEN** `nextAction(runId)` is called twice with no change to the
+  store snapshot for a gated phase
+- **THEN** the event sink receives the gated event exactly once across
+  the two calls
+
+#### Scenario: Re-entering a gated phase emits again
+- **WHEN** the run leaves and later re-enters the same gated phase
+  (distinct entries) and `nextAction` is called in each entry
+- **THEN** the event sink receives the gated event once per entry
+
+### Requirement: PhaseAction.advance is a read-only intent
+
+The router MUST NOT mutate `RunArtifactStore` when returning an
+`advance` action. The action MUST carry the name of the next event to
+fire as a pure value, and the orchestrator (caller) is responsible for
+invoking `store.advance(runId, event)` to materialize the transition.
+
+The router's only permitted side effect across the entire `PhaseRouter`
+surface is emission of gated surface events.
+
+#### Scenario: advance does not mutate the store
+- **WHEN** `nextAction(runId)` returns an `advance` action
+- **THEN** `RunArtifactStore.advance` is not invoked by the router and
+  the store snapshot is unchanged
+
+#### Scenario: advance carries the next event name
+- **WHEN** an `advance` action is returned for a phase whose
+  `PhaseContract.next_action` names event `E`
+- **THEN** the returned action exposes `E` as the event the caller
+  should fire
+
+### Requirement: Router fails fast on missing/malformed contract or inconsistent state
+
+The router MUST throw an error (no silent fallback) when:
+
+- the `PhaseContract` for the run's current phase is missing,
+- the contract omits any required metadata field (`next_action`,
+  `gated`, `terminal`) needed to derive a `PhaseAction`,
+- `run.json` cannot be read or parsed,
+- the run is in an inconsistent state (e.g. a phase whose contract is
+  `terminal` but the run also carries a pending gated decision).
+
+This policy MUST apply uniformly to `currentPhase` and `nextAction`.
+The orchestrator is responsible for catching the error, marking the
+run as `errored`, and escalating.
+
+#### Scenario: Missing PhaseContract throws
+- **WHEN** `nextAction(runId)` is invoked for a run whose current phase
+  has no registered `PhaseContract`
+- **THEN** the call throws an error and emits no event
+
+#### Scenario: Malformed contract throws
+- **WHEN** the `PhaseContract` for the run's current phase lacks
+  `next_action`
+- **THEN** the call throws an error identifying the missing field and
+  emits no event
+
+#### Scenario: Inconsistent run state throws
+- **WHEN** the run's current phase contract is `terminal` but the run
+  also carries pending gated-decision metadata
+- **THEN** the call throws an error and emits no event
+
+### Requirement: PhaseRouter assumes single-writer per runId
+
+The router MUST be safe to use under the precondition that **at most
+one writer per `runId`** invokes its operations at any time. The router
+itself MUST NOT acquire per-`runId` locks; serialization is the
+orchestrator's responsibility. Emission deduplication
+(`(runId, phase, event_kind)`) provides defense-in-depth so that
+unintended repeated calls within the same gated state do not produce
+duplicate events.
+
+#### Scenario: No locking inside router
+- **WHEN** `nextAction(runId)` is invoked
+- **THEN** the router does not acquire or hold any per-`runId` lock
+  for the duration of the call
+
+### Requirement: PhaseRouter uses constructor-injected RunArtifactStore and event sink
+
+The `PhaseRouter` MUST receive its `RunArtifactStore` and surface event
+sink via constructor injection. Tests MUST be able to inject in-memory
+mocks (including a read-only / assert-no-write store double) without
+touching the filesystem. Production wiring uses the real store and the
+real event sink.
+
+#### Scenario: Router constructed with injected dependencies
+- **WHEN** `new PhaseRouter({ store, eventSink })` is called
+- **THEN** subsequent `currentPhase` / `nextAction` calls read from
+  `store` and emit through `eventSink` exclusively
+
+#### Scenario: Router does not import filesystem APIs directly
+- **WHEN** the `PhaseRouter` module is loaded
+- **THEN** it does not depend on `node:fs` or any other filesystem
+  module; all I/O flows through injected interfaces
+
+### Requirement: PhaseRouter ships dormant in this change
+
+The `PhaseRouter` and `PhaseAction` types MUST be exported from the
+server orchestration surface in this change. No existing CLI command
+or runtime code path MUST be rewired onto the router in this change.
+CLI rewiring is deferred to a follow-up change.
+
+#### Scenario: No CLI command imports PhaseRouter
+- **WHEN** the change lands
+- **THEN** no file under the existing CLI command path imports
+  `PhaseRouter` or `PhaseAction`
+
+#### Scenario: Router is exported and unit-tested
+- **WHEN** the change lands
+- **THEN** `PhaseRouter` is reachable from the server orchestration
+  surface's public exports and is covered by unit tests for every
+  phase in the workflow machine
+

--- a/src/lib/phase-router/derive-action.ts
+++ b/src/lib/phase-router/derive-action.ts
@@ -1,0 +1,159 @@
+// Pure derivation of PhaseAction from PhaseContract metadata.
+// No side effects, no I/O — unit-testable in isolation.
+
+import { MalformedContractError } from "./errors.js";
+import type { PhaseAction, PhaseContract, PhaseNextAction } from "./types.js";
+
+const VALID_NEXT_ACTIONS: readonly PhaseNextAction[] = [
+	"invoke_agent",
+	"await_user",
+	"advance",
+	"terminal",
+] as const;
+
+export function isGated(contract: PhaseContract): boolean {
+	return contract.gated === true;
+}
+
+export function isTerminal(contract: PhaseContract): boolean {
+	return contract.terminal === true;
+}
+
+/**
+ * Derive the PhaseAction for a contract.
+ *
+ * Precedence:
+ *   terminal → gated (await_user) → invoke_agent → advance → throw
+ *
+ * Any shape violation (missing required scalars, unrecognized next_action,
+ * missing kind-specific metadata, or contradictory flags) throws
+ * MalformedContractError and emits no event.
+ */
+export function deriveAction(contract: PhaseContract): PhaseAction {
+	// Validate required scalar fields first so callers get actionable errors.
+	if (typeof contract.phase !== "string" || contract.phase.length === 0) {
+		throw new MalformedContractError(
+			String(contract.phase),
+			"phase",
+			"missing or empty",
+		);
+	}
+	if (typeof contract.next_action !== "string") {
+		throw new MalformedContractError(
+			contract.phase,
+			"next_action",
+			"missing or not a string",
+		);
+	}
+	if (!VALID_NEXT_ACTIONS.includes(contract.next_action)) {
+		throw new MalformedContractError(
+			contract.phase,
+			"next_action",
+			`unrecognized value: ${String(contract.next_action)}`,
+		);
+	}
+	if (typeof contract.gated !== "boolean") {
+		throw new MalformedContractError(
+			contract.phase,
+			"gated",
+			"must be boolean",
+		);
+	}
+	if (typeof contract.terminal !== "boolean") {
+		throw new MalformedContractError(
+			contract.phase,
+			"terminal",
+			"must be boolean",
+		);
+	}
+
+	// Contradiction: terminal and gated cannot both be true.
+	if (contract.terminal && contract.gated) {
+		throw new MalformedContractError(
+			contract.phase,
+			"terminal/gated",
+			"cannot both be true",
+		);
+	}
+
+	// Terminal takes precedence.
+	if (contract.terminal) {
+		if (contract.next_action !== "terminal") {
+			throw new MalformedContractError(
+				contract.phase,
+				"next_action",
+				'terminal=true requires next_action="terminal"',
+			);
+		}
+		if (typeof contract.terminal_reason !== "string") {
+			throw new MalformedContractError(
+				contract.phase,
+				"terminal_reason",
+				"required when terminal=true",
+			);
+		}
+		return { kind: "terminal", reason: contract.terminal_reason };
+	}
+
+	// Gated: emission + await_user. Enforced by the router; here we just
+	// derive the action value.
+	if (contract.gated) {
+		if (contract.next_action !== "await_user") {
+			throw new MalformedContractError(
+				contract.phase,
+				"next_action",
+				'gated=true requires next_action="await_user"',
+			);
+		}
+		if (typeof contract.gated_event_kind !== "string") {
+			throw new MalformedContractError(
+				contract.phase,
+				"gated_event_kind",
+				"required when gated=true",
+			);
+		}
+		return { kind: "await_user", event_kind: contract.gated_event_kind };
+	}
+
+	// Non-terminal, non-gated: dispatch on next_action.
+	// Exhaustive switch — TypeScript flags any new PhaseNextAction kind here.
+	switch (contract.next_action) {
+		case "invoke_agent": {
+			if (typeof contract.agent !== "string") {
+				throw new MalformedContractError(
+					contract.phase,
+					"agent",
+					'required when next_action="invoke_agent"',
+				);
+			}
+			return { kind: "invoke_agent", agent: contract.agent };
+		}
+		case "advance": {
+			if (typeof contract.advance_event !== "string") {
+				throw new MalformedContractError(
+					contract.phase,
+					"advance_event",
+					'required when next_action="advance"',
+				);
+			}
+			return { kind: "advance", event: contract.advance_event };
+		}
+		// The following two cases are belt-and-suspenders: the terminal/gated
+		// guards above already consume any contract whose next_action is
+		// "terminal" or "await_user" when the flags agree. These throws catch
+		// the contradictory case where the flags lie (e.g. next_action="await_user"
+		// with gated=false), which deriveAction must still reject explicitly.
+		case "await_user":
+			throw new MalformedContractError(
+				contract.phase,
+				"gated",
+				'next_action="await_user" requires gated=true',
+			);
+		case "terminal":
+			throw new MalformedContractError(
+				contract.phase,
+				"terminal",
+				'next_action="terminal" requires terminal=true',
+			);
+	}
+}

--- a/src/lib/phase-router/errors.ts
+++ b/src/lib/phase-router/errors.ts
@@ -1,0 +1,50 @@
+// Typed errors thrown by the PhaseRouter. The router never emits any event
+// when throwing; callers (orchestrators) are expected to catch these and
+// mark the run as errored.
+
+export class MissingContractError extends Error {
+	readonly phase: string;
+	constructor(phase: string) {
+		super(`PhaseContract missing for phase: ${phase}`);
+		this.name = "MissingContractError";
+		this.phase = phase;
+	}
+}
+
+export class MalformedContractError extends Error {
+	readonly phase: string;
+	readonly field: string;
+	readonly detail: string | undefined;
+	constructor(phase: string, field: string, detail?: string) {
+		const suffix = detail ? ` — ${detail}` : "";
+		super(
+			`PhaseContract for "${phase}" is malformed (field: ${field})${suffix}`,
+		);
+		this.name = "MalformedContractError";
+		this.phase = phase;
+		this.field = field;
+		this.detail = detail;
+	}
+}
+
+export class RunReadError extends Error {
+	readonly runId: string;
+	readonly cause: unknown;
+	constructor(runId: string, cause: unknown) {
+		super(`Failed to read run state for run: ${runId}`);
+		this.name = "RunReadError";
+		this.runId = runId;
+		this.cause = cause;
+	}
+}
+
+export class InconsistentRunStateError extends Error {
+	readonly runId: string;
+	readonly detail: string;
+	constructor(runId: string, detail: string) {
+		super(`Inconsistent run state for "${runId}": ${detail}`);
+		this.name = "InconsistentRunStateError";
+		this.runId = runId;
+		this.detail = detail;
+	}
+}

--- a/src/lib/phase-router/index.ts
+++ b/src/lib/phase-router/index.ts
@@ -1,0 +1,24 @@
+// Public surface of the PhaseRouter module.
+//
+// NOTE: No existing CLI command imports this module. The router ships
+// dormant by design (per change
+// feat-deterministic-phase-router-for-server-orchestration). A follow-up
+// change will wire it into the server orchestrator.
+
+export { deriveAction, isGated, isTerminal } from "./derive-action.js";
+export {
+	InconsistentRunStateError,
+	MalformedContractError,
+	MissingContractError,
+	RunReadError,
+} from "./errors.js";
+export type { PhaseRouterDeps } from "./router.js";
+export { PhaseRouter } from "./router.js";
+export type {
+	PhaseAction,
+	PhaseContract,
+	PhaseContractRegistry,
+	PhaseNextAction,
+	SurfaceEvent,
+	SurfaceEventSink,
+} from "./types.js";

--- a/src/lib/phase-router/router.ts
+++ b/src/lib/phase-router/router.ts
@@ -1,0 +1,217 @@
+// PhaseRouter — deterministic phase-to-action router for server-side
+// workflow orchestration. Holds no per-runId locks. Mutates nothing on the
+// RunArtifactStore — the only side effect across the entire PhaseRouter
+// surface is gated surface event emission (synchronous, deduped).
+
+import type { RunHistoryEntry, RunState } from "../../types/contracts.js";
+import type { RunArtifactStore } from "../artifact-store.js";
+import { runRef } from "../artifact-types.js";
+import { deriveAction } from "./derive-action.js";
+import {
+	InconsistentRunStateError,
+	MissingContractError,
+	RunReadError,
+} from "./errors.js";
+import type {
+	PhaseAction,
+	PhaseContract,
+	PhaseContractRegistry,
+	SurfaceEvent,
+	SurfaceEventSink,
+} from "./types.js";
+
+export interface PhaseRouterDeps {
+	readonly store: RunArtifactStore;
+	readonly eventSink: SurfaceEventSink;
+	readonly contracts: PhaseContractRegistry;
+	/** Injectable clock for deterministic emitted_at in tests. */
+	readonly now?: () => Date;
+}
+
+/**
+ * Per-runId dedup state.
+ *
+ * `entryAt` is the ISO timestamp of the most recent transition into the
+ * current phase. When the run re-enters the same phase, `entryAt` advances
+ * and `emitted` is reset. This naturally satisfies:
+ *   - repeated nextAction in the same entry → no duplicate emission
+ *   - run re-enters the same gated phase → emission happens again
+ */
+interface DedupEntry {
+	readonly entryAt: string;
+	readonly emitted: Set<string>;
+}
+
+export class PhaseRouter {
+	private readonly store: RunArtifactStore;
+	private readonly eventSink: SurfaceEventSink;
+	private readonly contracts: PhaseContractRegistry;
+	private readonly now: () => Date;
+	private readonly dedup: Map<string, DedupEntry> = new Map();
+
+	constructor(deps: PhaseRouterDeps) {
+		this.store = deps.store;
+		this.eventSink = deps.eventSink;
+		this.contracts = deps.contracts;
+		this.now = deps.now ?? (() => new Date());
+	}
+
+	/**
+	 * Return the PhaseContract for the run's current phase.
+	 * Throws on missing/malformed contract, read failure, or inconsistent
+	 * run state — never emits.
+	 */
+	currentPhase(runId: string): PhaseContract {
+		const run = this.readRun(runId);
+		const contract = this.resolveContract(run);
+		this.assertConsistent(runId, run, contract);
+		return contract;
+	}
+
+	/**
+	 * Return the next PhaseAction the orchestrator should take.
+	 * For gated phases, synchronously emits the gated surface event to the
+	 * sink (deduped by (runId, phase-entry, event_kind)) before returning.
+	 *
+	 * Read-only with respect to RunArtifactStore: advance actions do NOT
+	 * cause the router to write to the store — the orchestrator is
+	 * responsible for store.advance.
+	 */
+	nextAction(runId: string): PhaseAction {
+		const run = this.readRun(runId);
+		const contract = this.resolveContract(run);
+		this.assertConsistent(runId, run, contract);
+		const action = deriveAction(contract);
+
+		if (action.kind === "await_user") {
+			const entryAt = this.currentEntryAt(run);
+			if (!this.hasEmitted(runId, entryAt, action.event_kind)) {
+				const event: SurfaceEvent = {
+					run_id: runId,
+					phase: contract.phase,
+					event_kind: action.event_kind,
+					emitted_at: this.now().toISOString(),
+				};
+				this.eventSink.emit(event);
+				this.recordEmitted(runId, entryAt, action.event_kind);
+			}
+		}
+		return action;
+	}
+
+	// --- internals ---
+
+	private readRun(runId: string): RunState {
+		let raw: string;
+		try {
+			raw = this.store.read(runRef(runId));
+		} catch (cause) {
+			throw new RunReadError(runId, cause);
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch (cause) {
+			throw new RunReadError(runId, cause);
+		}
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			typeof (parsed as { current_phase?: unknown }).current_phase !== "string"
+		) {
+			throw new RunReadError(
+				runId,
+				new Error("run.json missing required field: current_phase"),
+			);
+		}
+		const run = parsed as RunState;
+		if (!Array.isArray(run.history)) {
+			throw new RunReadError(
+				runId,
+				new Error("run.json missing required field: history"),
+			);
+		}
+		for (let i = 0; i < run.history.length; i++) {
+			const entry = run.history[i] as Partial<RunHistoryEntry> | undefined;
+			if (
+				entry === null ||
+				typeof entry !== "object" ||
+				typeof entry.to !== "string" ||
+				typeof entry.timestamp !== "string"
+			) {
+				throw new RunReadError(
+					runId,
+					new Error(
+						`run.json history[${i}] missing required string fields: to, timestamp`,
+					),
+				);
+			}
+		}
+		return run;
+	}
+
+	private resolveContract(run: RunState): PhaseContract {
+		const contract = this.contracts.get(run.current_phase);
+		if (!contract) {
+			throw new MissingContractError(run.current_phase);
+		}
+		return contract;
+	}
+
+	private assertConsistent(
+		runId: string,
+		run: RunState,
+		contract: PhaseContract,
+	): void {
+		if (contract.phase !== run.current_phase) {
+			throw new InconsistentRunStateError(
+				runId,
+				`contract.phase "${contract.phase}" does not match run.current_phase "${run.current_phase}"`,
+			);
+		}
+		if (contract.terminal === true && contract.gated === true) {
+			throw new InconsistentRunStateError(
+				runId,
+				`phase "${contract.phase}" has both terminal=true and gated=true`,
+			);
+		}
+	}
+
+	private currentEntryAt(run: RunState): string {
+		for (let i = run.history.length - 1; i >= 0; i--) {
+			const entry = run.history[i] as RunHistoryEntry;
+			if (entry.to === run.current_phase) {
+				return entry.timestamp;
+			}
+		}
+		throw new InconsistentRunStateError(
+			run.run_id,
+			`no history entry transitions into current_phase "${run.current_phase}"`,
+		);
+	}
+
+	private hasEmitted(
+		runId: string,
+		entryAt: string,
+		eventKind: string,
+	): boolean {
+		const entry = this.dedup.get(runId);
+		if (!entry || entry.entryAt !== entryAt) {
+			return false;
+		}
+		return entry.emitted.has(eventKind);
+	}
+
+	private recordEmitted(
+		runId: string,
+		entryAt: string,
+		eventKind: string,
+	): void {
+		const existing = this.dedup.get(runId);
+		if (!existing || existing.entryAt !== entryAt) {
+			this.dedup.set(runId, { entryAt, emitted: new Set([eventKind]) });
+			return;
+		}
+		existing.emitted.add(eventKind);
+	}
+}

--- a/src/lib/phase-router/types.ts
+++ b/src/lib/phase-router/types.ts
@@ -1,0 +1,74 @@
+// PhaseRouter public types.
+//
+// PhaseContract and the surface event schema are owned by separate changes
+// (#129 and #100 respectively). Until those land, this module defines the
+// minimal shape that the router consumes. When #129/#100 merge, the
+// follow-up change will replace these declarations with imports from the
+// canonical locations without breaking the router surface.
+
+/** The four kinds of action the router can direct the orchestrator to take. */
+export type PhaseNextAction =
+	| "invoke_agent"
+	| "await_user"
+	| "advance"
+	| "terminal";
+
+/**
+ * Structured metadata attached to a single workflow phase.
+ * A `PhaseContract` is the router's only authoritative source for how a
+ * phase should route — the router never maintains a parallel mapping.
+ */
+export interface PhaseContract {
+	readonly phase: string;
+	readonly next_action: PhaseNextAction;
+	readonly gated: boolean;
+	readonly terminal: boolean;
+	/** Agent name — required iff next_action === "invoke_agent". */
+	readonly agent?: string;
+	/** Name of the event to fire — required iff next_action === "advance". */
+	readonly advance_event?: string;
+	/** Surface event kind — required iff gated === true. */
+	readonly gated_event_kind?: string;
+	/** Terminal reason — required iff terminal === true. */
+	readonly terminal_reason?: string;
+}
+
+/**
+ * Registry of PhaseContracts keyed by phase name.
+ * Kept interface-only so production registries and test fixtures can both
+ * implement it.
+ */
+export interface PhaseContractRegistry {
+	get(phase: string): PhaseContract | undefined;
+	phases(): readonly string[];
+}
+
+/**
+ * Discriminated union of actions the router returns to the orchestrator.
+ * `advance` carries the event name only — the router never mutates the
+ * store itself.
+ */
+export type PhaseAction =
+	| { readonly kind: "invoke_agent"; readonly agent: string }
+	| { readonly kind: "await_user"; readonly event_kind: string }
+	| { readonly kind: "advance"; readonly event: string }
+	| { readonly kind: "terminal"; readonly reason: string };
+
+/**
+ * A surface event emitted by the router at gated decisions.
+ * Schema is kept compatible with #100's Surface event contract.
+ */
+export interface SurfaceEvent {
+	readonly run_id: string;
+	readonly phase: string;
+	readonly event_kind: string;
+	readonly emitted_at: string;
+}
+
+/**
+ * Sink the router emits gated events through. Implementations include the
+ * production event bus and in-memory recorders used by tests.
+ */
+export interface SurfaceEventSink {
+	emit(event: SurfaceEvent): void;
+}

--- a/src/tests/phase-router.test.ts
+++ b/src/tests/phase-router.test.ts
@@ -1,0 +1,871 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+import type { RunArtifactStore } from "../lib/artifact-store.js";
+import type {
+	RunArtifactQuery,
+	RunArtifactRef,
+} from "../lib/artifact-types.js";
+import {
+	deriveAction,
+	InconsistentRunStateError,
+	isGated,
+	isTerminal,
+	MalformedContractError,
+	MissingContractError,
+	type PhaseAction,
+	type PhaseContract,
+	type PhaseContractRegistry,
+	PhaseRouter,
+	RunReadError,
+	type SurfaceEvent,
+	type SurfaceEventSink,
+} from "../lib/phase-router/index.js";
+import { workflowStates } from "../lib/workflow-machine.js";
+import type { RunHistoryEntry, RunState } from "../types/contracts.js";
+
+// --- Fixtures and doubles -------------------------------------------------
+
+interface InMemoryStoreOpts {
+	readonly initial?: Record<string, RunState>;
+	readonly corrupt?: Record<string, string>;
+	readonly throwOnRead?: Record<string, Error>;
+}
+
+function createInMemoryStore(opts: InMemoryStoreOpts = {}): {
+	store: RunArtifactStore;
+	setRun(runId: string, state: RunState): void;
+	setCorrupt(runId: string, raw: string): void;
+	setThrowOnRead(runId: string, err: Error): void;
+} {
+	const runs: Map<string, RunState> = new Map(
+		Object.entries(opts.initial ?? {}),
+	);
+	const corrupt: Map<string, string> = new Map(
+		Object.entries(opts.corrupt ?? {}),
+	);
+	const throwers: Map<string, Error> = new Map(
+		Object.entries(opts.throwOnRead ?? {}),
+	);
+	const store: RunArtifactStore = {
+		read(ref: RunArtifactRef): string {
+			const err = throwers.get(ref.runId);
+			if (err) throw err;
+			if (corrupt.has(ref.runId)) {
+				return corrupt.get(ref.runId) as string;
+			}
+			const run = runs.get(ref.runId);
+			if (!run) throw new Error(`not found: ${ref.runId}`);
+			return JSON.stringify(run);
+		},
+		write(): void {
+			throw new Error("write not allowed in this store double");
+		},
+		exists(ref: RunArtifactRef): boolean {
+			return runs.has(ref.runId);
+		},
+		list(query?: RunArtifactQuery): readonly RunArtifactRef[] {
+			const all: RunArtifactRef[] = [];
+			for (const runId of runs.keys()) {
+				if (query?.changeId && !runId.startsWith(`${query.changeId}-`))
+					continue;
+				all.push({ runId, type: "run-state" });
+			}
+			return all;
+		},
+	};
+	return {
+		store,
+		setRun(runId, state) {
+			runs.set(runId, state);
+			corrupt.delete(runId);
+			throwers.delete(runId);
+		},
+		setCorrupt(runId, raw) {
+			corrupt.set(runId, raw);
+			runs.delete(runId);
+		},
+		setThrowOnRead(runId, err) {
+			throwers.set(runId, err);
+		},
+	};
+}
+
+/** Store double that fails any test that calls a write method. */
+function createAssertNoWriteStore(reads: Record<string, RunState>): {
+	store: RunArtifactStore;
+	writeCalls: number;
+} {
+	const state = { writeCalls: 0 };
+	const store: RunArtifactStore = {
+		read(ref: RunArtifactRef): string {
+			const run = reads[ref.runId];
+			if (!run) throw new Error(`not found: ${ref.runId}`);
+			return JSON.stringify(run);
+		},
+		write(): void {
+			state.writeCalls += 1;
+			throw new Error(
+				"AssertNoWriteStore.write called — router must be read-only",
+			);
+		},
+		exists(): boolean {
+			return true;
+		},
+		list(): readonly RunArtifactRef[] {
+			return [];
+		},
+	};
+	return {
+		store,
+		get writeCalls() {
+			return state.writeCalls;
+		},
+	};
+}
+
+interface RecordingSink extends SurfaceEventSink {
+	readonly events: readonly SurfaceEvent[];
+	readonly callOrder: readonly string[];
+	markReturn(token: string): void;
+}
+
+function createRecordingSink(): RecordingSink {
+	const events: SurfaceEvent[] = [];
+	const callOrder: string[] = [];
+	return {
+		emit(event: SurfaceEvent): void {
+			events.push(event);
+			callOrder.push(`emit:${event.event_kind}`);
+		},
+		markReturn(token: string): void {
+			callOrder.push(`return:${token}`);
+		},
+		get events() {
+			return events;
+		},
+		get callOrder() {
+			return callOrder;
+		},
+	};
+}
+
+function createRegistry(
+	contracts: Record<string, PhaseContract>,
+): PhaseContractRegistry {
+	return {
+		get(phase: string): PhaseContract | undefined {
+			return contracts[phase];
+		},
+		phases(): readonly string[] {
+			return Object.keys(contracts);
+		},
+	};
+}
+
+function makeRun(overrides: {
+	readonly runId: string;
+	readonly currentPhase: string;
+	readonly history: readonly RunHistoryEntry[];
+}): RunState {
+	return {
+		run_id: overrides.runId,
+		change_name: overrides.runId.replace(/-\d+$/, ""),
+		current_phase: overrides.currentPhase,
+		status: "active",
+		allowed_events: [],
+		source: null,
+		project_id: "fixture",
+		repo_name: "fixture",
+		repo_path: "/fixture",
+		branch_name: "fixture",
+		worktree_path: "/fixture",
+		agents: { main: "claude", review: "codex" },
+		last_summary_path: null,
+		created_at: "2026-04-13T00:00:00Z",
+		updated_at: "2026-04-13T00:00:00Z",
+		history: overrides.history,
+		previous_run_id: null,
+	} as RunState;
+}
+
+/** Baseline well-formed contract fixtures covering each PhaseAction kind. */
+const FIXTURE_CONTRACTS: Record<string, PhaseContract> = {
+	invoke_phase: {
+		phase: "invoke_phase",
+		next_action: "invoke_agent",
+		gated: false,
+		terminal: false,
+		agent: "claude",
+	},
+	advance_phase: {
+		phase: "advance_phase",
+		next_action: "advance",
+		gated: false,
+		terminal: false,
+		advance_event: "continue",
+	},
+	gated_phase: {
+		phase: "gated_phase",
+		next_action: "await_user",
+		gated: true,
+		terminal: false,
+		gated_event_kind: "approval_requested",
+	},
+	terminal_phase: {
+		phase: "terminal_phase",
+		next_action: "terminal",
+		gated: false,
+		terminal: true,
+		terminal_reason: "done",
+	},
+};
+
+// --- 6.1 currentPhase returns the contract for the run's phase -----------
+
+test("PhaseRouter.currentPhase returns the contract for the run's phase", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-1",
+		makeRun({
+			runId: "r-1",
+			currentPhase: "advance_phase",
+			history: [
+				{
+					from: "start",
+					to: "advance_phase",
+					event: "propose",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const contracts = createRegistry(FIXTURE_CONTRACTS);
+	const router = new PhaseRouter({ store, eventSink: sink, contracts });
+
+	assert.deepEqual(router.currentPhase("r-1"), FIXTURE_CONTRACTS.advance_phase);
+});
+
+// --- 6.2 nextAction returns a value whose kind is in the PhaseAction union --
+
+test("PhaseRouter.nextAction returns a value with a valid kind for every fixture contract", () => {
+	const { store, setRun } = createInMemoryStore();
+	const sink = createRecordingSink();
+	const contracts = createRegistry(FIXTURE_CONTRACTS);
+	const router = new PhaseRouter({ store, eventSink: sink, contracts });
+
+	for (const phase of Object.keys(FIXTURE_CONTRACTS)) {
+		const runId = `r-${phase}`;
+		setRun(
+			runId,
+			makeRun({
+				runId,
+				currentPhase: phase,
+				history: [
+					{
+						from: "start",
+						to: phase,
+						event: "enter",
+						timestamp: `2026-04-13T01:${phase.length
+							.toString()
+							.padStart(2, "0")}:00Z`,
+					},
+				],
+			}),
+		);
+		const action = router.nextAction(runId);
+		assert.ok(
+			(["invoke_agent", "await_user", "advance", "terminal"] as const).includes(
+				action.kind,
+			),
+			`unexpected kind: ${action.kind}`,
+		);
+	}
+});
+
+// --- 6.3 Determinism -----------------------------------------------------
+
+test("PhaseRouter.nextAction is deterministic for unchanged store snapshots", () => {
+	const { store, setRun } = createInMemoryStore();
+	const baseRun = makeRun({
+		runId: "r-2",
+		currentPhase: "advance_phase",
+		history: [
+			{
+				from: "start",
+				to: "advance_phase",
+				event: "propose",
+				timestamp: "2026-04-13T00:00:00Z",
+			},
+		],
+	});
+	setRun("r-2", baseRun);
+	const contracts = createRegistry(FIXTURE_CONTRACTS);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({ store, eventSink: sink, contracts });
+
+	const a = router.nextAction("r-2");
+	const b = router.nextAction("r-2");
+	assert.deepEqual(a, b);
+});
+
+// --- 6.4 Gated phase emits event synchronously before await_user returns --
+
+test("PhaseRouter.nextAction emits the gated event before returning await_user", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-gated",
+		makeRun({
+			runId: "r-gated",
+			currentPhase: "gated_phase",
+			history: [
+				{
+					from: "start",
+					to: "gated_phase",
+					event: "enter",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	const action = router.nextAction("r-gated");
+	sink.markReturn("await_user");
+
+	assert.equal(action.kind, "await_user");
+	assert.deepEqual(sink.callOrder, [
+		"emit:approval_requested",
+		"return:await_user",
+	]);
+	assert.equal(sink.events.length, 1);
+	assert.equal(sink.events[0]?.run_id, "r-gated");
+	assert.equal(sink.events[0]?.phase, "gated_phase");
+	assert.equal(sink.events[0]?.event_kind, "approval_requested");
+});
+
+// --- 6.5 Dedup within same entry -----------------------------------------
+
+test("PhaseRouter.nextAction dedupes gated emission within the same phase-entry", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-dedup",
+		makeRun({
+			runId: "r-dedup",
+			currentPhase: "gated_phase",
+			history: [
+				{
+					from: "start",
+					to: "gated_phase",
+					event: "enter",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	const a = router.nextAction("r-dedup");
+	const b = router.nextAction("r-dedup");
+	const c = router.nextAction("r-dedup");
+
+	assert.deepEqual(a, b);
+	assert.deepEqual(b, c);
+	assert.equal(sink.events.length, 1, "expected exactly one emission");
+});
+
+// --- 6.6 Re-entering the same gated phase emits again --------------------
+
+test("PhaseRouter.nextAction re-emits when the run re-enters the same gated phase", () => {
+	const { store, setRun } = createInMemoryStore();
+	const run = makeRun({
+		runId: "r-reenter",
+		currentPhase: "gated_phase",
+		history: [
+			{
+				from: "start",
+				to: "gated_phase",
+				event: "enter",
+				timestamp: "2026-04-13T00:00:00Z",
+			},
+		],
+	});
+	setRun("r-reenter", run);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	router.nextAction("r-reenter");
+	router.nextAction("r-reenter"); // dedup
+	assert.equal(sink.events.length, 1);
+
+	// Simulate the run leaving and re-entering the same gated phase.
+	const reEntered = makeRun({
+		runId: "r-reenter",
+		currentPhase: "gated_phase",
+		history: [
+			...run.history,
+			{
+				from: "gated_phase",
+				to: "some_other_phase",
+				event: "out",
+				timestamp: "2026-04-13T01:00:00Z",
+			},
+			{
+				from: "some_other_phase",
+				to: "gated_phase",
+				event: "back",
+				timestamp: "2026-04-13T02:00:00Z",
+			},
+		],
+	});
+	setRun("r-reenter", reEntered);
+
+	router.nextAction("r-reenter");
+	assert.equal(
+		sink.events.length,
+		2,
+		"expected a second emission after re-entry",
+	);
+	// Both emissions carry the run's current gated phase.
+	assert.equal(sink.events[0]?.phase, "gated_phase");
+	assert.equal(sink.events[1]?.phase, "gated_phase");
+});
+
+// --- 6.7 Caller does not need to emit ------------------------------------
+
+test("PhaseRouter.nextAction is the sole emitter for gated events (no double source)", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-sole",
+		makeRun({
+			runId: "r-sole",
+			currentPhase: "gated_phase",
+			history: [
+				{
+					from: "start",
+					to: "gated_phase",
+					event: "enter",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	const action = router.nextAction("r-sole");
+	// The caller does nothing further.
+	assert.equal(action.kind, "await_user");
+	assert.equal(
+		sink.events.length,
+		1,
+		"sink should only record the router's emission",
+	);
+});
+
+// --- 6.8 advance does not mutate the store -------------------------------
+
+test("PhaseRouter.nextAction does not call any write method on the store (advance)", () => {
+	const run = makeRun({
+		runId: "r-advance",
+		currentPhase: "advance_phase",
+		history: [
+			{
+				from: "start",
+				to: "advance_phase",
+				event: "propose",
+				timestamp: "2026-04-13T00:00:00Z",
+			},
+		],
+	});
+	const noWrite = createAssertNoWriteStore({ "r-advance": run });
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store: noWrite.store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	const action = router.nextAction("r-advance");
+	assert.equal(action.kind, "advance");
+	assert.equal(noWrite.writeCalls, 0);
+});
+
+// --- 6.9 advance carries the event name ----------------------------------
+
+test("PhaseRouter.nextAction returns the advance event name from the contract", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-evt",
+		makeRun({
+			runId: "r-evt",
+			currentPhase: "advance_phase",
+			history: [
+				{
+					from: "start",
+					to: "advance_phase",
+					event: "propose",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	const action = router.nextAction("r-evt") as Extract<
+		PhaseAction,
+		{ kind: "advance" }
+	>;
+	assert.equal(action.kind, "advance");
+	assert.equal(action.event, "continue");
+});
+
+// --- 6.10 Terminal phase returns terminal --------------------------------
+
+test("PhaseRouter.nextAction returns terminal for terminal contracts", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-term",
+		makeRun({
+			runId: "r-term",
+			currentPhase: "terminal_phase",
+			history: [
+				{
+					from: "start",
+					to: "terminal_phase",
+					event: "finish",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	const action = router.nextAction("r-term");
+	assert.deepEqual(action, { kind: "terminal", reason: "done" });
+	assert.equal(sink.events.length, 0);
+});
+
+// --- 6.11 MissingContractError ------------------------------------------
+
+test("PhaseRouter throws MissingContractError when no contract is registered", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-miss",
+		makeRun({
+			runId: "r-miss",
+			currentPhase: "unregistered_phase",
+			history: [
+				{
+					from: "start",
+					to: "unregistered_phase",
+					event: "enter",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	assert.throws(() => router.nextAction("r-miss"), MissingContractError);
+	assert.throws(() => router.currentPhase("r-miss"), MissingContractError);
+	assert.equal(sink.events.length, 0);
+});
+
+// --- 6.12 MalformedContractError ----------------------------------------
+
+test("deriveAction throws MalformedContractError on missing next_action", () => {
+	assert.throws(
+		() =>
+			deriveAction({
+				phase: "bad",
+				// @ts-expect-error intentional malformed fixture
+				next_action: undefined,
+				gated: false,
+				terminal: false,
+			}),
+		MalformedContractError,
+	);
+});
+
+test("deriveAction throws MalformedContractError on unrecognized next_action", () => {
+	assert.throws(
+		() =>
+			deriveAction({
+				phase: "bad",
+				// @ts-expect-error intentional malformed fixture
+				next_action: "whatever",
+				gated: false,
+				terminal: false,
+			}),
+		MalformedContractError,
+	);
+});
+
+test("deriveAction throws when invoke_agent is missing the agent field", () => {
+	assert.throws(
+		() =>
+			deriveAction({
+				phase: "bad",
+				next_action: "invoke_agent",
+				gated: false,
+				terminal: false,
+			}),
+		MalformedContractError,
+	);
+});
+
+test("PhaseRouter.nextAction does not emit when the contract is malformed", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-bad",
+		makeRun({
+			runId: "r-bad",
+			currentPhase: "bad_phase",
+			history: [
+				{
+					from: "start",
+					to: "bad_phase",
+					event: "enter",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry({
+			bad_phase: {
+				phase: "bad_phase",
+				next_action: "await_user",
+				gated: true,
+				terminal: false,
+				// gated_event_kind missing
+			},
+		}),
+	});
+
+	assert.throws(() => router.nextAction("r-bad"), MalformedContractError);
+	assert.equal(sink.events.length, 0);
+});
+
+// --- 6.13 RunReadError --------------------------------------------------
+
+test("PhaseRouter throws RunReadError when the store read fails", () => {
+	const { store, setThrowOnRead } = createInMemoryStore();
+	setThrowOnRead("r-err", new Error("disk gone"));
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	assert.throws(() => router.nextAction("r-err"), RunReadError);
+});
+
+test("PhaseRouter throws RunReadError when run.json is not valid JSON", () => {
+	const { store, setCorrupt } = createInMemoryStore();
+	setCorrupt("r-corrupt", "{this is not json");
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	assert.throws(() => router.currentPhase("r-corrupt"), RunReadError);
+});
+
+test("PhaseRouter throws RunReadError when run.json lacks current_phase", () => {
+	const { store, setCorrupt } = createInMemoryStore();
+	setCorrupt("r-no-phase", JSON.stringify({ history: [] }));
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	assert.throws(() => router.currentPhase("r-no-phase"), RunReadError);
+});
+
+// --- 6.14 InconsistentRunStateError -------------------------------------
+
+test("PhaseRouter throws InconsistentRunStateError when terminal + gated contract collide", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-inc",
+		makeRun({
+			runId: "r-inc",
+			currentPhase: "bad_mix",
+			history: [
+				{
+					from: "start",
+					to: "bad_mix",
+					event: "enter",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry({
+			bad_mix: {
+				phase: "bad_mix",
+				next_action: "terminal",
+				gated: true,
+				terminal: true,
+				terminal_reason: "impossible",
+				gated_event_kind: "also_impossible",
+			},
+		}),
+	});
+
+	assert.throws(() => router.nextAction("r-inc"), InconsistentRunStateError);
+	assert.equal(sink.events.length, 0);
+});
+
+test("PhaseRouter throws InconsistentRunStateError when history has no entry for current phase", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-ghost",
+		makeRun({
+			runId: "r-ghost",
+			currentPhase: "gated_phase",
+			history: [
+				{
+					from: "start",
+					to: "some_other_phase",
+					event: "wander",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry(FIXTURE_CONTRACTS),
+	});
+
+	assert.throws(() => router.nextAction("r-ghost"), InconsistentRunStateError);
+	assert.equal(sink.events.length, 0);
+});
+
+// --- 6.15 No filesystem imports ------------------------------------------
+
+function readAllSources(dir: string): string {
+	const parts: string[] = [];
+	for (const name of readdirSync(dir)) {
+		const full = join(dir, name);
+		if (statSync(full).isDirectory()) {
+			parts.push(readAllSources(full));
+			continue;
+		}
+		if (!name.endsWith(".ts")) continue;
+		parts.push(readFileSync(full, "utf8"));
+	}
+	return parts.join("\n");
+}
+
+test("phase-router sources do not import node:fs or other filesystem modules", () => {
+	const body = readAllSources("src/lib/phase-router");
+	const forbidden = [
+		/from\s+["']node:fs["']/,
+		/from\s+["']fs["']/,
+		/from\s+["']node:fs\/promises["']/,
+		/require\s*\(\s*["']fs["']\s*\)/,
+	];
+	for (const pattern of forbidden) {
+		assert.ok(
+			!pattern.test(body),
+			`phase-router unexpectedly imports a filesystem module matching ${pattern}`,
+		);
+	}
+});
+
+// --- 6.16 Registry-driven test loop covers every workflow phase ----------
+
+test("phase-router test fixture must cover every workflow phase (registry-driven safety net)", () => {
+	// The production PhaseContractRegistry is owned by #129. Until it lands,
+	// this test asserts that we have exactly one test fixture contract per
+	// PhaseAction kind so the registry-driven suite above exercises every
+	// shape deriveAction supports. Acts as a reminder to add fixtures when
+	// new kinds are introduced.
+	const kinds = new Set<string>(
+		Object.values(FIXTURE_CONTRACTS).map((c) => c.next_action),
+	);
+	assert.deepEqual([...kinds].sort(), [
+		"advance",
+		"await_user",
+		"invoke_agent",
+		"terminal",
+	]);
+	// Sanity: every workflow machine state should be addressable by a future
+	// PhaseContract — assert our string comparison is live.
+	assert.ok(workflowStates.length > 0);
+});
+
+// --- 4.7 No existing CLI command path imports PhaseRouter ---------------
+
+test("no existing CLI command imports phase-router (dormant invariant)", () => {
+	const roots = ["src/bin", "src/core", "src/contracts", "src/generators"];
+	for (const root of roots) {
+		const body = readAllSources(root);
+		assert.ok(
+			!/from\s+["'][^"']*phase-router[^"']*["']/.test(body),
+			`${root}/ unexpectedly imports phase-router — router must stay dormant in this change`,
+		);
+	}
+});
+
+// --- Helpers-exported cover ---------------------------------------------
+
+test("isGated and isTerminal classify fixture contracts correctly", () => {
+	assert.equal(isGated(FIXTURE_CONTRACTS.gated_phase), true);
+	assert.equal(isGated(FIXTURE_CONTRACTS.advance_phase), false);
+	assert.equal(isTerminal(FIXTURE_CONTRACTS.terminal_phase), true);
+	assert.equal(isTerminal(FIXTURE_CONTRACTS.advance_phase), false);
+});


### PR DESCRIPTION
## Summary

- Adds `PhaseRouter` — a pure, AI-free decision layer that returns the next `PhaseAction` (`invoke_agent | await_user | advance | terminal`) for a run's current phase, driven entirely by `PhaseContract` metadata.
- Gated decisions synchronously emit a Surface event (deduped per `(runId, phase-entry, event_kind)`) **before** returning `await_user`; `advance` is a pure intent — the router never mutates `RunArtifactStore`.
- Fail-fast error model: throws typed errors (`MissingContractError`, `MalformedContractError`, `RunReadError`, `InconsistentRunStateError`) on any contract gap, parse failure, or inconsistent run state; no silent fallbacks.
- Single-writer per `runId` is an invariant of the caller — the router holds no locks; emission dedup keying is defense-in-depth only.
- **Ships dormant**: no existing CLI command imports `PhaseRouter` in this change. Follow-up change will wire the server orchestrator on top. Static grep test enforces the invariant.

## Issue

Closes https://github.com/skr19930617/specflow/issues/132