### PR TITLE
feat: define surface event contract for external runtimes (#100)

### DIFF
--- a/assets/global/schemas/surface-events/actor-identity.schema.json
+++ b/assets/global/schemas/surface-events/actor-identity.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "actor-identity.schema.json",
+  "title": "ActorIdentity",
+  "description": "Identity of the actor that initiated or received the event, per actor-surface-model taxonomy.",
+  "type": "object",
+  "properties": {
+    "actor": {
+      "type": "string",
+      "enum": [
+        "human",
+        "ai-agent",
+        "automation"
+      ],
+      "description": "Actor kind from the capability matrix."
+    },
+    "actor_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for the specific actor instance."
+    },
+    "delegated_by": {
+      "type": "string",
+      "const": "human",
+      "description": "Present only on delegated approval events."
+    },
+    "delegated_by_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable id of the delegating human — present iff delegated_by is set."
+    }
+  },
+  "required": [
+    "actor",
+    "actor_id"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/actor-identity.schema.json
+++ b/assets/global/schemas/surface-events/actor-identity.schema.json
@@ -1,38 +1,31 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "actor-identity.schema.json",
-  "title": "ActorIdentity",
-  "description": "Identity of the actor that initiated or received the event, per actor-surface-model taxonomy.",
-  "type": "object",
-  "properties": {
-    "actor": {
-      "type": "string",
-      "enum": [
-        "human",
-        "ai-agent",
-        "automation"
-      ],
-      "description": "Actor kind from the capability matrix."
-    },
-    "actor_id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Stable identifier for the specific actor instance."
-    },
-    "delegated_by": {
-      "type": "string",
-      "const": "human",
-      "description": "Present only on delegated approval events."
-    },
-    "delegated_by_id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Stable id of the delegating human — present iff delegated_by is set."
-    }
-  },
-  "required": [
-    "actor",
-    "actor_id"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "actor-identity.schema.json",
+	"title": "ActorIdentity",
+	"description": "Identity of the actor that initiated or received the event, per actor-surface-model taxonomy.",
+	"type": "object",
+	"properties": {
+		"actor": {
+			"type": "string",
+			"enum": ["human", "ai-agent", "automation"],
+			"description": "Actor kind from the capability matrix."
+		},
+		"actor_id": {
+			"type": "string",
+			"minLength": 1,
+			"description": "Stable identifier for the specific actor instance."
+		},
+		"delegated_by": {
+			"type": "string",
+			"const": "human",
+			"description": "Present only on delegated approval events."
+		},
+		"delegated_by_id": {
+			"type": "string",
+			"minLength": 1,
+			"description": "Stable id of the delegating human — present iff delegated_by is set."
+		}
+	},
+	"required": ["actor", "actor_id"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/approval-payload.schema.json
+++ b/assets/global/schemas/surface-events/approval-payload.schema.json
@@ -1,24 +1,21 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "approval-payload.schema.json",
-  "title": "ApprovalPayload",
-  "description": "Payload for approval events: accept_spec, accept_design, accept_apply.",
-  "type": "object",
-  "properties": {
-    "phase_from": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Workflow phase the approval transitions from."
-    },
-    "phase_to": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Workflow phase the approval transitions to."
-    }
-  },
-  "required": [
-    "phase_from",
-    "phase_to"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "approval-payload.schema.json",
+	"title": "ApprovalPayload",
+	"description": "Payload for approval events: accept_spec, accept_design, accept_apply.",
+	"type": "object",
+	"properties": {
+		"phase_from": {
+			"type": "string",
+			"minLength": 1,
+			"description": "Workflow phase the approval transitions from."
+		},
+		"phase_to": {
+			"type": "string",
+			"minLength": 1,
+			"description": "Workflow phase the approval transitions to."
+		}
+	},
+	"required": ["phase_from", "phase_to"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/approval-payload.schema.json
+++ b/assets/global/schemas/surface-events/approval-payload.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "approval-payload.schema.json",
+  "title": "ApprovalPayload",
+  "description": "Payload for approval events: accept_spec, accept_design, accept_apply.",
+  "type": "object",
+  "properties": {
+    "phase_from": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Workflow phase the approval transitions from."
+    },
+    "phase_to": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Workflow phase the approval transitions to."
+    }
+  },
+  "required": [
+    "phase_from",
+    "phase_to"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/clarify-request-payload.schema.json
+++ b/assets/global/schemas/surface-events/clarify-request-payload.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "clarify-request-payload.schema.json",
+  "title": "ClarifyRequestPayload",
+  "description": "Payload for outbound clarify_request events.",
+  "type": "object",
+  "properties": {
+    "question": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The clarification question text."
+    },
+    "context": {
+      "type": "string",
+      "description": "Additional context for the question."
+    }
+  },
+  "required": [
+    "question"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/clarify-request-payload.schema.json
+++ b/assets/global/schemas/surface-events/clarify-request-payload.schema.json
@@ -1,22 +1,20 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "clarify-request-payload.schema.json",
-  "title": "ClarifyRequestPayload",
-  "description": "Payload for outbound clarify_request events.",
-  "type": "object",
-  "properties": {
-    "question": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The clarification question text."
-    },
-    "context": {
-      "type": "string",
-      "description": "Additional context for the question."
-    }
-  },
-  "required": [
-    "question"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "clarify-request-payload.schema.json",
+	"title": "ClarifyRequestPayload",
+	"description": "Payload for outbound clarify_request events.",
+	"type": "object",
+	"properties": {
+		"question": {
+			"type": "string",
+			"minLength": 1,
+			"description": "The clarification question text."
+		},
+		"context": {
+			"type": "string",
+			"description": "Additional context for the question."
+		}
+	},
+	"required": ["question"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/clarify-response-payload.schema.json
+++ b/assets/global/schemas/surface-events/clarify-response-payload.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "clarify-response-payload.schema.json",
+  "title": "ClarifyResponsePayload",
+  "description": "Payload for inbound clarify_response events.",
+  "type": "object",
+  "properties": {
+    "answer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The clarification answer text."
+    },
+    "question_event_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "event_id of the corresponding clarify_request."
+    }
+  },
+  "required": [
+    "answer",
+    "question_event_id"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/clarify-response-payload.schema.json
+++ b/assets/global/schemas/surface-events/clarify-response-payload.schema.json
@@ -1,24 +1,21 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "clarify-response-payload.schema.json",
-  "title": "ClarifyResponsePayload",
-  "description": "Payload for inbound clarify_response events.",
-  "type": "object",
-  "properties": {
-    "answer": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The clarification answer text."
-    },
-    "question_event_id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "event_id of the corresponding clarify_request."
-    }
-  },
-  "required": [
-    "answer",
-    "question_event_id"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "clarify-response-payload.schema.json",
+	"title": "ClarifyResponsePayload",
+	"description": "Payload for inbound clarify_response events.",
+	"type": "object",
+	"properties": {
+		"answer": {
+			"type": "string",
+			"minLength": 1,
+			"description": "The clarification answer text."
+		},
+		"question_event_id": {
+			"type": "string",
+			"minLength": 1,
+			"description": "event_id of the corresponding clarify_request."
+		}
+	},
+	"required": ["answer", "question_event_id"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/correlation.schema.json
+++ b/assets/global/schemas/surface-events/correlation.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "correlation.schema.json",
+  "title": "CorrelationContext",
+  "description": "Traceability context linking the event to a workflow run.",
+  "type": "object",
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Run identifier in <change_id>-<N> format."
+    },
+    "change_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Change identifier."
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Monotonically increasing within a run — optional, caller-assigned."
+    },
+    "caused_by": {
+      "type": "string",
+      "description": "event_id of the event that triggered this one (request-response)."
+    }
+  },
+  "required": [
+    "run_id",
+    "change_id"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/correlation.schema.json
+++ b/assets/global/schemas/surface-events/correlation.schema.json
@@ -1,33 +1,30 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "correlation.schema.json",
-  "title": "CorrelationContext",
-  "description": "Traceability context linking the event to a workflow run.",
-  "type": "object",
-  "properties": {
-    "run_id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Run identifier in <change_id>-<N> format."
-    },
-    "change_id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Change identifier."
-    },
-    "sequence": {
-      "type": "integer",
-      "minimum": 0,
-      "description": "Monotonically increasing within a run — optional, caller-assigned."
-    },
-    "caused_by": {
-      "type": "string",
-      "description": "event_id of the event that triggered this one (request-response)."
-    }
-  },
-  "required": [
-    "run_id",
-    "change_id"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "correlation.schema.json",
+	"title": "CorrelationContext",
+	"description": "Traceability context linking the event to a workflow run.",
+	"type": "object",
+	"properties": {
+		"run_id": {
+			"type": "string",
+			"minLength": 1,
+			"description": "Run identifier in <change_id>-<N> format."
+		},
+		"change_id": {
+			"type": "string",
+			"minLength": 1,
+			"description": "Change identifier."
+		},
+		"sequence": {
+			"type": "integer",
+			"minimum": 0,
+			"description": "Monotonically increasing within a run — optional, caller-assigned."
+		},
+		"caused_by": {
+			"type": "string",
+			"description": "event_id of the event that triggered this one (request-response)."
+		}
+	},
+	"required": ["run_id", "change_id"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/envelope.schema.json
+++ b/assets/global/schemas/surface-events/envelope.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "envelope.schema.json",
+  "title": "SurfaceEventEnvelope",
+  "description": "Bidirectional, transport-agnostic event envelope for specflow surface events. Version 1.0.",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Envelope schema version. Consumers branch on this field for version handling."
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for the event instance."
+    },
+    "event_kind": {
+      "type": "string",
+      "enum": [
+        "approval",
+        "reject",
+        "clarify",
+        "resume"
+      ],
+      "description": "Abstract event category."
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "accept_spec",
+        "accept_design",
+        "accept_apply",
+        "reject",
+        "clarify_request",
+        "clarify_response",
+        "resume",
+        "design_review_approved",
+        "apply_review_approved",
+        "request_changes",
+        "block"
+      ],
+      "description": "Concrete event type."
+    },
+    "direction": {
+      "type": "string",
+      "enum": [
+        "inbound",
+        "outbound"
+      ],
+      "description": "Event flow direction relative to specflow."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of event creation."
+    },
+    "correlation": {
+      "$ref": "correlation.schema.json"
+    },
+    "actor": {
+      "$ref": "actor-identity.schema.json"
+    },
+    "surface": {
+      "$ref": "surface-identity.schema.json"
+    },
+    "payload": {
+      "type": "object",
+      "description": "Event-type-specific payload. See individual event type schemas for structure."
+    }
+  },
+  "required": [
+    "schema_version",
+    "event_id",
+    "event_kind",
+    "event_type",
+    "direction",
+    "timestamp",
+    "correlation",
+    "actor",
+    "surface",
+    "payload"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/envelope.schema.json
+++ b/assets/global/schemas/surface-events/envelope.schema.json
@@ -1,85 +1,77 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "envelope.schema.json",
-  "title": "SurfaceEventEnvelope",
-  "description": "Bidirectional, transport-agnostic event envelope for specflow surface events. Version 1.0.",
-  "type": "object",
-  "properties": {
-    "schema_version": {
-      "type": "string",
-      "const": "1.0",
-      "description": "Envelope schema version. Consumers branch on this field for version handling."
-    },
-    "event_id": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Unique identifier for the event instance."
-    },
-    "event_kind": {
-      "type": "string",
-      "enum": [
-        "approval",
-        "reject",
-        "clarify",
-        "resume"
-      ],
-      "description": "Abstract event category."
-    },
-    "event_type": {
-      "type": "string",
-      "enum": [
-        "accept_spec",
-        "accept_design",
-        "accept_apply",
-        "reject",
-        "clarify_request",
-        "clarify_response",
-        "resume",
-        "design_review_approved",
-        "apply_review_approved",
-        "request_changes",
-        "block"
-      ],
-      "description": "Concrete event type."
-    },
-    "direction": {
-      "type": "string",
-      "enum": [
-        "inbound",
-        "outbound"
-      ],
-      "description": "Event flow direction relative to specflow."
-    },
-    "timestamp": {
-      "type": "string",
-      "format": "date-time",
-      "description": "ISO 8601 timestamp of event creation."
-    },
-    "correlation": {
-      "$ref": "correlation.schema.json"
-    },
-    "actor": {
-      "$ref": "actor-identity.schema.json"
-    },
-    "surface": {
-      "$ref": "surface-identity.schema.json"
-    },
-    "payload": {
-      "type": "object",
-      "description": "Event-type-specific payload. See individual event type schemas for structure."
-    }
-  },
-  "required": [
-    "schema_version",
-    "event_id",
-    "event_kind",
-    "event_type",
-    "direction",
-    "timestamp",
-    "correlation",
-    "actor",
-    "surface",
-    "payload"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "envelope.schema.json",
+	"title": "SurfaceEventEnvelope",
+	"description": "Bidirectional, transport-agnostic event envelope for specflow surface events. Version 1.0.",
+	"type": "object",
+	"properties": {
+		"schema_version": {
+			"type": "string",
+			"const": "1.0",
+			"description": "Envelope schema version. Consumers branch on this field for version handling."
+		},
+		"event_id": {
+			"type": "string",
+			"minLength": 1,
+			"description": "Unique identifier for the event instance."
+		},
+		"event_kind": {
+			"type": "string",
+			"enum": ["approval", "reject", "clarify", "resume"],
+			"description": "Abstract event category."
+		},
+		"event_type": {
+			"type": "string",
+			"enum": [
+				"accept_spec",
+				"accept_design",
+				"accept_apply",
+				"reject",
+				"clarify_request",
+				"clarify_response",
+				"resume",
+				"design_review_approved",
+				"apply_review_approved",
+				"request_changes",
+				"block"
+			],
+			"description": "Concrete event type."
+		},
+		"direction": {
+			"type": "string",
+			"enum": ["inbound", "outbound"],
+			"description": "Event flow direction relative to specflow."
+		},
+		"timestamp": {
+			"type": "string",
+			"format": "date-time",
+			"description": "ISO 8601 timestamp of event creation."
+		},
+		"correlation": {
+			"$ref": "correlation.schema.json"
+		},
+		"actor": {
+			"$ref": "actor-identity.schema.json"
+		},
+		"surface": {
+			"$ref": "surface-identity.schema.json"
+		},
+		"payload": {
+			"type": "object",
+			"description": "Event-type-specific payload. See individual event type schemas for structure."
+		}
+	},
+	"required": [
+		"schema_version",
+		"event_id",
+		"event_kind",
+		"event_type",
+		"direction",
+		"timestamp",
+		"correlation",
+		"actor",
+		"surface",
+		"payload"
+	],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/reject-payload.schema.json
+++ b/assets/global/schemas/surface-events/reject-payload.schema.json
@@ -1,22 +1,20 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "reject-payload.schema.json",
-  "title": "RejectPayload",
-  "description": "Payload for the reject event.",
-  "type": "object",
-  "properties": {
-    "phase_from": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Workflow phase where rejection occurred."
-    },
-    "reason": {
-      "type": "string",
-      "description": "Human-readable rejection reason."
-    }
-  },
-  "required": [
-    "phase_from"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "reject-payload.schema.json",
+	"title": "RejectPayload",
+	"description": "Payload for the reject event.",
+	"type": "object",
+	"properties": {
+		"phase_from": {
+			"type": "string",
+			"minLength": 1,
+			"description": "Workflow phase where rejection occurred."
+		},
+		"reason": {
+			"type": "string",
+			"description": "Human-readable rejection reason."
+		}
+	},
+	"required": ["phase_from"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/reject-payload.schema.json
+++ b/assets/global/schemas/surface-events/reject-payload.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "reject-payload.schema.json",
+  "title": "RejectPayload",
+  "description": "Payload for the reject event.",
+  "type": "object",
+  "properties": {
+    "phase_from": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Workflow phase where rejection occurred."
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable rejection reason."
+    }
+  },
+  "required": [
+    "phase_from"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/resume-payload.schema.json
+++ b/assets/global/schemas/surface-events/resume-payload.schema.json
@@ -1,18 +1,16 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "resume-payload.schema.json",
-  "title": "ResumePayload",
-  "description": "Payload for the resume event.",
-  "type": "object",
-  "properties": {
-    "phase_from": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The phase the run was suspended in."
-    }
-  },
-  "required": [
-    "phase_from"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "resume-payload.schema.json",
+	"title": "ResumePayload",
+	"description": "Payload for the resume event.",
+	"type": "object",
+	"properties": {
+		"phase_from": {
+			"type": "string",
+			"minLength": 1,
+			"description": "The phase the run was suspended in."
+		}
+	},
+	"required": ["phase_from"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/resume-payload.schema.json
+++ b/assets/global/schemas/surface-events/resume-payload.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "resume-payload.schema.json",
+  "title": "ResumePayload",
+  "description": "Payload for the resume event.",
+  "type": "object",
+  "properties": {
+    "phase_from": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The phase the run was suspended in."
+    }
+  },
+  "required": [
+    "phase_from"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/review-outcome-payload.schema.json
+++ b/assets/global/schemas/surface-events/review-outcome-payload.schema.json
@@ -1,54 +1,47 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "review-outcome-payload.schema.json",
-  "title": "ReviewOutcomePayload",
-  "description": "Payload for review outcome events: design_review_approved, apply_review_approved, request_changes, block.",
-  "type": "object",
-  "properties": {
-    "phase_from": {
-      "type": "string",
-      "minLength": 1,
-      "description": "The review phase."
-    },
-    "reviewer_actor": {
-      "$ref": "actor-identity.schema.json",
-      "description": "Actor identity of the reviewer."
-    },
-    "summary": {
-      "type": "string",
-      "description": "Review summary text."
-    },
-    "issues": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "minLength": 1
-          },
-          "severity": {
-            "type": "string",
-            "minLength": 1
-          },
-          "detail": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "required": [
-          "id",
-          "severity",
-          "detail"
-        ],
-        "additionalProperties": false
-      },
-      "description": "Array of review issues (for request_changes and block)."
-    }
-  },
-  "required": [
-    "phase_from",
-    "reviewer_actor"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "review-outcome-payload.schema.json",
+	"title": "ReviewOutcomePayload",
+	"description": "Payload for review outcome events: design_review_approved, apply_review_approved, request_changes, block.",
+	"type": "object",
+	"properties": {
+		"phase_from": {
+			"type": "string",
+			"minLength": 1,
+			"description": "The review phase."
+		},
+		"reviewer_actor": {
+			"$ref": "actor-identity.schema.json",
+			"description": "Actor identity of the reviewer."
+		},
+		"summary": {
+			"type": "string",
+			"description": "Review summary text."
+		},
+		"issues": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string",
+						"minLength": 1
+					},
+					"severity": {
+						"type": "string",
+						"minLength": 1
+					},
+					"detail": {
+						"type": "string",
+						"minLength": 1
+					}
+				},
+				"required": ["id", "severity", "detail"],
+				"additionalProperties": false
+			},
+			"description": "Array of review issues (for request_changes and block)."
+		}
+	},
+	"required": ["phase_from", "reviewer_actor"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/review-outcome-payload.schema.json
+++ b/assets/global/schemas/surface-events/review-outcome-payload.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "review-outcome-payload.schema.json",
+  "title": "ReviewOutcomePayload",
+  "description": "Payload for review outcome events: design_review_approved, apply_review_approved, request_changes, block.",
+  "type": "object",
+  "properties": {
+    "phase_from": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The review phase."
+    },
+    "reviewer_actor": {
+      "$ref": "actor-identity.schema.json",
+      "description": "Actor identity of the reviewer."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Review summary text."
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "type": "string",
+            "minLength": 1
+          },
+          "detail": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "id",
+          "severity",
+          "detail"
+        ],
+        "additionalProperties": false
+      },
+      "description": "Array of review issues (for request_changes and block)."
+    }
+  },
+  "required": [
+    "phase_from",
+    "reviewer_actor"
+  ],
+  "additionalProperties": false
+}

--- a/assets/global/schemas/surface-events/surface-identity.schema.json
+++ b/assets/global/schemas/surface-events/surface-identity.schema.json
@@ -1,27 +1,20 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "surface-identity.schema.json",
-  "title": "SurfaceIdentity",
-  "description": "Identity of the surface through which the event flows, per actor-surface-model taxonomy.",
-  "type": "object",
-  "properties": {
-    "surface": {
-      "type": "string",
-      "enum": [
-        "local-cli",
-        "remote-api",
-        "agent-native",
-        "batch"
-      ],
-      "description": "Surface type from the surface taxonomy."
-    },
-    "surface_id": {
-      "type": "string",
-      "description": "Optional instance identifier (e.g., session id)."
-    }
-  },
-  "required": [
-    "surface"
-  ],
-  "additionalProperties": false
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "surface-identity.schema.json",
+	"title": "SurfaceIdentity",
+	"description": "Identity of the surface through which the event flows, per actor-surface-model taxonomy.",
+	"type": "object",
+	"properties": {
+		"surface": {
+			"type": "string",
+			"enum": ["local-cli", "remote-api", "agent-native", "batch"],
+			"description": "Surface type from the surface taxonomy."
+		},
+		"surface_id": {
+			"type": "string",
+			"description": "Optional instance identifier (e.g., session id)."
+		}
+	},
+	"required": ["surface"],
+	"additionalProperties": false
 }

--- a/assets/global/schemas/surface-events/surface-identity.schema.json
+++ b/assets/global/schemas/surface-events/surface-identity.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "surface-identity.schema.json",
+  "title": "SurfaceIdentity",
+  "description": "Identity of the surface through which the event flows, per actor-surface-model taxonomy.",
+  "type": "object",
+  "properties": {
+    "surface": {
+      "type": "string",
+      "enum": [
+        "local-cli",
+        "remote-api",
+        "agent-native",
+        "batch"
+      ],
+      "description": "Surface type from the surface taxonomy."
+    },
+    "surface_id": {
+      "type": "string",
+      "description": "Optional instance identifier (e.g., session id)."
+    }
+  },
+  "required": [
+    "surface"
+  ],
+  "additionalProperties": false
+}

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/approval-summary.md
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/approval-summary.md
@@ -1,0 +1,85 @@
+# Approval Summary: define-surface-event-contract-for-external-runtimes
+
+**Generated**: 2026-04-15T02:34:00Z
+**Branch**: define-surface-event-contract-for-external-runtimes
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+```
+ package-lock.json                     |  62 ++++++++++++++++++-
+ package.json                          |   1 +
+ src/contracts/install.ts              |   7 +++
+ src/contracts/surface-events.ts       | 205 +++ (new)
+ src/generators/static-assets.ts       |   4 ++
+ src/lib/phase-router/derive-action.ts |   7 +++
+ src/lib/phase-router/router.ts        |  60 +++++++++++++++---
+ src/lib/phase-router/types.ts         |  47 ++++++++++----
+ src/tests/phase-router.test.ts        | 113 +++++++++++++++++++++++++++++++---
+ src/tests/surface-event-schema-drift.test.ts | 242 +++ (new)
+ assets/global/schemas/surface-events/ | 10 schema files (new)
+```
+
+## Files Touched
+
+- package-lock.json
+- package.json
+- src/contracts/install.ts
+- src/contracts/surface-events.ts (new)
+- src/generators/static-assets.ts
+- src/lib/phase-router/derive-action.ts
+- src/lib/phase-router/router.ts
+- src/lib/phase-router/types.ts
+- src/tests/phase-router.test.ts
+- src/tests/surface-event-schema-drift.test.ts (new)
+- assets/global/schemas/surface-events/*.schema.json (10 new files)
+
+## Review Loop Summary
+
+### Design Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 1     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 3     |
+
+### Impl Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 1     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 2     |
+
+## Proposal Coverage
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | SurfaceEventEnvelope with all required fields | Yes | src/contracts/surface-events.ts |
+| 2 | Bidirectional (inbound + outbound) direction | Yes | src/contracts/surface-events.ts |
+| 3 | schema_version for forward compatibility | Yes | src/contracts/surface-events.ts |
+| 4 | Correlation object (run_id, change_id, sequence, caused_by) | Yes | src/contracts/surface-events.ts |
+| 5 | Actor identity reuses actor-surface-model taxonomy | Yes | src/contracts/surface-events.ts |
+| 6 | Surface identity from surface taxonomy | Yes | src/contracts/surface-events.ts |
+| 7 | Hierarchical event type system (4 categories, 11 concrete types) | Yes | src/contracts/surface-events.ts |
+| 8 | Fixed payload schema per concrete event type | Yes | src/contracts/surface-events.ts |
+| 9 | Slash-command-to-event mapping documented | Yes | openspec/changes/.../specs/surface-event-contract/spec.md |
+| 10 | TypeScript types + JSON Schema dual format | Yes | src/contracts/surface-events.ts, assets/global/schemas/surface-events/ |
+| 11 | Phase-router conforms to event contract | Yes | src/lib/phase-router/router.ts, types.ts |
+| 12 | JSON Schema in distribution bundle | Yes | src/contracts/install.ts, src/generators/static-assets.ts |
+
+**Coverage Rate**: 12/12 (100%)
+
+## Remaining Risks
+
+- R2-F07: EVENT_TYPE_TO_KIND maps request_changes and block to 'approval' (severity: low) — intentional coarse categorization per spec, but could confuse external consumers filtering on event_kind.
+
+## Human Checkpoints
+
+- [ ] Verify the EVENT_TYPE_TO_KIND mapping makes semantic sense for external consumers (request_changes/block under "approval" category)
+- [ ] Confirm that PhaseContract.gated_event_type will be populated correctly by the production PhaseContractRegistry (#129) when it lands
+- [ ] Validate that the JSON Schema $ref resolution works correctly when consumed from `$HOME/.config/specflow/global/schemas/`
+- [ ] Test that the ajv devDependency doesn't affect the production bundle size (devDependency only)

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/current-phase.md
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/current-phase.md
@@ -1,0 +1,15 @@
+# Current Phase: define-surface-event-contract-for-external-runtimes
+
+- Phase: fix-review
+- Round: 2
+- Status: in_progress
+- Open High Findings: 0 件
+- Actionable Findings: 1
+- Accepted Risks: none
+- Latest Changes:
+  - 44dd63e feat: define design contract required for specflow task planning and apply windowing (#138)
+  - 81c6925 feat: add specflow-owned task planner with bundle-based task graph (#137)
+  - bb0a9ca feat: add AgentSessionManager for persistent agent sessions (#133)
+  - d6db669 feat: add AgentSessionManager for persistent agent sessions (#133)
+  - 4d76d44 feat: add deterministic PhaseRouter for server orchestration (#132)
+- Next Recommended Action: /specflow.fix_apply

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/design.md
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/design.md
@@ -1,0 +1,96 @@
+## Context
+
+specflow's workflow engine currently has no shared event contract. The `phase-router` (landed in #132) emits gated surface events through a `SurfaceEventSink` interface, but the `SurfaceEvent` type in `src/lib/phase-router/types.ts` is a minimal placeholder (run_id, phase, event_kind, emitted_at) with a comment explicitly deferring to #100.
+
+The server PoC is moving to a separate repo that needs to consume and produce workflow events. Without a canonical event contract, external runtimes would have to reverse-engineer the event shape from the phase-router's internals.
+
+Existing codebase state:
+- **No actor/surface types exist in code.** The `actor-surface-model` spec defines the taxonomy, but no TypeScript types have been implemented yet.
+- **`src/contracts/`** contains the contract-driven distribution bundle (commands, prompts, orchestrators, workflow, templates).
+- **`src/core/types.ts`** defines the `Result<T, E>` pattern and core runtime error contract.
+- **`src/lib/phase-router/types.ts`** owns the placeholder `SurfaceEvent` and `SurfaceEventSink` interfaces.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define canonical TypeScript types for the bidirectional surface event envelope.
+- Define JSON Schema files for each concrete event type, suitable for language-agnostic consumers.
+- Re-export actor and surface identity types so consumers use a single import path.
+- Make JSON Schema files distributable via the existing `contract-driven-distribution` bundle.
+- Replace the phase-router's placeholder `SurfaceEvent` with the canonical type.
+
+**Non-Goals:**
+- Implement transport bindings (HTTP webhooks, WebSocket adapters, message queues).
+- Build an event bus or pub/sub infrastructure.
+- Implement runtime validation middleware (consumers validate on their side).
+- Rewire existing CLI commands to emit/consume events (deferred to follow-up).
+- Generate TypeScript types from JSON Schema or vice versa at build time (manual sync for now; generation can be added later).
+
+## Decisions
+
+### D1: New `src/contracts/surface-events.ts` as the canonical module
+
+Place all event envelope types in a new contract module `src/contracts/surface-events.ts`. This follows the established pattern where each contract domain has its own file under `src/contracts/`.
+
+**Why not `src/lib/`?** Contract types are declaration-only (no runtime logic). The `src/contracts/` directory is already the canonical location for distributable contract definitions. Placing event types here aligns with `workflow.ts`, `commands.ts`, etc.
+
+**Why not `src/types/`?** `src/types/` holds internal type infrastructure (e.g., `contracts.ts` for bundle types). Surface event types are a public contract surface, not internal plumbing.
+
+### D2: Actor/surface identity types defined inline in the event contract module
+
+The `actor-surface-model` spec defines the taxonomy, but no TypeScript types exist yet. Rather than creating a separate `src/types/actor-surface.ts` module (which would create a dependency for a single consumer), define the actor and surface identity types directly in `src/contracts/surface-events.ts` and export them.
+
+When a future change implements the full actor-surface permission engine, these types can be extracted to a shared module and re-exported from the event contract for backward compatibility.
+
+**Alternative considered:** Create `src/types/actor-surface.ts` now. Rejected because it creates a module with only two small union types and no runtime code — premature extraction.
+
+### D3: JSON Schema files under `assets/global/schemas/`
+
+Place JSON Schema files at `assets/global/schemas/surface-events/`. The `assets/global/` directory already holds prompts and workflow files that the distribution bundle copies. Adding a `schemas/` subdirectory follows the same pattern.
+
+The distribution bundle (`src/contracts/install.ts`) will get a new `InstallCopyContract` entry to copy `global/schemas` to `$HOME/.config/specflow/global/schemas/`.
+
+**Alternative considered:** Embed JSON Schema as string literals in TypeScript. Rejected because external (non-TypeScript) consumers need raw `.json` files, and embedded strings are harder to validate with standard JSON Schema tooling.
+
+### D4: Envelope uses string literal unions, not numeric enums
+
+All discriminant fields (`event_kind`, `event_type`, `direction`) use string literal unions. This matches the existing codebase conventions (e.g., `CoreRuntimeErrorKind`, `PhaseNextAction`) and produces self-documenting JSON payloads.
+
+### D5: Phase-router's SurfaceEvent is replaced with a re-export
+
+The placeholder `SurfaceEvent` in `src/lib/phase-router/types.ts` will be replaced with an import from `src/contracts/surface-events.ts`. The `SurfaceEventSink` interface signature remains compatible — it accepts the expanded type that is a superset of the old shape.
+
+The router currently emits 4 fields (run_id, phase, event_kind, emitted_at). After this change, the router will construct a full `SurfaceEventEnvelope` with all required fields. The router already has access to run_id and phase from its store read; additional fields (actor, surface, correlation) will come from the orchestrator context passed to the router.
+
+**Context threading:** The phase-router's `createPhaseRouter` (or its emit helper) will accept a new `SurfaceEventContext` parameter containing `actor: ActorIdentity`, `surface: SurfaceIdentity`, and `correlation: CorrelationContext`. This interface is defined in `src/lib/phase-router/types.ts` (not in `src/contracts/surface-events.ts`) because it is internal runtime plumbing for threading orchestrator state into the router, not a distributable contract surface consumed by external runtimes. The orchestrator that invokes the router is responsible for constructing this context object and passing it at each router invocation. The `event_id` field will be generated using `crypto.randomUUID()` (Node.js built-in, no additional dependency). This avoids store augmentation — the context is threaded as a function parameter, not stored in the XState machine context.
+
+### D6: schema_version starts at "1.0", follows additive-only evolution
+
+`schema_version` is a string field in the envelope, starting at `"1.0"`. Version policy:
+- Adding optional fields: no version bump.
+- Adding a new event_type: minor bump (e.g., "1.1").
+- Changing required fields or removing fields: major bump (e.g., "2.0").
+
+This is documented in the spec and JSON Schema description, not enforced at runtime.
+
+### D7: Correlation sequence is optional and caller-assigned
+
+The `sequence` field in the correlation object is optional. The caller (orchestrator or surface adapter) is responsible for assigning monotonically increasing sequence numbers if ordering matters. The event contract does not enforce or generate sequences — it only defines the field shape.
+
+## Risks / Trade-offs
+
+**[Risk] TypeScript types and JSON Schema can drift.**
+→ Mitigation: Add a build-time test that parses the JSON Schema files and validates them against sample TypeScript objects using `ajv` (added as a devDependency). This is a lightweight check, not a full schema-from-types generator.
+
+**[Risk] Phase-router refactor is a breaking change for test fixtures.**
+→ Mitigation: The `SurfaceEventSink.emit()` signature accepts the wider envelope type. Existing test fixtures that construct a minimal 4-field `SurfaceEvent` will need updating, but the change is mechanical.
+
+**[Risk] Actor/surface types defined inline may diverge from a future shared module.**
+→ Mitigation: Keep the types minimal (union + identity interface). When the permission engine lands, extract and re-export. The type shapes are spec-defined and stable.
+
+**[Risk] External consumers may depend on payload field ordering.**
+→ Mitigation: JSON Schema and TypeScript types define shape, not ordering. Document that field ordering is not guaranteed.
+
+## Open Questions
+
+None — all ambiguities were resolved during proposal challenge/reclarify.

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/proposal.md
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The server PoC is moving to a separate repo, but that repo needs a well-defined event contract to communicate workflow decisions (approval, rejection, clarification, resume) back to specflow. Today, the `phase-router` spec already references a "Surface event contract (#100)" for gated event emission, but no such contract exists yet. Without it, external runtimes and future surfaces (web UI, server API, CI bots) cannot interoperate with specflow's workflow in a surface-neutral way.
+
+- Source: https://github.com/skr19930617/specflow/issues/100
+
+## What Changes
+
+- Define a **bidirectional surface event contract** — covering both outbound notifications (specflow → surface, e.g., "gated decision awaiting approval") and inbound commands (surface → specflow, e.g., "user approved"). The contract is transport-agnostic; HTTP/WebSocket/file-based transport is an implementation concern outside this contract.
+- Define a **surface event envelope** with a `schema_version` field for forward compatibility. External runtimes can branch on `schema_version` to handle version mismatches gracefully.
+- Define **actor identity** and **surface identity** fields within the envelope, re-exported from `actor-surface-model` so consumers need only a single import.
+- Define **payload** and **correlation** fields for event traceability (run_id, change_id, sequence).
+- Define a **hierarchical event type system**: 4 abstract categories (approval, reject, clarify, resume) with concrete specializations for gated decisions (accept_spec, accept_design, accept_apply), review outcomes (design_review_approved, apply_review_approved, request_changes, block), and their inbound command counterparts. Each concrete event type has a **fixed payload schema** with required and optional fields, enabling strict validation by external runtimes.
+- Document the slash-command-to-event mapping as a reference table in spec text (not a runtime artifact). Surface adapters implement the mapping.
+- Provide the contract as both **TypeScript type definitions** (with re-exports of actor-surface-model types) and **JSON Schema** within this repo.
+
+## Capabilities
+
+### New Capabilities
+- `surface-event-contract`: Defines the bidirectional, transport-agnostic, versioned event envelope, identity fields, correlation model, hierarchical event type system, and concrete event schemas that external runtimes and future surfaces reference to interoperate with specflow workflows.
+
+### Modified Capabilities
+- None — `phase-router` already declares conformance to this contract (#100) but requires no spec-level change; it only needs the contract to exist.
+
+## Impact
+
+- `src/contracts/` — new event envelope types, concrete event schemas, and JSON Schema files will be added. Actor/surface types are re-exported from `actor-surface-model`.
+- `phase-router` — gated event emission will conform to the new contract (implementation only, no spec change).
+- External runtime repos — can import TypeScript types (single import) or reference JSON Schema for server-side workflow orchestration.
+- `actor-surface-model` — no spec change; the event contract re-exports its actor/surface taxonomy types.
+- Build pipeline — JSON Schema files will be included in the distribution bundle via `contract-driven-distribution`.

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/review-ledger-design.json
@@ -1,0 +1,132 @@
+{
+  "feature_id": "define-surface-event-contract-for-external-runtimes",
+  "phase": "design",
+  "current_round": 3,
+  "status": "all_resolved",
+  "max_finding_id": 6,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "feasibility",
+      "title": "ajv dependency missing for Task 5",
+      "detail": "Task 5 requires validating TypeScript objects against JSON Schema using a schema validator (e.g., ajv), but the project has no JSON Schema validator dependency. package.json only has xstate as a runtime dependency and biome/c8/prettier/typescript as devDependencies. Task 5 needs a subtask to add ajv (or alternative) as a devDependency before the validation tests can be written. Without this, the drift-detection test cannot be implemented as designed.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "completeness",
+      "title": "Task 4.4 underspecifies orchestrator context threading",
+      "detail": "Task 4.4 says 'construct full SurfaceEventEnvelope with actor, surface, and correlation fields from orchestrator context (D5)' but the phase-router currently receives no orchestrator context carrying actor/surface identity. The router's emit call sites construct a minimal 4-field object. This task needs to specify: (a) what interface change is needed to thread context into the router (function signature change or store augmentation), and (b) where event_id generation happens (uuid? nanoid? already a dependency?). Without this, the implementer will have to make design decisions that should be captured here.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "consistency",
+      "title": "Spec requires 'block' event but slash-command mapping table has no explicit block trigger",
+      "detail": "The spec defines a 'block' event type under review outcomes, and the slash-command mapping table maps /specflow.review_design and /specflow.review_apply to 'design_review_approved or request_changes'. The 'block' event type is missing from the mapping table rows. This is a spec-level gap, but the design and tasks should note it — the TypeScript types and JSON Schema must still include 'block' as a concrete event type. Task 1.7 should explicitly list all 11 concrete event types to avoid the implementer missing 'block'.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F04",
+      "severity": "low",
+      "category": "granularity",
+      "title": "Task 1.7 is too coarse for 11 concrete payload interfaces",
+      "detail": "Task 1.7 ('Define concrete event type interfaces as discriminated union members') covers all 11 concrete event types and their payload schemas in a single subtask. Consider splitting into approval payloads, reject payload, clarify payloads, resume payload, and review outcome payloads — matching the spec's grouping — to reduce implementation ambiguity and make progress trackable.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R2-F05",
+      "severity": "high",
+      "category": "consistency",
+      "file": "openspec/changes/define-surface-event-contract-for-external-runtimes/tasks.md",
+      "title": "Task 1.7c uses wrong event type names",
+      "detail": "Task 1.7c defines clarify payload interfaces as 'request_clarification' and 'provide_clarification', but the spec defines these concrete event types as 'clarify_request' and 'clarify_response'. This naming mismatch will cause the TypeScript types to diverge from the spec, breaking the JSON Schema alignment and the slash-command mapping table. Fix: rename to 'clarify_request' and 'clarify_response' in task 1.7c.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F06",
+      "severity": "low",
+      "category": "completeness",
+      "file": "openspec/changes/define-surface-event-contract-for-external-runtimes/tasks.md",
+      "title": "Task 4.4a places SurfaceEventContext in the wrong module",
+      "detail": "Task 4.4a says 'Define a SurfaceEventContext interface ... in the canonical contract module'. SurfaceEventContext is a runtime concern (threading orchestrator state into the router) rather than a contract surface consumed by external runtimes. Placing it in src/contracts/surface-events.ts conflates contract types with internal runtime plumbing. Consider defining it in src/lib/phase-router/types.ts alongside the router's own types, or in a separate internal types file. This is low severity because the implementation works either way, but it deviates from the project's convention of keeping src/contracts/ for distributable declarations only.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 4,
+      "open": 4,
+      "new": 4,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 2,
+        "low": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 6,
+      "open": 3,
+      "new": 2,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "high": 1,
+        "low": 1
+      }
+    },
+    {
+      "round": 3,
+      "total": 6,
+      "open": 0,
+      "new": 0,
+      "resolved": 6,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/review-ledger-design.json.bak
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/review-ledger-design.json.bak
@@ -1,0 +1,120 @@
+{
+  "feature_id": "define-surface-event-contract-for-external-runtimes",
+  "phase": "design",
+  "current_round": 2,
+  "status": "has_open_high",
+  "max_finding_id": 6,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "feasibility",
+      "title": "ajv dependency missing for Task 5",
+      "detail": "Task 5 requires validating TypeScript objects against JSON Schema using a schema validator (e.g., ajv), but the project has no JSON Schema validator dependency. package.json only has xstate as a runtime dependency and biome/c8/prettier/typescript as devDependencies. Task 5 needs a subtask to add ajv (or alternative) as a devDependency before the validation tests can be written. Without this, the drift-detection test cannot be implemented as designed.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "completeness",
+      "title": "Task 4.4 underspecifies orchestrator context threading",
+      "detail": "Task 4.4 says 'construct full SurfaceEventEnvelope with actor, surface, and correlation fields from orchestrator context (D5)' but the phase-router currently receives no orchestrator context carrying actor/surface identity. The router's emit call sites construct a minimal 4-field object. This task needs to specify: (a) what interface change is needed to thread context into the router (function signature change or store augmentation), and (b) where event_id generation happens (uuid? nanoid? already a dependency?). Without this, the implementer will have to make design decisions that should be captured here.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "consistency",
+      "title": "Spec requires 'block' event but slash-command mapping table has no explicit block trigger",
+      "detail": "The spec defines a 'block' event type under review outcomes, and the slash-command mapping table maps /specflow.review_design and /specflow.review_apply to 'design_review_approved or request_changes'. The 'block' event type is missing from the mapping table rows. This is a spec-level gap, but the design and tasks should note it — the TypeScript types and JSON Schema must still include 'block' as a concrete event type. Task 1.7 should explicitly list all 11 concrete event types to avoid the implementer missing 'block'.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F04",
+      "severity": "low",
+      "category": "granularity",
+      "title": "Task 1.7 is too coarse for 11 concrete payload interfaces",
+      "detail": "Task 1.7 ('Define concrete event type interfaces as discriminated union members') covers all 11 concrete event types and their payload schemas in a single subtask. Consider splitting into approval payloads, reject payload, clarify payloads, resume payload, and review outcome payloads — matching the spec's grouping — to reduce implementation ambiguity and make progress trackable.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R2-F05",
+      "severity": "high",
+      "category": "consistency",
+      "file": "openspec/changes/define-surface-event-contract-for-external-runtimes/tasks.md",
+      "title": "Task 1.7c uses wrong event type names",
+      "detail": "Task 1.7c defines clarify payload interfaces as 'request_clarification' and 'provide_clarification', but the spec defines these concrete event types as 'clarify_request' and 'clarify_response'. This naming mismatch will cause the TypeScript types to diverge from the spec, breaking the JSON Schema alignment and the slash-command mapping table. Fix: rename to 'clarify_request' and 'clarify_response' in task 1.7c.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F06",
+      "severity": "low",
+      "category": "completeness",
+      "file": "openspec/changes/define-surface-event-contract-for-external-runtimes/tasks.md",
+      "title": "Task 4.4a places SurfaceEventContext in the wrong module",
+      "detail": "Task 4.4a says 'Define a SurfaceEventContext interface ... in the canonical contract module'. SurfaceEventContext is a runtime concern (threading orchestrator state into the router) rather than a contract surface consumed by external runtimes. Placing it in src/contracts/surface-events.ts conflates contract types with internal runtime plumbing. Consider defining it in src/lib/phase-router/types.ts alongside the router's own types, or in a separate internal types file. This is low severity because the implementation works either way, but it deviates from the project's convention of keeping src/contracts/ for distributable declarations only.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 4,
+      "open": 4,
+      "new": 4,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 2,
+        "low": 1
+      }
+    },
+    {
+      "round": 2,
+      "total": 6,
+      "open": 3,
+      "new": 2,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "high": 1,
+        "low": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/review-ledger.json
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/review-ledger.json
@@ -1,0 +1,139 @@
+{
+  "feature_id": "define-surface-event-contract-for-external-runtimes",
+  "phase": "impl",
+  "current_round": 2,
+  "status": "in_progress",
+  "max_finding_id": 7,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/lib/phase-router/router.ts",
+      "title": "Hardcoded event_kind and event_type in envelope construction",
+      "detail": "Lines 116-117 hardcode `event_kind: \"approval\"` and `event_type: \"accept_spec\"` for every gated phase emission. The router should derive the concrete event_kind and event_type from the PhaseContract or action metadata, not hardcode them. When a design-review or apply-review phase is gated, it will incorrectly emit an `accept_spec` event instead of the correct type. Fix: map the contract phase (or action.event_kind) to the appropriate EventKind and EventType values.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "src/lib/phase-router/router.ts",
+      "title": "phase_to is always empty string",
+      "detail": "Line 128 hardcodes `phase_to: \"\"` in the ApprovalPayload. The spec defines `phase_to` as 'the phase the workflow transitions to upon approval'. The router has access to the contract and could derive the next phase (e.g., from the contract's `next` field or the action's advance target). An empty string provides no useful information to external consumers.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "assets/global/schemas/surface-events/envelope.schema.json",
+      "title": "JSON Schema uses draft-07, tasks.md specifies draft-2020-12",
+      "detail": "Task 2.5 says 'Validate all schema files parse as valid JSON Schema draft-2020-12', but envelope.schema.json (line 2) declares `$schema: http://json-schema.org/draft-07/schema#`. Either update the schemas to use draft-2020-12 or document the intentional deviation.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/tests/phase-router.test.ts",
+      "title": "Tests do not verify event_type or payload fields",
+      "detail": "The updated phase-router tests check `correlation.run_id`, `schema_version`, and `direction`, but never assert `event_type`, `event_kind`, or the `payload` object. Given that these are the primary new fields on the envelope, test coverage should verify their values — especially to catch F1 if/when different gated phases emit different event types.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F05",
+      "severity": "low",
+      "category": "quality",
+      "file": "src/lib/phase-router/router.ts",
+      "title": "run.change_name access without type evidence",
+      "detail": "Line 110 accesses `run.change_name` with a nullish coalesce to `\"\"`, but `RunState` may not declare a `change_name` field. If the field is optional/undocumented on `RunState`, add it to the type definition or use a safer access pattern. Currently this compiles due to the `as RunState` cast in `readRun`.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F06",
+      "severity": "low",
+      "category": "scope",
+      "file": "src/lib/phase-router/index.ts",
+      "title": "SurfaceEventContext exported from public barrel despite being 'internal'",
+      "detail": "The design doc D5 and the JSDoc in types.ts both describe SurfaceEventContext as 'internal runtime plumbing... NOT part of the distributable contract surface'. However, it is exported from the public barrel file (phase-router/index.ts line 23). This is likely intentional for orchestrator use but contradicts the stated intent. Consider clarifying the doc or removing the public export.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R2-F07",
+      "severity": "low",
+      "category": "correctness",
+      "file": "src/contracts/surface-events.ts",
+      "title": "EVENT_TYPE_TO_KIND maps request_changes and block to 'approval'",
+      "detail": "Lines 203-204 map request_changes → 'approval' and block → 'approval'. Semantically, 'request_changes' and 'block' are rejection/negative outcomes rather than approvals. If the abstract EventKind categories are intentionally coarse (approval = 'review outcome'), this is fine but worth a JSDoc note on the mapping to avoid confusion for external runtime consumers who might filter on event_kind === 'approval' expecting only positive outcomes.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 6,
+      "open": 6,
+      "new": 6,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 3,
+        "low": 2
+      }
+    },
+    {
+      "round": 2,
+      "total": 7,
+      "open": 1,
+      "new": 1,
+      "resolved": 6,
+      "overridden": 0,
+      "by_severity": {
+        "low": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/review-ledger.json.bak
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/review-ledger.json.bak
@@ -1,0 +1,108 @@
+{
+  "feature_id": "define-surface-event-contract-for-external-runtimes",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 6,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/lib/phase-router/router.ts",
+      "title": "Hardcoded event_kind and event_type in envelope construction",
+      "detail": "Lines 116-117 hardcode `event_kind: \"approval\"` and `event_type: \"accept_spec\"` for every gated phase emission. The router should derive the concrete event_kind and event_type from the PhaseContract or action metadata, not hardcode them. When a design-review or apply-review phase is gated, it will incorrectly emit an `accept_spec` event instead of the correct type. Fix: map the contract phase (or action.event_kind) to the appropriate EventKind and EventType values.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "src/lib/phase-router/router.ts",
+      "title": "phase_to is always empty string",
+      "detail": "Line 128 hardcodes `phase_to: \"\"` in the ApprovalPayload. The spec defines `phase_to` as 'the phase the workflow transitions to upon approval'. The router has access to the contract and could derive the next phase (e.g., from the contract's `next` field or the action's advance target). An empty string provides no useful information to external consumers.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "assets/global/schemas/surface-events/envelope.schema.json",
+      "title": "JSON Schema uses draft-07, tasks.md specifies draft-2020-12",
+      "detail": "Task 2.5 says 'Validate all schema files parse as valid JSON Schema draft-2020-12', but envelope.schema.json (line 2) declares `$schema: http://json-schema.org/draft-07/schema#`. Either update the schemas to use draft-2020-12 or document the intentional deviation.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/tests/phase-router.test.ts",
+      "title": "Tests do not verify event_type or payload fields",
+      "detail": "The updated phase-router tests check `correlation.run_id`, `schema_version`, and `direction`, but never assert `event_type`, `event_kind`, or the `payload` object. Given that these are the primary new fields on the envelope, test coverage should verify their values — especially to catch F1 if/when different gated phases emit different event types.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F05",
+      "severity": "low",
+      "category": "quality",
+      "file": "src/lib/phase-router/router.ts",
+      "title": "run.change_name access without type evidence",
+      "detail": "Line 110 accesses `run.change_name` with a nullish coalesce to `\"\"`, but `RunState` may not declare a `change_name` field. If the field is optional/undocumented on `RunState`, add it to the type definition or use a safer access pattern. Currently this compiles due to the `as RunState` cast in `readRun`.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F06",
+      "severity": "low",
+      "category": "scope",
+      "file": "src/lib/phase-router/index.ts",
+      "title": "SurfaceEventContext exported from public barrel despite being 'internal'",
+      "detail": "The design doc D5 and the JSDoc in types.ts both describe SurfaceEventContext as 'internal runtime plumbing... NOT part of the distributable contract surface'. However, it is exported from the public barrel file (phase-router/index.ts line 23). This is likely intentional for orchestrator use but contradicts the stated intent. Consider clarifying the doc or removing the public export.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 6,
+      "open": 6,
+      "new": 6,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 3,
+        "low": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/specs/surface-event-contract/spec.md
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/specs/surface-event-contract/spec.md
@@ -1,0 +1,266 @@
+## ADDED Requirements
+
+### Requirement: Surface event envelope defines the standard message wrapper
+
+The system SHALL define a `SurfaceEventEnvelope` as the standard wrapper for all surface events, both outbound (specflow → surface) and inbound (surface → specflow). The envelope SHALL be transport-agnostic: it defines a pure data schema with no dependency on HTTP, WebSocket, or any other transport mechanism.
+
+The envelope SHALL include the following required fields:
+- `schema_version`: A string identifying the envelope schema version (e.g., `"1.0"`). Consumers SHALL use this field to handle version mismatches.
+- `event_id`: A unique identifier for the event instance.
+- `event_kind`: A string identifying the abstract event category (one of `approval`, `reject`, `clarify`, `resume`).
+- `event_type`: A string identifying the concrete event type (e.g., `accept_spec`, `design_review_approved`).
+- `direction`: A string literal `"outbound"` or `"inbound"` indicating the event flow direction.
+- `timestamp`: An ISO 8601 timestamp of when the event was created.
+- `correlation`: A correlation object (defined in a separate requirement).
+- `actor`: An actor identity object (defined in a separate requirement).
+- `surface`: A surface identity object (defined in a separate requirement).
+- `payload`: An event-type-specific payload object (defined per concrete event type).
+
+#### Scenario: Outbound event envelope is complete
+
+- **WHEN** specflow emits an outbound event to a surface
+- **THEN** the event SHALL conform to the `SurfaceEventEnvelope` schema
+- **AND** `direction` SHALL be `"outbound"`
+- **AND** all required fields SHALL be present and non-null
+
+#### Scenario: Inbound event envelope is complete
+
+- **WHEN** a surface sends an inbound command to specflow
+- **THEN** the command SHALL conform to the `SurfaceEventEnvelope` schema
+- **AND** `direction` SHALL be `"inbound"`
+- **AND** all required fields SHALL be present and non-null
+
+#### Scenario: Schema version enables forward compatibility
+
+- **WHEN** a consumer receives an event with an unrecognized `schema_version`
+- **THEN** the consumer SHALL be able to read `schema_version` before attempting to parse the full payload
+- **AND** the consumer MAY reject the event with a version-mismatch error rather than failing silently
+
+### Requirement: Correlation object provides event traceability
+
+The envelope SHALL include a `correlation` object with the following required fields:
+- `run_id`: The run identifier in `<change_id>-<N>` format.
+- `change_id`: The change identifier.
+
+The correlation object SHALL include the following optional fields:
+- `sequence`: A monotonically increasing integer within a run for ordering events.
+- `caused_by`: The `event_id` of the event that triggered this event (for request-response correlation).
+
+#### Scenario: Correlation links events to a run
+
+- **WHEN** a surface event is created for a workflow run
+- **THEN** the `correlation.run_id` SHALL match the run's `run_id`
+- **AND** the `correlation.change_id` SHALL match the run's `change_name`
+
+#### Scenario: Caused-by enables request-response pairing
+
+- **WHEN** an inbound command is sent in response to an outbound notification
+- **THEN** the inbound event's `correlation.caused_by` SHALL contain the `event_id` of the outbound event it responds to
+
+### Requirement: Actor identity reuses actor-surface-model taxonomy
+
+The envelope's `actor` field SHALL conform to the actor identity model defined in `actor-surface-model`. The event contract module SHALL re-export the actor identity types from `actor-surface-model` so that consumers need only a single import.
+
+The actor identity object SHALL include:
+- `actor`: The actor kind (`human`, `ai-agent`, or `automation`) as defined by the actor-surface-model capability matrix.
+- `actor_id`: A stable identifier for the specific actor instance.
+
+For delegated approval events, the actor identity object SHALL additionally include:
+- `delegated_by`: The actor kind of the delegating actor (always `human`).
+- `delegated_by_id`: The stable identifier of the delegating human actor.
+
+#### Scenario: Actor identity matches actor-surface-model taxonomy
+
+- **WHEN** a surface event is created
+- **THEN** the `actor.actor` field SHALL be one of `human`, `ai-agent`, or `automation`
+- **AND** the `actor.actor_id` field SHALL be a non-empty string
+
+#### Scenario: Re-exported types provide single-import access
+
+- **WHEN** an external consumer imports the event contract module
+- **THEN** the actor identity types SHALL be available without a separate import from `actor-surface-model`
+
+#### Scenario: Delegated approval includes delegating human provenance
+
+- **WHEN** a delegated approval event is created
+- **THEN** the `actor` object SHALL include `delegated_by: "human"` and a non-empty `delegated_by_id`
+
+### Requirement: Surface identity identifies the interaction mediation layer
+
+The envelope's `surface` field SHALL conform to the surface taxonomy defined in `actor-surface-model`. The event contract module SHALL re-export the surface identity types.
+
+The surface identity object SHALL include:
+- `surface`: The surface type (at minimum `local-cli`, `remote-api`, `agent-native`, `batch`) as defined by the actor-surface-model surface taxonomy.
+- `surface_id`: An optional string providing a specific surface instance identifier (e.g., a session ID).
+
+#### Scenario: Surface identity matches surface taxonomy
+
+- **WHEN** a surface event is created
+- **THEN** the `surface.surface` field SHALL be one of the recognized surface types from `actor-surface-model`
+
+#### Scenario: Surface ID is optional
+
+- **WHEN** a surface event is created without a specific surface instance
+- **THEN** the `surface.surface_id` field MAY be omitted or null
+- **AND** the event SHALL still be valid
+
+### Requirement: Event type system uses a hierarchical category-specialization model
+
+The event type system SHALL define 4 abstract categories and their concrete specializations:
+
+**Category `approval`** (gated decisions):
+- `accept_spec` — approve spec to enter design
+- `accept_design` — approve design to enter apply
+- `accept_apply` — approve implementation for final merge
+
+**Category `reject`**:
+- `reject` — irreversible run rejection (human-only per actor-surface-model)
+
+**Category `clarify`**:
+- `clarify_request` — outbound: specflow requests clarification from user
+- `clarify_response` — inbound: user provides clarification answer
+
+**Category `resume`**:
+- `resume` — resume a suspended run
+
+**Review outcomes** (classified under `approval` category as they gate workflow progression):
+- `design_review_approved` — design review passes
+- `apply_review_approved` — apply review passes
+- `request_changes` — reviewer requests changes
+- `block` — reviewer blocks progression
+
+Each concrete event type SHALL have a unique `event_type` string. The `event_kind` field SHALL contain the abstract category name.
+
+#### Scenario: Every concrete event maps to exactly one abstract category
+
+- **WHEN** a concrete event type is inspected
+- **THEN** its `event_kind` SHALL be one of `approval`, `reject`, `clarify`, `resume`
+- **AND** the mapping SHALL be static and deterministic
+
+#### Scenario: Consumers can filter by abstract category
+
+- **WHEN** a consumer subscribes to events by `event_kind`
+- **THEN** it SHALL receive all concrete events within that category
+- **AND** no events from other categories
+
+#### Scenario: Review outcomes are classified under approval category
+
+- **WHEN** `design_review_approved`, `apply_review_approved`, `request_changes`, or `block` is inspected
+- **THEN** its `event_kind` SHALL be `approval`
+
+### Requirement: Each concrete event type defines a fixed payload schema
+
+Each concrete event type SHALL define a payload schema with explicitly declared required and optional fields. External runtimes SHALL be able to validate payloads strictly against the declared schema.
+
+**Approval payloads** (`accept_spec`, `accept_design`, `accept_apply`) SHALL include:
+- `phase_from`: The workflow phase the approval transitions from (required).
+- `phase_to`: The workflow phase the approval transitions to (required).
+
+**Reject payload** SHALL include:
+- `phase_from`: The workflow phase where rejection occurred (required).
+- `reason`: A human-readable rejection reason (optional).
+
+**Clarify request payload** (`clarify_request`, outbound) SHALL include:
+- `question`: The clarification question text (required).
+- `context`: Additional context for the question (optional).
+
+**Clarify response payload** (`clarify_response`, inbound) SHALL include:
+- `answer`: The clarification answer text (required).
+- `question_event_id`: The `event_id` of the corresponding `clarify_request` (required).
+
+**Resume payload** SHALL include:
+- `phase_from`: The phase the run was suspended in (required).
+
+**Review outcome payloads** (`design_review_approved`, `apply_review_approved`, `request_changes`, `block`) SHALL include:
+- `phase_from`: The review phase (required).
+- `reviewer_actor`: The actor identity of the reviewer (required).
+- `summary`: A review summary text (optional).
+- `issues`: An array of review issues (optional, for `request_changes` and `block`).
+
+#### Scenario: Approval payload includes transition phases
+
+- **WHEN** an `accept_spec` event is created
+- **THEN** the payload SHALL include `phase_from` and `phase_to`
+- **AND** both fields SHALL be non-empty strings matching workflow phase names
+
+#### Scenario: Clarify response links to its request
+
+- **WHEN** a `clarify_response` event is created
+- **THEN** the payload SHALL include `question_event_id` referencing the originating `clarify_request`
+- **AND** the `answer` field SHALL be a non-empty string
+
+#### Scenario: Review outcome includes reviewer identity
+
+- **WHEN** a `request_changes` event is created
+- **THEN** the payload SHALL include `reviewer_actor` conforming to the actor identity schema
+- **AND** the payload MAY include `issues` as an array
+
+#### Scenario: Unknown payload fields are tolerated for forward compatibility
+
+- **WHEN** a consumer receives a payload with fields not defined in the current schema version
+- **THEN** the consumer SHALL ignore unknown fields rather than rejecting the event
+- **AND** validation SHALL pass if all required fields are present
+
+### Requirement: Slash-command-to-event mapping is documented as a reference table
+
+The spec SHALL include a normative reference table mapping local slash commands to their corresponding surface event types. This mapping is documentation only — surface adapters are responsible for implementing the translation at runtime. The core workflow SHALL NOT reference or depend on slash command names.
+
+| Slash Command | Direction | Event Type | Event Kind |
+|---------------|-----------|------------|------------|
+| `/specflow.approve` | inbound | `accept_spec`, `accept_design`, or `accept_apply` | `approval` |
+| `/specflow.reject` | inbound | `reject` | `reject` |
+| `/specflow` (clarify phase) | outbound | `clarify_request` | `clarify` |
+| User response to clarify | inbound | `clarify_response` | `clarify` |
+| `/specflow.approve` (resume) | inbound | `resume` | `resume` |
+| `/specflow.review_design` | outbound/inbound | `design_review_approved` or `request_changes` | `approval` |
+| `/specflow.review_apply` | outbound/inbound | `apply_review_approved` or `request_changes` | `approval` |
+
+#### Scenario: Slash command mapping covers all event types
+
+- **WHEN** the reference table is inspected
+- **THEN** every concrete event type defined in this spec SHALL appear in at least one row of the mapping table
+
+#### Scenario: Core workflow does not reference slash commands
+
+- **WHEN** the event contract types and schemas are inspected
+- **THEN** they SHALL NOT contain references to slash command names
+- **AND** the event contract SHALL be usable without any knowledge of the slash command system
+
+### Requirement: Contract is provided as both TypeScript types and JSON Schema
+
+The event contract SHALL be provided in two formats within this repository:
+- **TypeScript type definitions**: Exported from the event contract module under `src/contracts/`. Actor and surface identity types SHALL be re-exported from `actor-surface-model`.
+- **JSON Schema**: Provided as `.json` schema files for language-agnostic consumers.
+
+The TypeScript types SHALL be the source of truth. JSON Schema files SHALL be generated or kept in sync with the TypeScript definitions.
+
+#### Scenario: TypeScript types are importable from contracts
+
+- **WHEN** a TypeScript consumer imports the event contract
+- **THEN** it SHALL have access to `SurfaceEventEnvelope`, all concrete event payload types, actor identity types, and surface identity types from a single module path under `src/contracts/`
+
+#### Scenario: JSON Schema covers the full envelope
+
+- **WHEN** the JSON Schema files are inspected
+- **THEN** there SHALL be a schema for `SurfaceEventEnvelope` that references sub-schemas for correlation, actor, surface, and each concrete payload type
+
+#### Scenario: JSON Schema is included in the distribution bundle
+
+- **WHEN** the build pipeline runs
+- **THEN** JSON Schema files SHALL be included in the distribution bundle as defined by `contract-driven-distribution`
+
+### Requirement: Outbound events conform to phase-router emission contract
+
+Outbound surface events emitted by the `phase-router` for gated decisions SHALL conform to this event contract. The `phase-router` spec's requirement that "the event schema MUST conform to the Surface event contract (#100)" is satisfied by this spec.
+
+#### Scenario: Phase-router gated events use the envelope
+
+- **WHEN** the `phase-router` emits a gated surface event
+- **THEN** the event SHALL conform to `SurfaceEventEnvelope` with `direction: "outbound"`
+- **AND** the `event_type` SHALL match the concrete gated decision type
+
+#### Scenario: Phase-router deduplication is preserved
+
+- **WHEN** the `phase-router` applies its `(runId, phase, event_kind)` deduplication
+- **THEN** the deduplication SHALL operate on the `event_type` field of the envelope
+- **AND** the deduplication logic SHALL NOT be affected by this contract

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/task-graph.json
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/task-graph.json
@@ -1,0 +1,251 @@
+{
+  "version": "1.0",
+  "change_id": "define-surface-event-contract-for-external-runtimes",
+  "bundles": [
+    {
+      "id": "canonical-event-types",
+      "title": "Define canonical surface event TypeScript types",
+      "goal": "Create src/contracts/surface-events.ts with actor/surface identity types and the full SurfaceEventEnvelope discriminated union.",
+      "depends_on": [],
+      "inputs": [
+        "src/contracts/workflow.ts",
+        "src/core/types.ts",
+        "src/lib/phase-router/types.ts"
+      ],
+      "outputs": [
+        "src/contracts/surface-events.ts"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Define ActorKind string literal union and ActorIdentity interface (D2)",
+          "status": "pending"
+        },
+        {
+          "id": "2",
+          "title": "Define SurfaceKind string literal union and SurfaceIdentity interface (D2)",
+          "status": "pending"
+        },
+        {
+          "id": "3",
+          "title": "Define EventDirection ('inbound' | 'outbound') string literal union (D4)",
+          "status": "pending"
+        },
+        {
+          "id": "4",
+          "title": "Define EventKind and EventType string literal unions for the discriminant fields (D4)",
+          "status": "pending"
+        },
+        {
+          "id": "5",
+          "title": "Define CorrelationContext interface with optional sequence field (D7)",
+          "status": "pending"
+        },
+        {
+          "id": "6",
+          "title": "Define SurfaceEventEnvelope interface with schema_version '1.0', all required fields, and readonly modifiers (D1, D6)",
+          "status": "pending"
+        },
+        {
+          "id": "7",
+          "title": "Define concrete event type interfaces as discriminated union members of SurfaceEventEnvelope",
+          "status": "pending"
+        },
+        {
+          "id": "8",
+          "title": "Export all public types from the module",
+          "status": "pending"
+        },
+        {
+          "id": "9",
+          "title": "Verify the module compiles with tsc and passes lint",
+          "status": "pending"
+        }
+      ],
+      "owner_capabilities": [
+        "actor-surface-model",
+        "contract-driven-distribution"
+      ]
+    },
+    {
+      "id": "json-schema-definitions",
+      "title": "Create JSON Schema files for surface events",
+      "goal": "Author JSON Schema files under assets/global/schemas/surface-events/ that mirror each concrete event type for language-agnostic consumers.",
+      "depends_on": [
+        "canonical-event-types"
+      ],
+      "inputs": [
+        "src/contracts/surface-events.ts"
+      ],
+      "outputs": [
+        "assets/global/schemas/surface-events/"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Create assets/global/schemas/surface-events/ directory",
+          "status": "pending"
+        },
+        {
+          "id": "2",
+          "title": "Author envelope.schema.json defining the base SurfaceEventEnvelope with schema_version, discriminant fields, and correlation",
+          "status": "pending"
+        },
+        {
+          "id": "3",
+          "title": "Author individual .schema.json files for each concrete event type (one per event_type discriminant)",
+          "status": "pending"
+        },
+        {
+          "id": "4",
+          "title": "Author actor-identity.schema.json and surface-identity.schema.json for the identity sub-objects",
+          "status": "pending"
+        },
+        {
+          "id": "5",
+          "title": "Validate all schema files parse as valid JSON Schema draft-2020-12",
+          "status": "pending"
+        }
+      ],
+      "owner_capabilities": [
+        "contract-driven-distribution",
+        "actor-surface-model"
+      ]
+    },
+    {
+      "id": "distribution-wiring",
+      "title": "Wire schema distribution via install contract",
+      "goal": "Add an InstallCopyContract entry in src/contracts/install.ts so the distribution bundle copies global/schemas/ to the user config directory.",
+      "depends_on": [
+        "json-schema-definitions"
+      ],
+      "inputs": [
+        "src/contracts/install.ts",
+        "assets/global/schemas/surface-events/"
+      ],
+      "outputs": [
+        "src/contracts/install.ts"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Add InstallCopyContract entry for global/schemas → $HOME/.config/specflow/global/schemas in installCopies array",
+          "status": "pending"
+        },
+        {
+          "id": "2",
+          "title": "Verify the contracts bundle exports the updated installCopies and compiles cleanly",
+          "status": "pending"
+        }
+      ],
+      "owner_capabilities": [
+        "contract-driven-distribution"
+      ]
+    },
+    {
+      "id": "phase-router-migration",
+      "title": "Replace phase-router placeholder SurfaceEvent with canonical import",
+      "goal": "Remove the placeholder SurfaceEvent and SurfaceEventSink from phase-router/types.ts and replace with imports from the canonical contract module.",
+      "depends_on": [
+        "canonical-event-types"
+      ],
+      "inputs": [
+        "src/lib/phase-router/types.ts",
+        "src/lib/phase-router/",
+        "src/contracts/surface-events.ts"
+      ],
+      "outputs": [
+        "src/lib/phase-router/types.ts",
+        "src/lib/phase-router/"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Import SurfaceEventEnvelope from src/contracts/surface-events.ts into phase-router/types.ts",
+          "status": "pending"
+        },
+        {
+          "id": "2",
+          "title": "Remove the placeholder SurfaceEvent interface and replace the type alias with re-export from canonical module",
+          "status": "pending"
+        },
+        {
+          "id": "3",
+          "title": "Update SurfaceEventSink to accept SurfaceEventEnvelope (or re-export canonical SurfaceEventSink if defined)",
+          "status": "pending"
+        },
+        {
+          "id": "4",
+          "title": "Update phase-router emit call sites to construct full SurfaceEventEnvelope with actor, surface, and correlation fields from orchestrator context (D5)",
+          "status": "pending"
+        },
+        {
+          "id": "5",
+          "title": "Update existing phase-router test fixtures to use the expanded envelope shape",
+          "status": "pending"
+        },
+        {
+          "id": "6",
+          "title": "Run phase-router unit tests and verify all pass",
+          "status": "pending"
+        }
+      ],
+      "owner_capabilities": [
+        "phase-router"
+      ]
+    },
+    {
+      "id": "schema-drift-test",
+      "title": "Add build-time test for TypeScript/JSON Schema consistency",
+      "goal": "Create a test that parses JSON Schema files and validates them against sample TypeScript objects to detect drift between the two representations.",
+      "depends_on": [
+        "canonical-event-types",
+        "json-schema-definitions"
+      ],
+      "inputs": [
+        "src/contracts/surface-events.ts",
+        "assets/global/schemas/surface-events/"
+      ],
+      "outputs": [
+        "src/__tests__/surface-event-schema-drift.test.ts"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Create test file that loads each JSON Schema from assets/global/schemas/surface-events/",
+          "status": "pending"
+        },
+        {
+          "id": "2",
+          "title": "Construct sample SurfaceEventEnvelope objects (one per concrete event type) using the TypeScript types",
+          "status": "pending"
+        },
+        {
+          "id": "3",
+          "title": "Validate each sample object against its corresponding JSON Schema using a schema validator (e.g., ajv)",
+          "status": "pending"
+        },
+        {
+          "id": "4",
+          "title": "Add negative test cases: objects with missing required fields must fail validation",
+          "status": "pending"
+        },
+        {
+          "id": "5",
+          "title": "Verify test passes in CI (build + test)",
+          "status": "pending"
+        }
+      ],
+      "owner_capabilities": [
+        "contract-driven-distribution"
+      ]
+    }
+  ],
+  "generated_at": "2026-04-15T01:48:51.061Z",
+  "generated_from": "design.md"
+}

--- a/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/tasks.md
+++ b/openspec/changes/archive/2026-04-15-define-surface-event-contract-for-external-runtimes/tasks.md
@@ -1,0 +1,67 @@
+## 1. Define canonical surface event TypeScript types
+
+> Create src/contracts/surface-events.ts with actor/surface identity types and the full SurfaceEventEnvelope discriminated union.
+
+- [ ] 1.1 Define ActorKind string literal union and ActorIdentity interface (D2)
+- [ ] 1.2 Define SurfaceKind string literal union and SurfaceIdentity interface (D2)
+- [ ] 1.3 Define EventDirection ('inbound' | 'outbound') string literal union (D4)
+- [ ] 1.4 Define EventKind and EventType string literal unions for the discriminant fields (D4)
+- [ ] 1.5 Define CorrelationContext interface with optional sequence field (D7)
+- [ ] 1.6 Define SurfaceEventEnvelope interface with schema_version '1.0', all required fields, and readonly modifiers (D1, D6)
+- [ ] 1.7a Define approval payload interfaces: accept_spec, accept_design, accept_apply (3 concrete event types)
+- [ ] 1.7b Define reject payload interface: reject (1 concrete event type)
+- [ ] 1.7c Define clarify payload interfaces: clarify_request, clarify_response (2 concrete event types)
+- [ ] 1.7d Define resume payload interface: resume (1 concrete event type)
+- [ ] 1.7e Define review outcome payload interfaces: design_review_approved, apply_review_approved, request_changes, block (4 concrete event types)
+- [ ] 1.7f Combine all 11 concrete event type interfaces into a discriminated union type. The complete list of concrete event types is: accept_spec, accept_design, accept_apply, reject, clarify_request, clarify_response, resume, design_review_approved, apply_review_approved, request_changes, block
+- [ ] 1.8 Export all public types from the module
+- [ ] 1.9 Verify the module compiles with tsc and passes lint
+
+## 2. Create JSON Schema files for surface events
+
+> Author JSON Schema files under assets/global/schemas/surface-events/ that mirror each concrete event type for language-agnostic consumers.
+
+> Depends on: canonical-event-types
+
+- [ ] 2.1 Create assets/global/schemas/surface-events/ directory
+- [ ] 2.2 Author envelope.schema.json defining the base SurfaceEventEnvelope with schema_version, discriminant fields, and correlation
+- [ ] 2.3 Author individual .schema.json files for each concrete event type (one per event_type discriminant)
+- [ ] 2.4 Author actor-identity.schema.json and surface-identity.schema.json for the identity sub-objects
+- [ ] 2.5 Validate all schema files parse as valid JSON Schema draft-2020-12
+
+## 3. Wire schema distribution via install contract
+
+> Add an InstallCopyContract entry in src/contracts/install.ts so the distribution bundle copies global/schemas/ to the user config directory.
+
+> Depends on: json-schema-definitions
+
+- [ ] 3.1 Add InstallCopyContract entry for global/schemas → $HOME/.config/specflow/global/schemas in installCopies array
+- [ ] 3.2 Verify the contracts bundle exports the updated installCopies and compiles cleanly
+
+## 4. Replace phase-router placeholder SurfaceEvent with canonical import
+
+> Remove the placeholder SurfaceEvent and SurfaceEventSink from phase-router/types.ts and replace with imports from the canonical contract module.
+
+> Depends on: canonical-event-types
+
+- [ ] 4.1 Import SurfaceEventEnvelope from src/contracts/surface-events.ts into phase-router/types.ts
+- [ ] 4.2 Remove the placeholder SurfaceEvent interface and replace the type alias with re-export from canonical module
+- [ ] 4.3 Update SurfaceEventSink to accept SurfaceEventEnvelope (or re-export canonical SurfaceEventSink if defined)
+- [ ] 4.4a Define a SurfaceEventContext interface (actor: ActorIdentity, surface: SurfaceIdentity, correlation: CorrelationContext) in src/lib/phase-router/types.ts (D5). SurfaceEventContext is internal runtime plumbing for threading orchestrator state into the router, not a distributable contract surface — it belongs alongside the router's own types, not in src/contracts/.
+- [ ] 4.4b Update createPhaseRouter (or its emit helper) function signature to accept SurfaceEventContext as a parameter (D5)
+- [ ] 4.4c Update emit call sites to construct full SurfaceEventEnvelope using the threaded context and crypto.randomUUID() for event_id (D5)
+- [ ] 4.5 Update existing phase-router test fixtures to use the expanded envelope shape
+- [ ] 4.6 Run phase-router unit tests and verify all pass
+
+## 5. Add build-time test for TypeScript/JSON Schema consistency
+
+> Create a test that parses JSON Schema files and validates them against sample TypeScript objects to detect drift between the two representations.
+
+> Depends on: canonical-event-types, json-schema-definitions
+
+- [ ] 5.0 Add ajv as a devDependency (npm install --save-dev ajv)
+- [ ] 5.1 Create test file that loads each JSON Schema from assets/global/schemas/surface-events/
+- [ ] 5.2 Construct sample SurfaceEventEnvelope objects (one per concrete event type) using the TypeScript types
+- [ ] 5.3 Validate each sample object against its corresponding JSON Schema using a schema validator (e.g., ajv)
+- [ ] 5.4 Add negative test cases: objects with missing required fields must fail validation
+- [ ] 5.5 Verify test passes in CI (build + test)

--- a/openspec/specs/surface-event-contract/spec.md
+++ b/openspec/specs/surface-event-contract/spec.md
@@ -1,0 +1,270 @@
+# surface-event-contract Specification
+
+## Purpose
+TBD - created by archiving change define-surface-event-contract-for-external-runtimes. Update Purpose after archive.
+## Requirements
+### Requirement: Surface event envelope defines the standard message wrapper
+
+The system SHALL define a `SurfaceEventEnvelope` as the standard wrapper for all surface events, both outbound (specflow → surface) and inbound (surface → specflow). The envelope SHALL be transport-agnostic: it defines a pure data schema with no dependency on HTTP, WebSocket, or any other transport mechanism.
+
+The envelope SHALL include the following required fields:
+- `schema_version`: A string identifying the envelope schema version (e.g., `"1.0"`). Consumers SHALL use this field to handle version mismatches.
+- `event_id`: A unique identifier for the event instance.
+- `event_kind`: A string identifying the abstract event category (one of `approval`, `reject`, `clarify`, `resume`).
+- `event_type`: A string identifying the concrete event type (e.g., `accept_spec`, `design_review_approved`).
+- `direction`: A string literal `"outbound"` or `"inbound"` indicating the event flow direction.
+- `timestamp`: An ISO 8601 timestamp of when the event was created.
+- `correlation`: A correlation object (defined in a separate requirement).
+- `actor`: An actor identity object (defined in a separate requirement).
+- `surface`: A surface identity object (defined in a separate requirement).
+- `payload`: An event-type-specific payload object (defined per concrete event type).
+
+#### Scenario: Outbound event envelope is complete
+
+- **WHEN** specflow emits an outbound event to a surface
+- **THEN** the event SHALL conform to the `SurfaceEventEnvelope` schema
+- **AND** `direction` SHALL be `"outbound"`
+- **AND** all required fields SHALL be present and non-null
+
+#### Scenario: Inbound event envelope is complete
+
+- **WHEN** a surface sends an inbound command to specflow
+- **THEN** the command SHALL conform to the `SurfaceEventEnvelope` schema
+- **AND** `direction` SHALL be `"inbound"`
+- **AND** all required fields SHALL be present and non-null
+
+#### Scenario: Schema version enables forward compatibility
+
+- **WHEN** a consumer receives an event with an unrecognized `schema_version`
+- **THEN** the consumer SHALL be able to read `schema_version` before attempting to parse the full payload
+- **AND** the consumer MAY reject the event with a version-mismatch error rather than failing silently
+
+### Requirement: Correlation object provides event traceability
+
+The envelope SHALL include a `correlation` object with the following required fields:
+- `run_id`: The run identifier in `<change_id>-<N>` format.
+- `change_id`: The change identifier.
+
+The correlation object SHALL include the following optional fields:
+- `sequence`: A monotonically increasing integer within a run for ordering events.
+- `caused_by`: The `event_id` of the event that triggered this event (for request-response correlation).
+
+#### Scenario: Correlation links events to a run
+
+- **WHEN** a surface event is created for a workflow run
+- **THEN** the `correlation.run_id` SHALL match the run's `run_id`
+- **AND** the `correlation.change_id` SHALL match the run's `change_name`
+
+#### Scenario: Caused-by enables request-response pairing
+
+- **WHEN** an inbound command is sent in response to an outbound notification
+- **THEN** the inbound event's `correlation.caused_by` SHALL contain the `event_id` of the outbound event it responds to
+
+### Requirement: Actor identity reuses actor-surface-model taxonomy
+
+The envelope's `actor` field SHALL conform to the actor identity model defined in `actor-surface-model`. The event contract module SHALL re-export the actor identity types from `actor-surface-model` so that consumers need only a single import.
+
+The actor identity object SHALL include:
+- `actor`: The actor kind (`human`, `ai-agent`, or `automation`) as defined by the actor-surface-model capability matrix.
+- `actor_id`: A stable identifier for the specific actor instance.
+
+For delegated approval events, the actor identity object SHALL additionally include:
+- `delegated_by`: The actor kind of the delegating actor (always `human`).
+- `delegated_by_id`: The stable identifier of the delegating human actor.
+
+#### Scenario: Actor identity matches actor-surface-model taxonomy
+
+- **WHEN** a surface event is created
+- **THEN** the `actor.actor` field SHALL be one of `human`, `ai-agent`, or `automation`
+- **AND** the `actor.actor_id` field SHALL be a non-empty string
+
+#### Scenario: Re-exported types provide single-import access
+
+- **WHEN** an external consumer imports the event contract module
+- **THEN** the actor identity types SHALL be available without a separate import from `actor-surface-model`
+
+#### Scenario: Delegated approval includes delegating human provenance
+
+- **WHEN** a delegated approval event is created
+- **THEN** the `actor` object SHALL include `delegated_by: "human"` and a non-empty `delegated_by_id`
+
+### Requirement: Surface identity identifies the interaction mediation layer
+
+The envelope's `surface` field SHALL conform to the surface taxonomy defined in `actor-surface-model`. The event contract module SHALL re-export the surface identity types.
+
+The surface identity object SHALL include:
+- `surface`: The surface type (at minimum `local-cli`, `remote-api`, `agent-native`, `batch`) as defined by the actor-surface-model surface taxonomy.
+- `surface_id`: An optional string providing a specific surface instance identifier (e.g., a session ID).
+
+#### Scenario: Surface identity matches surface taxonomy
+
+- **WHEN** a surface event is created
+- **THEN** the `surface.surface` field SHALL be one of the recognized surface types from `actor-surface-model`
+
+#### Scenario: Surface ID is optional
+
+- **WHEN** a surface event is created without a specific surface instance
+- **THEN** the `surface.surface_id` field MAY be omitted or null
+- **AND** the event SHALL still be valid
+
+### Requirement: Event type system uses a hierarchical category-specialization model
+
+The event type system SHALL define 4 abstract categories and their concrete specializations:
+
+**Category `approval`** (gated decisions):
+- `accept_spec` — approve spec to enter design
+- `accept_design` — approve design to enter apply
+- `accept_apply` — approve implementation for final merge
+
+**Category `reject`**:
+- `reject` — irreversible run rejection (human-only per actor-surface-model)
+
+**Category `clarify`**:
+- `clarify_request` — outbound: specflow requests clarification from user
+- `clarify_response` — inbound: user provides clarification answer
+
+**Category `resume`**:
+- `resume` — resume a suspended run
+
+**Review outcomes** (classified under `approval` category as they gate workflow progression):
+- `design_review_approved` — design review passes
+- `apply_review_approved` — apply review passes
+- `request_changes` — reviewer requests changes
+- `block` — reviewer blocks progression
+
+Each concrete event type SHALL have a unique `event_type` string. The `event_kind` field SHALL contain the abstract category name.
+
+#### Scenario: Every concrete event maps to exactly one abstract category
+
+- **WHEN** a concrete event type is inspected
+- **THEN** its `event_kind` SHALL be one of `approval`, `reject`, `clarify`, `resume`
+- **AND** the mapping SHALL be static and deterministic
+
+#### Scenario: Consumers can filter by abstract category
+
+- **WHEN** a consumer subscribes to events by `event_kind`
+- **THEN** it SHALL receive all concrete events within that category
+- **AND** no events from other categories
+
+#### Scenario: Review outcomes are classified under approval category
+
+- **WHEN** `design_review_approved`, `apply_review_approved`, `request_changes`, or `block` is inspected
+- **THEN** its `event_kind` SHALL be `approval`
+
+### Requirement: Each concrete event type defines a fixed payload schema
+
+Each concrete event type SHALL define a payload schema with explicitly declared required and optional fields. External runtimes SHALL be able to validate payloads strictly against the declared schema.
+
+**Approval payloads** (`accept_spec`, `accept_design`, `accept_apply`) SHALL include:
+- `phase_from`: The workflow phase the approval transitions from (required).
+- `phase_to`: The workflow phase the approval transitions to (required).
+
+**Reject payload** SHALL include:
+- `phase_from`: The workflow phase where rejection occurred (required).
+- `reason`: A human-readable rejection reason (optional).
+
+**Clarify request payload** (`clarify_request`, outbound) SHALL include:
+- `question`: The clarification question text (required).
+- `context`: Additional context for the question (optional).
+
+**Clarify response payload** (`clarify_response`, inbound) SHALL include:
+- `answer`: The clarification answer text (required).
+- `question_event_id`: The `event_id` of the corresponding `clarify_request` (required).
+
+**Resume payload** SHALL include:
+- `phase_from`: The phase the run was suspended in (required).
+
+**Review outcome payloads** (`design_review_approved`, `apply_review_approved`, `request_changes`, `block`) SHALL include:
+- `phase_from`: The review phase (required).
+- `reviewer_actor`: The actor identity of the reviewer (required).
+- `summary`: A review summary text (optional).
+- `issues`: An array of review issues (optional, for `request_changes` and `block`).
+
+#### Scenario: Approval payload includes transition phases
+
+- **WHEN** an `accept_spec` event is created
+- **THEN** the payload SHALL include `phase_from` and `phase_to`
+- **AND** both fields SHALL be non-empty strings matching workflow phase names
+
+#### Scenario: Clarify response links to its request
+
+- **WHEN** a `clarify_response` event is created
+- **THEN** the payload SHALL include `question_event_id` referencing the originating `clarify_request`
+- **AND** the `answer` field SHALL be a non-empty string
+
+#### Scenario: Review outcome includes reviewer identity
+
+- **WHEN** a `request_changes` event is created
+- **THEN** the payload SHALL include `reviewer_actor` conforming to the actor identity schema
+- **AND** the payload MAY include `issues` as an array
+
+#### Scenario: Unknown payload fields are tolerated for forward compatibility
+
+- **WHEN** a consumer receives a payload with fields not defined in the current schema version
+- **THEN** the consumer SHALL ignore unknown fields rather than rejecting the event
+- **AND** validation SHALL pass if all required fields are present
+
+### Requirement: Slash-command-to-event mapping is documented as a reference table
+
+The spec SHALL include a normative reference table mapping local slash commands to their corresponding surface event types. This mapping is documentation only — surface adapters are responsible for implementing the translation at runtime. The core workflow SHALL NOT reference or depend on slash command names.
+
+| Slash Command | Direction | Event Type | Event Kind |
+|---------------|-----------|------------|------------|
+| `/specflow.approve` | inbound | `accept_spec`, `accept_design`, or `accept_apply` | `approval` |
+| `/specflow.reject` | inbound | `reject` | `reject` |
+| `/specflow` (clarify phase) | outbound | `clarify_request` | `clarify` |
+| User response to clarify | inbound | `clarify_response` | `clarify` |
+| `/specflow.approve` (resume) | inbound | `resume` | `resume` |
+| `/specflow.review_design` | outbound/inbound | `design_review_approved` or `request_changes` | `approval` |
+| `/specflow.review_apply` | outbound/inbound | `apply_review_approved` or `request_changes` | `approval` |
+
+#### Scenario: Slash command mapping covers all event types
+
+- **WHEN** the reference table is inspected
+- **THEN** every concrete event type defined in this spec SHALL appear in at least one row of the mapping table
+
+#### Scenario: Core workflow does not reference slash commands
+
+- **WHEN** the event contract types and schemas are inspected
+- **THEN** they SHALL NOT contain references to slash command names
+- **AND** the event contract SHALL be usable without any knowledge of the slash command system
+
+### Requirement: Contract is provided as both TypeScript types and JSON Schema
+
+The event contract SHALL be provided in two formats within this repository:
+- **TypeScript type definitions**: Exported from the event contract module under `src/contracts/`. Actor and surface identity types SHALL be re-exported from `actor-surface-model`.
+- **JSON Schema**: Provided as `.json` schema files for language-agnostic consumers.
+
+The TypeScript types SHALL be the source of truth. JSON Schema files SHALL be generated or kept in sync with the TypeScript definitions.
+
+#### Scenario: TypeScript types are importable from contracts
+
+- **WHEN** a TypeScript consumer imports the event contract
+- **THEN** it SHALL have access to `SurfaceEventEnvelope`, all concrete event payload types, actor identity types, and surface identity types from a single module path under `src/contracts/`
+
+#### Scenario: JSON Schema covers the full envelope
+
+- **WHEN** the JSON Schema files are inspected
+- **THEN** there SHALL be a schema for `SurfaceEventEnvelope` that references sub-schemas for correlation, actor, surface, and each concrete payload type
+
+#### Scenario: JSON Schema is included in the distribution bundle
+
+- **WHEN** the build pipeline runs
+- **THEN** JSON Schema files SHALL be included in the distribution bundle as defined by `contract-driven-distribution`
+
+### Requirement: Outbound events conform to phase-router emission contract
+
+Outbound surface events emitted by the `phase-router` for gated decisions SHALL conform to this event contract. The `phase-router` spec's requirement that "the event schema MUST conform to the Surface event contract (#100)" is satisfied by this spec.
+
+#### Scenario: Phase-router gated events use the envelope
+
+- **WHEN** the `phase-router` emits a gated surface event
+- **THEN** the event SHALL conform to `SurfaceEventEnvelope` with `direction: "outbound"`
+- **AND** the `event_type` SHALL match the concrete gated decision type
+
+#### Scenario: Phase-router deduplication is preserved
+
+- **WHEN** the `phase-router` applies its `(runId, phase, event_kind)` deduplication
+- **THEN** the deduplication SHALL operate on the `event_type` field of the envelope
+- **AND** the deduplication logic SHALL NOT be affected by this contract
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,21 +13,23 @@
 			},
 			"bin": {
 				"specflow-analyze": "bin/specflow-analyze",
+				"specflow-challenge-proposal": "bin/specflow-challenge-proposal",
 				"specflow-create-sub-issues": "bin/specflow-create-sub-issues",
 				"specflow-design-artifacts": "bin/specflow-design-artifacts",
 				"specflow-fetch-issue": "bin/specflow-fetch-issue",
 				"specflow-filter-diff": "bin/specflow-filter-diff",
+				"specflow-generate-task-graph": "bin/specflow-generate-task-graph",
 				"specflow-init": "bin/specflow-init",
 				"specflow-install": "bin/specflow-install",
 				"specflow-prepare-change": "bin/specflow-prepare-change",
 				"specflow-review-apply": "bin/specflow-review-apply",
 				"specflow-review-design": "bin/specflow-review-design",
-				"specflow-review-proposal": "bin/specflow-review-proposal",
 				"specflow-run": "bin/specflow-run"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.11",
 				"@types/node": "^25.5.2",
+				"ajv": "^8.18.0",
 				"c8": "^11.0.0",
 				"prettier": "^3.8.1",
 				"typescript": "^5.6.0"
@@ -259,6 +261,23 @@
 				"undici-types": "~7.18.0"
 			}
 		},
+		"node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -416,6 +435,30 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -550,6 +593,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -708,6 +758,16 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.11",
 		"@types/node": "^25.5.2",
+		"ajv": "^8.18.0",
 		"c8": "^11.0.0",
 		"prettier": "^3.8.1",
 		"typescript": "^5.6.0"

--- a/src/contracts/install.ts
+++ b/src/contracts/install.ts
@@ -47,6 +47,13 @@ const installCopies: readonly InstallCopyContract[] = [
 		targetPath: "$HOME/.config/specflow/global/commands",
 		sourceKind: "directory",
 	},
+	{
+		id: "copy-global-schemas",
+		type: AssetType.InstallerAsset,
+		sourcePath: "global/schemas",
+		targetPath: "$HOME/.config/specflow/global/schemas",
+		sourceKind: "directory",
+	},
 ];
 
 const installLinks: readonly InstallLinkContract[] = orchestratorContracts.map(

--- a/src/contracts/surface-events.ts
+++ b/src/contracts/surface-events.ts
@@ -1,0 +1,238 @@
+// Surface Event Contract — canonical types for the bidirectional event envelope.
+//
+// This module defines the surface-neutral event contract that external runtimes
+// and future surfaces reference to interoperate with specflow workflows.
+// Actor/surface identity types are defined here (D2) and re-exported so
+// consumers need only a single import path.
+
+// ---------------------------------------------------------------------------
+// Actor Identity (actor-surface-model taxonomy)
+// ---------------------------------------------------------------------------
+
+/** Actor kinds recognised by the actor-surface capability matrix. */
+export type ActorKind = "human" | "ai-agent" | "automation";
+
+/** Identity of the actor that initiated or received the event. */
+export interface ActorIdentity {
+	readonly actor: ActorKind;
+	readonly actor_id: string;
+	/** Present only on delegated approval events. */
+	readonly delegated_by?: "human";
+	/** Stable id of the delegating human — present iff delegated_by is set. */
+	readonly delegated_by_id?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Surface Identity (actor-surface-model taxonomy)
+// ---------------------------------------------------------------------------
+
+/** Surface types recognised by the surface taxonomy. */
+export type SurfaceKind = "local-cli" | "remote-api" | "agent-native" | "batch";
+
+/** Identity of the surface through which the event flows. */
+export interface SurfaceIdentity {
+	readonly surface: SurfaceKind;
+	/** Optional instance identifier (e.g., session id). */
+	readonly surface_id?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Event direction
+// ---------------------------------------------------------------------------
+
+/** Direction of the event relative to specflow. */
+export type EventDirection = "inbound" | "outbound";
+
+// ---------------------------------------------------------------------------
+// Event type hierarchy
+// ---------------------------------------------------------------------------
+
+/** Abstract event categories. */
+export type EventKind = "approval" | "reject" | "clarify" | "resume";
+
+/** All concrete event types across every category. */
+export type EventType =
+	| "accept_spec"
+	| "accept_design"
+	| "accept_apply"
+	| "reject"
+	| "clarify_request"
+	| "clarify_response"
+	| "resume"
+	| "design_review_approved"
+	| "apply_review_approved"
+	| "request_changes"
+	| "block";
+
+// ---------------------------------------------------------------------------
+// Correlation
+// ---------------------------------------------------------------------------
+
+/** Traceability context linking the event to a workflow run. */
+export interface CorrelationContext {
+	readonly run_id: string;
+	readonly change_id: string;
+	/** Monotonically increasing within a run — optional, caller-assigned. */
+	readonly sequence?: number;
+	/** event_id of the event that triggered this one (request-response). */
+	readonly caused_by?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Concrete event payloads
+// ---------------------------------------------------------------------------
+
+/** Payload for approval events (accept_spec, accept_design, accept_apply). */
+export interface ApprovalPayload {
+	readonly phase_from: string;
+	readonly phase_to: string;
+}
+
+/** Payload for the reject event. */
+export interface RejectPayload {
+	readonly phase_from: string;
+	readonly reason?: string;
+}
+
+/** Payload for outbound clarify_request. */
+export interface ClarifyRequestPayload {
+	readonly question: string;
+	readonly context?: string;
+}
+
+/** Payload for inbound clarify_response. */
+export interface ClarifyResponsePayload {
+	readonly answer: string;
+	readonly question_event_id: string;
+}
+
+/** Payload for the resume event. */
+export interface ResumePayload {
+	readonly phase_from: string;
+}
+
+/** Shared review issue entry. */
+export interface ReviewIssue {
+	readonly id: string;
+	readonly severity: string;
+	readonly detail: string;
+}
+
+/** Payload for review outcome events. */
+export interface ReviewOutcomePayload {
+	readonly phase_from: string;
+	readonly reviewer_actor: ActorIdentity;
+	readonly summary?: string;
+	readonly issues?: readonly ReviewIssue[];
+}
+
+// ---------------------------------------------------------------------------
+// Payload union keyed by EventType
+// ---------------------------------------------------------------------------
+
+export type EventPayloadMap = {
+	readonly accept_spec: ApprovalPayload;
+	readonly accept_design: ApprovalPayload;
+	readonly accept_apply: ApprovalPayload;
+	readonly reject: RejectPayload;
+	readonly clarify_request: ClarifyRequestPayload;
+	readonly clarify_response: ClarifyResponsePayload;
+	readonly resume: ResumePayload;
+	readonly design_review_approved: ReviewOutcomePayload;
+	readonly apply_review_approved: ReviewOutcomePayload;
+	readonly request_changes: ReviewOutcomePayload;
+	readonly block: ReviewOutcomePayload;
+};
+
+// ---------------------------------------------------------------------------
+// Surface Event Envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * The standard bidirectional, transport-agnostic event envelope.
+ *
+ * Generic over `T extends EventType` so each concrete event carries a
+ * correctly-typed payload.
+ */
+export interface SurfaceEventEnvelope<T extends EventType = EventType> {
+	readonly schema_version: "1.0";
+	readonly event_id: string;
+	readonly event_kind: EventKind;
+	readonly event_type: T;
+	readonly direction: EventDirection;
+	readonly timestamp: string;
+	readonly correlation: CorrelationContext;
+	readonly actor: ActorIdentity;
+	readonly surface: SurfaceIdentity;
+	readonly payload: EventPayloadMap[T];
+}
+
+// ---------------------------------------------------------------------------
+// Concrete event type aliases (convenience)
+// ---------------------------------------------------------------------------
+
+export type AcceptSpecEvent = SurfaceEventEnvelope<"accept_spec">;
+export type AcceptDesignEvent = SurfaceEventEnvelope<"accept_design">;
+export type AcceptApplyEvent = SurfaceEventEnvelope<"accept_apply">;
+export type RejectEvent = SurfaceEventEnvelope<"reject">;
+export type ClarifyRequestEvent = SurfaceEventEnvelope<"clarify_request">;
+export type ClarifyResponseEvent = SurfaceEventEnvelope<"clarify_response">;
+export type ResumeEvent = SurfaceEventEnvelope<"resume">;
+export type DesignReviewApprovedEvent =
+	SurfaceEventEnvelope<"design_review_approved">;
+export type ApplyReviewApprovedEvent =
+	SurfaceEventEnvelope<"apply_review_approved">;
+export type RequestChangesEvent = SurfaceEventEnvelope<"request_changes">;
+export type BlockEvent = SurfaceEventEnvelope<"block">;
+
+// ---------------------------------------------------------------------------
+// EventType → EventKind mapping (runtime lookup for envelope construction)
+// ---------------------------------------------------------------------------
+
+/** Maps each concrete EventType to its abstract EventKind category. */
+export const EVENT_TYPE_TO_KIND: Readonly<Record<EventType, EventKind>> = {
+	accept_spec: "approval",
+	accept_design: "approval",
+	accept_apply: "approval",
+	reject: "reject",
+	clarify_request: "clarify",
+	clarify_response: "clarify",
+	resume: "resume",
+	design_review_approved: "approval",
+	apply_review_approved: "approval",
+	request_changes: "approval",
+	block: "approval",
+};
+
+/** Union of all concrete surface events. */
+export type SurfaceEvent =
+	| AcceptSpecEvent
+	| AcceptDesignEvent
+	| AcceptApplyEvent
+	| RejectEvent
+	| ClarifyRequestEvent
+	| ClarifyResponseEvent
+	| ResumeEvent
+	| DesignReviewApprovedEvent
+	| ApplyReviewApprovedEvent
+	| RequestChangesEvent
+	| BlockEvent;
+
+// ---------------------------------------------------------------------------
+// Event kind → concrete type mapping (static, for category filtering)
+// ---------------------------------------------------------------------------
+
+/** Maps each EventKind to its concrete EventType members. */
+export type EventKindToTypes = {
+	readonly approval:
+		| "accept_spec"
+		| "accept_design"
+		| "accept_apply"
+		| "design_review_approved"
+		| "apply_review_approved"
+		| "request_changes"
+		| "block";
+	readonly reject: "reject";
+	readonly clarify: "clarify_request" | "clarify_response";
+	readonly resume: "resume";
+};

--- a/src/generators/static-assets.ts
+++ b/src/generators/static-assets.ts
@@ -6,4 +6,8 @@ export function renderStaticAssets(): void {
 		fromRepo("assets/global/claude-settings.json"),
 		fromDistribution("global/claude-settings.json"),
 	);
+	copyPath(
+		fromRepo("assets/global/schemas"),
+		fromDistribution("global/schemas"),
+	);
 }

--- a/src/lib/phase-router/derive-action.ts
+++ b/src/lib/phase-router/derive-action.ts
@@ -112,6 +112,13 @@ export function deriveAction(contract: PhaseContract): PhaseAction {
 				"required when gated=true",
 			);
 		}
+		if (typeof contract.gated_event_type !== "string") {
+			throw new MalformedContractError(
+				contract.phase,
+				"gated_event_type",
+				"required when gated=true",
+			);
+		}
 		return { kind: "await_user", event_kind: contract.gated_event_kind };
 	}
 

--- a/src/lib/phase-router/router.ts
+++ b/src/lib/phase-router/router.ts
@@ -117,8 +117,10 @@ export class PhaseRouter {
 							typeof run.change_name === "string" ? run.change_name : "",
 					},
 				};
-				// gated_event_type is validated by deriveAction; safe to assert here.
-				const eventType = contract.gated_event_type!;
+				// gated_event_type is validated by deriveAction before we reach here.
+				const eventType = contract.gated_event_type as NonNullable<
+					typeof contract.gated_event_type
+				>;
 				const eventKind = EVENT_TYPE_TO_KIND[eventType];
 				const event: SurfaceEventEnvelope = {
 					schema_version: "1.0",

--- a/src/lib/phase-router/router.ts
+++ b/src/lib/phase-router/router.ts
@@ -3,6 +3,11 @@
 // RunArtifactStore — the only side effect across the entire PhaseRouter
 // surface is gated surface event emission (synchronous, deduped).
 
+import { randomUUID } from "node:crypto";
+import {
+	EVENT_TYPE_TO_KIND,
+	type SurfaceEventEnvelope,
+} from "../../contracts/surface-events.js";
 import type { RunHistoryEntry, RunState } from "../../types/contracts.js";
 import type { RunArtifactStore } from "../artifact-store.js";
 import { runRef } from "../artifact-types.js";
@@ -16,9 +21,16 @@ import type {
 	PhaseAction,
 	PhaseContract,
 	PhaseContractRegistry,
-	SurfaceEvent,
+	SurfaceEventContext,
 	SurfaceEventSink,
 } from "./types.js";
+
+/** Default context used when no orchestrator context is provided (tests). */
+const DEFAULT_CONTEXT: SurfaceEventContext = {
+	actor: { actor: "automation", actor_id: "system:phase-router" },
+	surface: { surface: "local-cli" },
+	correlation: { run_id: "", change_id: "" },
+};
 
 export interface PhaseRouterDeps {
 	readonly store: RunArtifactStore;
@@ -26,6 +38,8 @@ export interface PhaseRouterDeps {
 	readonly contracts: PhaseContractRegistry;
 	/** Injectable clock for deterministic emitted_at in tests. */
 	readonly now?: () => Date;
+	/** Injectable UUID generator for deterministic event_id in tests. */
+	readonly uuid?: () => string;
 }
 
 /**
@@ -47,6 +61,7 @@ export class PhaseRouter {
 	private readonly eventSink: SurfaceEventSink;
 	private readonly contracts: PhaseContractRegistry;
 	private readonly now: () => Date;
+	private readonly uuid: () => string;
 	private readonly dedup: Map<string, DedupEntry> = new Map();
 
 	constructor(deps: PhaseRouterDeps) {
@@ -54,6 +69,7 @@ export class PhaseRouter {
 		this.eventSink = deps.eventSink;
 		this.contracts = deps.contracts;
 		this.now = deps.now ?? (() => new Date());
+		this.uuid = deps.uuid ?? randomUUID;
 	}
 
 	/**
@@ -76,8 +92,11 @@ export class PhaseRouter {
 	 * Read-only with respect to RunArtifactStore: advance actions do NOT
 	 * cause the router to write to the store — the orchestrator is
 	 * responsible for store.advance.
+	 *
+	 * @param context - Orchestrator-provided actor/surface/correlation context.
+	 *   Falls back to a minimal default for backward-compatible test usage.
 	 */
-	nextAction(runId: string): PhaseAction {
+	nextAction(runId: string, context?: SurfaceEventContext): PhaseAction {
 		const run = this.readRun(runId);
 		const contract = this.resolveContract(run);
 		this.assertConsistent(runId, run, contract);
@@ -86,11 +105,38 @@ export class PhaseRouter {
 		if (action.kind === "await_user") {
 			const entryAt = this.currentEntryAt(run);
 			if (!this.hasEmitted(runId, entryAt, action.event_kind)) {
-				const event: SurfaceEvent = {
-					run_id: runId,
-					phase: contract.phase,
-					event_kind: action.event_kind,
-					emitted_at: this.now().toISOString(),
+				const ctx = context ?? {
+					...DEFAULT_CONTEXT,
+					correlation: {
+						...DEFAULT_CONTEXT.correlation,
+						run_id: runId,
+						// change_name is string | null on RunState but may be absent on
+						// legacy run.json files that predate the field — nullish coalesce
+						// safely handles both null and runtime-undefined.
+						change_id:
+							typeof run.change_name === "string" ? run.change_name : "",
+					},
+				};
+				// gated_event_type is validated by deriveAction; safe to assert here.
+				const eventType = contract.gated_event_type!;
+				const eventKind = EVENT_TYPE_TO_KIND[eventType];
+				const event: SurfaceEventEnvelope = {
+					schema_version: "1.0",
+					event_id: this.uuid(),
+					event_kind: eventKind,
+					event_type: eventType,
+					direction: "outbound",
+					timestamp: this.now().toISOString(),
+					correlation: {
+						...ctx.correlation,
+						run_id: runId,
+					},
+					actor: ctx.actor,
+					surface: ctx.surface,
+					payload: {
+						phase_from: contract.phase,
+						phase_to: contract.next_phase ?? "",
+					},
 				};
 				this.eventSink.emit(event);
 				this.recordEmitted(runId, entryAt, action.event_kind);

--- a/src/lib/phase-router/types.ts
+++ b/src/lib/phase-router/types.ts
@@ -1,10 +1,22 @@
 // PhaseRouter public types.
 //
-// PhaseContract and the surface event schema are owned by separate changes
-// (#129 and #100 respectively). Until those land, this module defines the
-// minimal shape that the router consumes. When #129/#100 merge, the
-// follow-up change will replace these declarations with imports from the
-// canonical locations without breaking the router surface.
+// PhaseContract is owned by a separate change (#129). Until that lands,
+// this module defines the minimal shape that the router consumes.
+//
+// Surface event types are now imported from the canonical contract module
+// (src/contracts/surface-events.ts), which satisfies #100.
+
+import type {
+	ActorIdentity,
+	CorrelationContext,
+	EventType,
+	SurfaceEventEnvelope,
+	SurfaceIdentity,
+} from "../../contracts/surface-events.js";
+
+// Re-export canonical types so existing consumers that import from
+// phase-router/types still work.
+export type { SurfaceEventEnvelope as SurfaceEvent } from "../../contracts/surface-events.js";
 
 /** The four kinds of action the router can direct the orchestrator to take. */
 export type PhaseNextAction =
@@ -29,6 +41,10 @@ export interface PhaseContract {
 	readonly advance_event?: string;
 	/** Surface event kind — required iff gated === true. */
 	readonly gated_event_kind?: string;
+	/** Concrete event type for the gated envelope — required iff gated === true. */
+	readonly gated_event_type?: EventType;
+	/** Phase the workflow transitions to upon approval — used in envelope payload. */
+	readonly next_phase?: string;
 	/** Terminal reason — required iff terminal === true. */
 	readonly terminal_reason?: string;
 }
@@ -55,14 +71,19 @@ export type PhaseAction =
 	| { readonly kind: "terminal"; readonly reason: string };
 
 /**
- * A surface event emitted by the router at gated decisions.
- * Schema is kept compatible with #100's Surface event contract.
+ * Orchestrator-provided context for constructing full SurfaceEventEnvelopes.
+ *
+ * This is internal runtime plumbing for threading orchestrator state into
+ * the router. It is deliberately NOT exported from the phase-router barrel
+ * (index.ts) because it is not part of the distributable contract surface
+ * consumed by external runtimes — that surface lives in
+ * src/contracts/surface-events.ts. Orchestrator code that needs this type
+ * should import it directly from this module.
  */
-export interface SurfaceEvent {
-	readonly run_id: string;
-	readonly phase: string;
-	readonly event_kind: string;
-	readonly emitted_at: string;
+export interface SurfaceEventContext {
+	readonly actor: ActorIdentity;
+	readonly surface: SurfaceIdentity;
+	readonly correlation: CorrelationContext;
 }
 
 /**
@@ -70,5 +91,5 @@ export interface SurfaceEvent {
  * production event bus and in-memory recorders used by tests.
  */
 export interface SurfaceEventSink {
-	emit(event: SurfaceEvent): void;
+	emit(event: SurfaceEventEnvelope): void;
 }

--- a/src/tests/phase-router.test.ts
+++ b/src/tests/phase-router.test.ts
@@ -22,6 +22,7 @@ import {
 	type SurfaceEvent,
 	type SurfaceEventSink,
 } from "../lib/phase-router/index.js";
+import type { SurfaceEventContext } from "../lib/phase-router/types.js";
 import { workflowStates } from "../lib/workflow-machine.js";
 import type { RunHistoryEntry, RunState } from "../types/contracts.js";
 
@@ -212,6 +213,8 @@ const FIXTURE_CONTRACTS: Record<string, PhaseContract> = {
 		gated: true,
 		terminal: false,
 		gated_event_kind: "approval_requested",
+		gated_event_type: "accept_spec",
+		next_phase: "design_draft",
 	},
 	terminal_phase: {
 		phase: "terminal_phase",
@@ -341,14 +344,67 @@ test("PhaseRouter.nextAction emits the gated event before returning await_user",
 	sink.markReturn("await_user");
 
 	assert.equal(action.kind, "await_user");
-	assert.deepEqual(sink.callOrder, [
-		"emit:approval_requested",
-		"return:await_user",
-	]);
+	assert.deepEqual(sink.callOrder, ["emit:approval", "return:await_user"]);
 	assert.equal(sink.events.length, 1);
-	assert.equal(sink.events[0]?.run_id, "r-gated");
-	assert.equal(sink.events[0]?.phase, "gated_phase");
-	assert.equal(sink.events[0]?.event_kind, "approval_requested");
+
+	const evt = sink.events[0]!;
+	assert.equal(evt.correlation.run_id, "r-gated");
+	assert.equal(evt.schema_version, "1.0");
+	assert.equal(evt.direction, "outbound");
+	assert.equal(evt.event_kind, "approval");
+	assert.equal(evt.event_type, "accept_spec");
+	assert.deepEqual(evt.payload, {
+		phase_from: "gated_phase",
+		phase_to: "design_draft",
+	});
+});
+
+// --- 6.4b Different gated phases produce different event_type values ------
+
+test("PhaseRouter.nextAction derives event_kind and event_type from the contract", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-design-gated",
+		makeRun({
+			runId: "r-design-gated",
+			currentPhase: "design_review_gate",
+			history: [
+				{
+					from: "start",
+					to: "design_review_gate",
+					event: "enter",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry({
+			design_review_gate: {
+				phase: "design_review_gate",
+				next_action: "await_user",
+				gated: true,
+				terminal: false,
+				gated_event_kind: "design_approval",
+				gated_event_type: "accept_design",
+				next_phase: "apply_draft",
+			},
+		}),
+	});
+
+	router.nextAction("r-design-gated");
+	assert.equal(sink.events.length, 1);
+
+	const evt = sink.events[0]!;
+	assert.equal(evt.event_kind, "approval");
+	assert.equal(evt.event_type, "accept_design");
+	assert.deepEqual(evt.payload, {
+		phase_from: "design_review_gate",
+		phase_to: "apply_draft",
+	});
 });
 
 // --- 6.5 Dedup within same entry -----------------------------------------
@@ -442,9 +498,9 @@ test("PhaseRouter.nextAction re-emits when the run re-enters the same gated phas
 		2,
 		"expected a second emission after re-entry",
 	);
-	// Both emissions carry the run's current gated phase.
-	assert.equal(sink.events[0]?.phase, "gated_phase");
-	assert.equal(sink.events[1]?.phase, "gated_phase");
+	// Both emissions carry the run's correlation.
+	assert.equal(sink.events[0]?.correlation.run_id, "r-reenter");
+	assert.equal(sink.events[1]?.correlation.run_id, "r-reenter");
 });
 
 // --- 6.7 Caller does not need to emit ------------------------------------
@@ -683,6 +739,43 @@ test("PhaseRouter.nextAction does not emit when the contract is malformed", () =
 	});
 
 	assert.throws(() => router.nextAction("r-bad"), MalformedContractError);
+	assert.equal(sink.events.length, 0);
+});
+
+test("PhaseRouter.nextAction throws MalformedContractError when gated_event_type is missing", () => {
+	const { store, setRun } = createInMemoryStore();
+	setRun(
+		"r-bad2",
+		makeRun({
+			runId: "r-bad2",
+			currentPhase: "bad_phase2",
+			history: [
+				{
+					from: "start",
+					to: "bad_phase2",
+					event: "enter",
+					timestamp: "2026-04-13T00:00:00Z",
+				},
+			],
+		}),
+	);
+	const sink = createRecordingSink();
+	const router = new PhaseRouter({
+		store,
+		eventSink: sink,
+		contracts: createRegistry({
+			bad_phase2: {
+				phase: "bad_phase2",
+				next_action: "await_user",
+				gated: true,
+				terminal: false,
+				gated_event_kind: "approval_requested",
+				// gated_event_type missing
+			},
+		}),
+	});
+
+	assert.throws(() => router.nextAction("r-bad2"), MalformedContractError);
 	assert.equal(sink.events.length, 0);
 });
 

--- a/src/tests/surface-event-schema-drift.test.ts
+++ b/src/tests/surface-event-schema-drift.test.ts
@@ -1,0 +1,246 @@
+// Schema drift test — validates TypeScript surface event types against JSON
+// Schema files to detect drift between the two representations.
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import _Ajv2020 from "ajv/dist/2020.js";
+
+// ajv's ESM export requires this workaround for TypeScript module interop.
+const Ajv2020 = _Ajv2020 as unknown as typeof _Ajv2020.default;
+
+import type {
+	ActorIdentity,
+	ApprovalPayload,
+	ClarifyRequestPayload,
+	ClarifyResponsePayload,
+	CorrelationContext,
+	RejectPayload,
+	ResumePayload,
+	ReviewOutcomePayload,
+	SurfaceEventEnvelope,
+	SurfaceIdentity,
+} from "../contracts/surface-events.js";
+
+const SCHEMAS_DIR = resolve("assets/global/schemas/surface-events");
+
+// --- Helpers ---------------------------------------------------------------
+
+function loadSchemas(): Record<string, unknown> {
+	const schemas: Record<string, unknown> = {};
+	for (const name of readdirSync(SCHEMAS_DIR)) {
+		if (!name.endsWith(".schema.json")) continue;
+		const raw = readFileSync(join(SCHEMAS_DIR, name), "utf8");
+		schemas[name] = JSON.parse(raw);
+	}
+	return schemas;
+}
+
+function createAjv(
+	schemas: Record<string, unknown>,
+): InstanceType<typeof Ajv2020> {
+	const ajv = new Ajv2020({ strict: false, allErrors: true });
+	for (const [name, schema] of Object.entries(schemas)) {
+		ajv.addSchema(schema as object, name);
+	}
+	return ajv;
+}
+
+// --- Fixtures: one sample per concrete event type --------------------------
+
+const ACTOR: ActorIdentity = {
+	actor: "human",
+	actor_id: "user-123",
+};
+
+const SURFACE: SurfaceIdentity = {
+	surface: "local-cli",
+};
+
+const CORRELATION: CorrelationContext = {
+	run_id: "my-feature-1",
+	change_id: "my-feature",
+};
+
+function makeEnvelope<T extends string>(
+	eventKind: "approval" | "reject" | "clarify" | "resume",
+	eventType: T,
+	direction: "inbound" | "outbound",
+	payload: unknown,
+): SurfaceEventEnvelope {
+	return {
+		schema_version: "1.0",
+		event_id: "evt-001",
+		event_kind: eventKind,
+		event_type: eventType,
+		direction,
+		timestamp: "2026-04-15T00:00:00Z",
+		correlation: CORRELATION,
+		actor: ACTOR,
+		surface: SURFACE,
+		payload,
+	} as SurfaceEventEnvelope;
+}
+
+const APPROVAL_PAYLOAD: ApprovalPayload = {
+	phase_from: "spec_ready",
+	phase_to: "design_draft",
+};
+
+const REJECT_PAYLOAD: RejectPayload = {
+	phase_from: "proposal_draft",
+	reason: "not aligned with roadmap",
+};
+
+const CLARIFY_REQ_PAYLOAD: ClarifyRequestPayload = {
+	question: "What auth method?",
+	context: "The proposal mentions auth but not which method",
+};
+
+const CLARIFY_RESP_PAYLOAD: ClarifyResponsePayload = {
+	answer: "Use OAuth2",
+	question_event_id: "evt-000",
+};
+
+const RESUME_PAYLOAD: ResumePayload = {
+	phase_from: "design_draft",
+};
+
+const REVIEW_OUTCOME_PAYLOAD: ReviewOutcomePayload = {
+	phase_from: "design_review",
+	reviewer_actor: { actor: "ai-agent", actor_id: "codex" },
+	summary: "Looks good",
+	issues: [{ id: "P1", severity: "medium", detail: "Minor gap" }],
+};
+
+const SAMPLE_EVENTS: readonly SurfaceEventEnvelope[] = [
+	makeEnvelope("approval", "accept_spec", "inbound", APPROVAL_PAYLOAD),
+	makeEnvelope("approval", "accept_design", "inbound", APPROVAL_PAYLOAD),
+	makeEnvelope("approval", "accept_apply", "inbound", APPROVAL_PAYLOAD),
+	makeEnvelope("reject", "reject", "inbound", REJECT_PAYLOAD),
+	makeEnvelope("clarify", "clarify_request", "outbound", CLARIFY_REQ_PAYLOAD),
+	makeEnvelope("clarify", "clarify_response", "inbound", CLARIFY_RESP_PAYLOAD),
+	makeEnvelope("resume", "resume", "inbound", RESUME_PAYLOAD),
+	makeEnvelope(
+		"approval",
+		"design_review_approved",
+		"inbound",
+		REVIEW_OUTCOME_PAYLOAD,
+	),
+	makeEnvelope(
+		"approval",
+		"apply_review_approved",
+		"inbound",
+		REVIEW_OUTCOME_PAYLOAD,
+	),
+	makeEnvelope(
+		"approval",
+		"request_changes",
+		"inbound",
+		REVIEW_OUTCOME_PAYLOAD,
+	),
+	makeEnvelope("approval", "block", "inbound", REVIEW_OUTCOME_PAYLOAD),
+];
+
+// --- Tests -----------------------------------------------------------------
+
+test("all JSON Schema files parse as valid JSON", () => {
+	const schemas = loadSchemas();
+	assert.ok(
+		Object.keys(schemas).length >= 10,
+		`expected >= 10 schema files, got ${Object.keys(schemas).length}`,
+	);
+});
+
+test("envelope schema validates all 11 concrete event samples", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("envelope.schema.json");
+	assert.ok(validate, "envelope.schema.json should compile");
+
+	for (const event of SAMPLE_EVENTS) {
+		const valid = validate(event);
+		assert.ok(
+			valid,
+			`event_type=${event.event_type} failed envelope validation: ${JSON.stringify(validate.errors)}`,
+		);
+	}
+});
+
+test("actor-identity schema validates sample actor", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("actor-identity.schema.json");
+	assert.ok(validate);
+	assert.ok(validate(ACTOR));
+});
+
+test("surface-identity schema validates sample surface", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("surface-identity.schema.json");
+	assert.ok(validate);
+	assert.ok(validate(SURFACE));
+});
+
+test("correlation schema validates sample correlation", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("correlation.schema.json");
+	assert.ok(validate);
+	assert.ok(validate(CORRELATION));
+});
+
+// --- Negative tests --------------------------------------------------------
+
+test("envelope schema rejects event missing required schema_version", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("envelope.schema.json");
+	assert.ok(validate);
+
+	const invalid = { ...SAMPLE_EVENTS[0] } as Record<string, unknown>;
+	delete invalid.schema_version;
+	assert.ok(!validate(invalid), "should reject missing schema_version");
+});
+
+test("envelope schema rejects event missing required event_id", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("envelope.schema.json");
+	assert.ok(validate);
+
+	const invalid = { ...SAMPLE_EVENTS[0] } as Record<string, unknown>;
+	delete invalid.event_id;
+	assert.ok(!validate(invalid), "should reject missing event_id");
+});
+
+test("envelope schema rejects event missing required correlation", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("envelope.schema.json");
+	assert.ok(validate);
+
+	const invalid = { ...SAMPLE_EVENTS[0] } as Record<string, unknown>;
+	delete invalid.correlation;
+	assert.ok(!validate(invalid), "should reject missing correlation");
+});
+
+test("actor-identity schema rejects actor missing required actor_id", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("actor-identity.schema.json");
+	assert.ok(validate);
+
+	assert.ok(!validate({ actor: "human" }), "should reject missing actor_id");
+});
+
+test("correlation schema rejects correlation missing required run_id", () => {
+	const schemas = loadSchemas();
+	const ajv = createAjv(schemas);
+	const validate = ajv.getSchema("correlation.schema.json");
+	assert.ok(validate);
+
+	assert.ok(!validate({ change_id: "x" }), "should reject missing run_id");
+});


### PR DESCRIPTION
## Summary
- Define bidirectional, transport-agnostic `SurfaceEventEnvelope` with versioned schema, actor/surface identity, correlation, and 11 concrete event types
- Provide TypeScript types (`src/contracts/surface-events.ts`) and JSON Schema files (`assets/global/schemas/surface-events/`) for language-agnostic consumers
- Migrate phase-router from placeholder `SurfaceEvent` to canonical envelope with contract-driven `event_type` and `event_kind` derivation
- Wire JSON Schema distribution via `InstallCopyContract` and static asset build
- Add ajv-based schema drift tests validating TS types against JSON Schema

## Issue
Closes https://github.com/skr19930617/specflow/issues/100