### PR TITLE
feat: normalize child task statuses on terminal bundle transitions (#142)

### DIFF
--- a/bin/specflow-advance-bundle
+++ b/bin/specflow-advance-bundle
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "./.launcher.mjs";

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/approval-summary.md
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/approval-summary.md
@@ -1,0 +1,91 @@
+# Approval Summary: normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete
+
+**Generated**: 2026-04-15T06:02:15Z
+**Branch**: normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+```
+ package.json                        |   1 +
+ src/contracts/orchestrators.ts      |   8 ++
+ src/lib/schemas.ts                  |  35 ++++++
+ src/lib/task-planner/index.ts       |  15 ++-
+ src/lib/task-planner/status.ts      |  90 ++++++++++++++-
+ src/tests/task-planner-core.test.ts | 220 ++++++++++++++++++++++++++++++++++++
+ src/types/contracts.ts              |   1 +
+ 7 files changed, 365 insertions(+), 5 deletions(-)
+```
+
+_Also adds 4 untracked files that `git add -A` will stage on commit: `bin/specflow-advance-bundle`, `src/bin/specflow-advance-bundle.ts`, `src/lib/task-planner/advance.ts`, `src/tests/advance-bundle.test.ts`._
+
+## Files Touched
+
+```
+package.json
+src/contracts/orchestrators.ts
+src/lib/schemas.ts
+src/lib/task-planner/index.ts
+src/lib/task-planner/status.ts
+src/tests/task-planner-core.test.ts
+src/types/contracts.ts
+```
+
+## Review Loop Summary
+
+### Design Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+### Impl Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 2     |
+
+## Proposal Coverage
+
+Acceptance criteria come from the MODIFIED `task-planner` spec (scenarios inside the "Apply phase writes back bundle status to task graph" requirement, [openspec/changes/.../specs/task-planner/spec.md](openspec/changes/normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/specs/task-planner/spec.md)).
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | Status transitions from pending to in_progress (non-terminal preserves child statuses) | Yes | src/lib/task-planner/status.ts, src/tests/task-planner-core.test.ts |
+| 2 | Status transitions from in_progress to done (children normalized to done) | Yes | src/lib/task-planner/status.ts, src/tests/task-planner-core.test.ts |
+| 3 | Invalid status transition is rejected (e.g., done → pending) | Yes | src/lib/task-planner/status.ts, src/tests/task-planner-core.test.ts |
+| 4 | Bundle → done normalizes pending child tasks and reports coercions | Yes | src/lib/task-planner/status.ts, src/tests/task-planner-core.test.ts |
+| 5 | Bundle → skipped normalizes child tasks | Yes | src/lib/task-planner/status.ts, src/tests/task-planner-core.test.ts |
+| 6 | Normalization force-coerces conflicting prior terminal child status | Yes | src/lib/task-planner/status.ts, src/tests/task-planner-core.test.ts |
+| 7 | Terminal transition on empty bundle is a no-op for children | Yes | src/lib/task-planner/status.ts, src/tests/task-planner-core.test.ts |
+| 8 | Audit log suppressed when coercion does not change status | Yes | src/lib/task-planner/advance.ts, src/tests/advance-bundle.test.ts |
+| 9 | updateBundleStatus does not mutate input graph | Yes | src/lib/task-planner/status.ts, src/tests/task-planner-core.test.ts |
+| 10 | tasks.md re-rendered from normalized graph after terminal transition | Yes | src/lib/task-planner/advance.ts, src/tests/task-planner-core.test.ts, src/tests/advance-bundle.test.ts |
+| 11 | Atomic persistence avoids mismatched intermediate state | Yes | src/lib/task-planner/advance.ts (writer seam), src/lib/fs.ts#atomicWriteText (existing), src/tests/advance-bundle.test.ts |
+
+**Coverage Rate**: 11/11 (100%)
+
+## Remaining Risks
+
+**Deterministic risks (from review ledger — all LOW, explicitly marked optional by the reviewer):**
+
+- R1-F01: Atomicity test exercises atomicWriteText directly, not the CLI wiring (severity: low)
+- R1-F02: CLI usage/parse errors do not emit advance-bundle-result JSON (severity: low)
+- R1-F03: Defensive renameSync type check is dead weight (severity: low)
+
+**Untested new files:** none. (No newly-added tracked `.sh` or `.md` files fall outside of review finding `file` references.)
+
+**Uncovered criteria:** none.
+
+## Human Checkpoints
+
+- [ ] Confirm that emitting audit log lines on stderr (vs. a structured file sink) matches the operational expectation for this codebase — the spec only requires a "structured log entry", not a specific transport.
+- [ ] Verify that the new `specflow-advance-bundle` CLI surface is the right vehicle for the apply-phase caller integration, vs. invoking `advanceBundleStatus()` directly from another binary later.
+- [ ] Decide whether to address the 3 LOW findings (CLI error-envelope unification, end-to-end CLI atomicity test, removal of defensive `typeof renameSync` check) in this PR or in a follow-up.
+- [ ] Validate the atomic-write guarantee on your target deployment OS — the current implementation relies on `renameSync` being atomic within a single filesystem, which is true on POSIX and NTFS but worth confirming for any cross-filesystem deployment.

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/current-phase.md
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/current-phase.md
@@ -1,0 +1,15 @@
+# Current Phase: normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete
+
+- Phase: fix-review
+- Round: 2
+- Status: in_progress
+- Open High Findings: 0 件
+- Actionable Findings: 3
+- Accepted Risks: none
+- Latest Changes:
+  - 3fb6672 feat: define approval and clarify persistence semantics (#101)
+  - 973d949 fix: format JSON Schema files with biome and remove non-null assertion
+  - 9666fce feat: define surface event contract for external runtimes (#100)
+  - 44dd63e feat: define design contract required for specflow task planning and apply windowing (#138)
+  - 81c6925 feat: add specflow-owned task planner with bundle-based task graph (#137)
+- Next Recommended Action: /specflow.fix_apply

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/design.md
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/design.md
@@ -1,0 +1,152 @@
+## Context
+
+`task-graph.json` is the single source of truth for bundle/task state; `tasks.md` is a deterministic projection of it. Today's implementation splits that contract in a subtle way:
+
+- `src/lib/task-planner/status.ts#updateBundleStatus()` only rewrites `bundle.status`. Child task statuses are never touched.
+- `src/lib/task-planner/render.ts#renderTasksMd()` reads each task's `status` to draw its checkbox.
+- As a result, a bundle can legitimately reach `"done"` while every child task remains `"pending"`. On archive, `tasks.md` then shows an inconsistent artifact: a header labeled "✓" with unchecked checkboxes underneath.
+
+This is a **contract gap**, not a renderer bug. The fix is to tighten the bundle-status update contract so that terminal bundle transitions coerce child task statuses into a matching terminal state, preserving the "bundle = execution truth, tasks = informational" model and the existing immutable update discipline.
+
+**Relevant files:**
+- `src/lib/task-planner/status.ts` — pure `updateBundleStatus()` function
+- `src/lib/task-planner/render.ts` — `renderTasksMd()`, reads `task.status` directly
+- `src/lib/task-planner/types.ts` — `TaskGraph`, `Bundle`, `Task`, `BundleStatus`, `TaskStatus`
+- `src/lib/task-planner/index.ts` — public barrel
+- `src/tests/task-planner-core.test.ts` — existing unit tests for `updateBundleStatus`
+- Apply-phase caller (persistence + logging) — wired by an earlier change (archive: `move-task-generation-from-openspec-passthrough-to-specflow-owned-task-planner`)
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Close the terminal-bundle/pending-child contract gap so that, after a bundle reaches `"done"` or `"skipped"`, the persisted `task-graph.json` and the rendered `tasks.md` are internally consistent.
+- Keep `updateBundleStatus()` a **pure function** — no I/O, no hidden logger coupling, deterministic output.
+- Preserve backwards-compatible return shape for `updateBundleStatus()` callers that only consume `taskGraph`.
+- Provide enough structured information on the return value for the apply-phase caller to emit the required audit log.
+- Preserve existing immutable-update behavior: the input `TaskGraph` is never mutated.
+- Honor the existing atomic-write pattern for `task-graph.json` persistence (write-to-temp + rename).
+
+**Non-Goals:**
+
+- No new per-task execution tracking. `Task.status` remains informational; terminal bundle transitions drive it.
+- No widening of the allowed bundle-status transition set. `done → pending` etc. remain rejected.
+- No schema/validator change. `validateTaskGraph()` is not taught to reject pre-existing mismatched graphs; the fix is forward-only.
+- No retroactive rewrite of already-archived `tasks.md` files. Pre-change archives remain as-is.
+- No change to task graph generation (`generateTaskGraph`, windowing, completion detection).
+
+## Decisions
+
+### D1. Normalization lives inside `updateBundleStatus()` (not a separate helper)
+
+Put the child-coercion logic directly in `src/lib/task-planner/status.ts#updateBundleStatus`. When the target status is `"done"` or `"skipped"`, rebuild the bundle's `tasks` array with each `task.status` set to the target value, then rebuild the `bundles` array immutably as today.
+
+**Why:** The spec ties normalization to the bundle status update — they are one semantic operation. Putting them in the same pure function guarantees "you cannot end up with a terminal bundle whose children disagree" at the type level of the return value. A caller who does `result.taskGraph` always gets a consistent graph.
+
+**Alternative considered — separate `normalizeBundleChildren()` helper called by the caller:** Rejected. It pushes the invariant into caller discipline, re-opening the possibility that some apply path forgets to call it. Same failure mode the issue is trying to eliminate.
+
+**Alternative considered — normalize inside the renderer (`renderTasksMd`):** Rejected. It hides the fix in the projection layer, leaves `task-graph.json` itself still inconsistent on disk, and contradicts the "task graph is the single source of truth" rule.
+
+### D2. Extend `StatusUpdateResult` with a `coercions` array for observability
+
+`updateBundleStatus()` currently returns:
+
+```ts
+// status.ts (today)
+export interface StatusUpdateResult {
+  readonly ok: true;
+  readonly taskGraph: TaskGraph;
+}
+```
+
+Add:
+
+```ts
+export interface TaskStatusCoercion {
+  readonly bundleId: string;
+  readonly taskId: string;
+  readonly from: TaskStatus;
+  readonly to: TaskStatus;
+}
+
+export interface StatusUpdateResult {
+  readonly ok: true;
+  readonly taskGraph: TaskGraph;
+  readonly coercions: readonly TaskStatusCoercion[];
+}
+```
+
+`coercions` contains one entry **per child task whose status actually changed** (i.e., was not already equal to the target terminal status). Non-terminal transitions always return an empty array. No-op coercions (child already matched) are not emitted.
+
+The apply-phase caller iterates `result.coercions` and emits one structured log line per entry (`bundle_id`, `task_id`, `from_status`, `to_status`). The pure function stays pure; the caller owns the logging side effect.
+
+**Why:** Keeps `updateBundleStatus()` a pure, testable function while still making audit data available. Unit tests assert on `coercions` without mocking a logger. Empty array → no log → matches the spec requirement that no-op coercion is silent.
+
+**Alternative considered — accept a logger callback argument:** Rejected. Breaks purity, complicates testing, introduces a hidden dependency that every caller must wire correctly.
+
+**Alternative considered — emit a log directly from `status.ts`:** Rejected. Same purity concern, plus couples the task-planner library to a concrete logging abstraction it does not own today.
+
+### D3. Empty-bundle terminal transition is a silent no-op for children
+
+If `bundle.tasks.length === 0`, the bundle's status is still updated to the terminal value; `coercions` is returned as `[]`. No error, no log.
+
+**Why:** Vacuously satisfies the "every child matches" invariant. Matches the clarify answer (C1). Rules out a false failure mode for legitimately empty planning bundles.
+
+### D4. Conflicting prior terminal child statuses are force-coerced
+
+A child that already holds `"done"` when the bundle moves to `"skipped"` (or vice versa) is rewritten to match the bundle's new terminal status. A `coercions` entry is emitted because status actually changed.
+
+**Why:** Per spec, the bundle is the authoritative execution unit and child status is informational. Force-coercion is the only policy consistent with that model. The coercion entry in the return value makes the rewrite auditable.
+
+### D5. Renderer stays unchanged
+
+`renderTasksMd()` continues to consume `task.status` directly — no special case for terminal bundles. This is intentional: once `updateBundleStatus()` normalizes the graph, the renderer's per-task reading is correct, and the projection remains a trivial function of the graph.
+
+**Why:** Single point of truth for the invariant. If normalization lived only in the renderer, `task-graph.json` on disk would still carry the mismatched state, and any alternative renderer (external consumer, surface event payload) would have to re-implement the fix.
+
+### D6. Persistence is caller's responsibility; atomic write is reused
+
+`updateBundleStatus()` does no I/O. The caller:
+
+1. Calls `updateBundleStatus(graph, bundleId, newStatus)`
+2. If `result.ok`, writes `result.taskGraph` to `task-graph.json` using the existing atomic-write pattern (write to `task-graph.json.tmp`, then `rename` to `task-graph.json`).
+3. Calls `renderTasksMd(result.taskGraph)` and writes `tasks.md` (same atomic pattern).
+4. For each entry in `result.coercions`, emits a structured log line.
+
+**Why:** Matches existing apply-phase wiring (see archived design: "caller-responsible persistence"). Keeps the pure-function boundary clean and preserves the atomic-write guarantee without bespoke transaction code. Crash mid-write cannot produce a mismatched persisted graph because `result.taskGraph` is already internally consistent before the write starts.
+
+### D7. Validator is untouched
+
+`validateTaskGraph()` does **not** gain a "terminal bundle children must match" check. Rationale: pre-existing archived graphs may violate the invariant; adding the check now would make historical artifacts spuriously invalid. Normalization is applied on every future terminal transition, which forward-fixes the model without breaking old data.
+
+### D8. Public API surface update
+
+Export the new `TaskStatusCoercion` type from `src/lib/task-planner/index.ts` so apply-phase callers can type their audit-log payloads.
+
+## Risks / Trade-offs
+
+- **Risk:** Existing apply-phase callers ignore `result.coercions` and fail to emit audit logs.
+  **Mitigation:** Keep the default behavior useful without the audit log (graph is still normalized, `tasks.md` still consistent). Add a task that explicitly updates the apply-phase caller to iterate `coercions`. Covered by a test that asserts the caller emits one log per coercion.
+
+- **Risk:** The additional `coercions` field in the return type is a structural change to a public API.
+  **Mitigation:** It is an additive change — existing destructuring callers (`const { taskGraph } = result`) remain source-compatible. Any caller that narrows via `StatusUpdateResult` will get a non-breaking widening (new required field, but consumers generally only read the fields they care about; TS excess-property checks don't apply to read sites). Document in release notes; covered by existing tests.
+
+- **Risk:** Silent force-coercion of a prior terminal child (e.g., child `done` → coerced to `skipped`) could hide a user-intent mismatch upstream.
+  **Mitigation:** The audit log entry for every actual status change (D2) surfaces this. Operators see `(bundle_id, task_id, "done", "skipped")` in the log and can investigate upstream status tracking.
+
+- **Risk:** A future requirement to allow reverse transitions (`done → in_progress` on re-open) would conflict with this design.
+  **Mitigation:** Explicitly out of scope (clarify C4). If a future change adds reverse transitions, it will need its own normalization/re-expansion rule — this design does not paint itself into a corner because normalization is driven by the destination status, not the source.
+
+- **Trade-off:** Putting normalization in `updateBundleStatus()` slightly couples two operations (bundle status + child coercion). That coupling is the **point** of the fix; it is the contract.
+
+## Migration Plan
+
+- No data migration. The change is forward-only.
+- Pre-existing archived `tasks.md` files remain unchanged.
+- Pre-existing `task-graph.json` files with a terminal bundle and non-matching children are not retroactively normalized. Since terminal bundles cannot leave their state under the existing transition rules, the mismatch will persist until a future change (if any) re-runs normalization across all graphs.
+- Rollback strategy: revert the `status.ts` and `index.ts` edits; the pure-function return type change is backwards compatible, so callers keep working.
+- No configuration, feature flag, or environment variable.
+
+## Open Questions
+
+None. Every challenge from the proposal (C1–C5) is resolved in the Decisions above. The tasks artifact will flesh out per-file edits and tests.

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/proposal.md
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The `task-graph.json` ↔ `tasks.md` contract has a gap at bundle completion. Today the apply path can drive a bundle to `status = "done"` while every child `task.status` remains `"pending"`. Because `tasks.md` is re-rendered directly from per-task status, archived changes end up showing unchecked checkboxes underneath a "done" bundle — a visibly inconsistent artifact.
+
+The current `task-planner` spec defines bundle status transitions and re-render obligations, but it does not define what child task statuses must look like when the parent bundle reaches a terminal state. We need to close that contract gap so the rendered checklist always matches the bundle's executional truth.
+
+Source: github issue [skr19930617/specflow#142](https://github.com/skr19930617/specflow/issues/142).
+
+## What Changes
+
+- Define **bundle-completion normalization semantics**: when a bundle transitions to a terminal status, all of its child tasks SHALL be coerced to a status consistent with that terminal state before persistence.
+  - `bundle.status = "done"` → every `tasks[*].status` in that bundle MUST be `"done"`.
+  - `bundle.status = "skipped"` → every `tasks[*].status` in that bundle MUST be `"skipped"` (symmetric with the `done` rule; keeps the skipped signal explicit in the rendered `tasks.md`).
+- Normalize **on the transition only**, not as a validation invariant. The status-update path coerces child tasks when a bundle moves to a terminal state; the task-graph JSON schema is unchanged and the validator does not reject pre-existing inconsistent graphs.
+- Non-terminal transitions (`pending`, `in_progress`) are **out of scope**. Child task statuses underneath a non-terminal bundle are not touched. This preserves the existing "bundle = execution truth, tasks = informational" model and aligns with the issue's non-goal of per-task execution tracking.
+- Require the apply / status-update path to normalize child task statuses **before** writing the final `task-graph.json`, so the persisted graph never contains a terminal bundle with mismatched child tasks.
+- Require `tasks.md` to be re-rendered from the **normalized** graph, so archived `tasks.md` shows checked (or explicitly skipped) boxes that match the bundle's terminal state.
+- No changes to task graph generation prompts, windowing, bundle completion detection, or the renderer's per-task reading of `task.status`.
+
+### Normalization edge cases (from challenge/reclarify)
+
+- **Empty bundle**: A terminal transition on a bundle with zero child tasks is a **no-op** (vacuously satisfies the invariant). The bundle's terminal status is persisted as-is.
+- **Conflict policy**: If a child already holds a different terminal status than the bundle's new terminal status (e.g., a child is `done` but the bundle moves to `skipped`), normalization **force-coerces** the child to the bundle's terminal status. The bundle is the authoritative execution unit; per-task state is informational.
+- **Observability**: Whenever normalization actually **changes** a child's status, the apply path SHALL emit a structured log entry containing `(bundle_id, task_id, from_status, to_status)`. No-op coercions (child already matches) do not log.
+- **Reverse transitions** (terminal → non-terminal, e.g., `done → in_progress`) are **out of scope**. The existing `task-planner` spec already rejects `"done" → "pending"` as an invalid transition, and this change does not broaden the allowed transition set.
+- **Atomicity**: `updateBundleStatus` returns a new `TaskGraph` with **both** the bundle status change **and** the normalized child statuses applied in a single in-memory update. The caller persists the whole `task-graph.json` with the existing atomic-write pattern (write-to-temp + rename), then re-renders `tasks.md`. On crash mid-write the persisted graph is either the old state or the fully-normalized new state — never a mismatched middle. The original task graph is not mutated (preserves the immutable-update contract already in the `task-planner` spec).
+
+## Capabilities
+
+### New Capabilities
+- None. This change tightens an existing contract rather than introducing a new capability.
+
+### Modified Capabilities
+- `task-planner`: extend the bundle-status-update requirement so terminal bundle transitions normalize child task statuses, and require `tasks.md` to be rendered from the normalized graph. Affects the "Apply phase writes back bundle status to task graph" requirement (and any related re-render requirement).
+
+## Impact
+
+- **Specs**: `openspec/specs/task-planner/spec.md` — add normalization scenarios and tighten the re-render requirement.
+- **Code (apply / task-graph update path)**: status-update logic must normalize child tasks on terminal transitions; `tasks.md` renderer continues to read per-task status (no renderer-side special case).
+- **Tests**: cover (a) normalization on `pending|in_progress → done` coerces all child tasks to `done`, (b) normalization on `pending → skipped` coerces all child tasks to `skipped`, (c) force-coercion of a conflicting prior terminal child (e.g., child `done` + bundle `skipped` → child `skipped`), (d) terminal transition on a bundle with zero tasks is a no-op, (e) coercion that actually changes status emits the audit log line; no-op coercion stays silent, (f) `tasks.md` rendered from the normalized graph shows matching checkbox state, (g) non-terminal transitions (`pending → in_progress`) do NOT touch child task statuses, (h) archived artifacts preserve the normalized state, (i) `updateBundleStatus` returns a new graph without mutating the input.
+- **Archived artifacts**: post-change, archived `tasks.md` will reflect completed work consistently. Pre-change archives are not retroactively rewritten.
+- **No impact** on task graph generation, windowing, or per-task execution tracking.
+
+### Release notes (additive API surface)
+
+This change is backwards-compatible for existing callers that only consume `result.taskGraph`. New surface:
+
+- `StatusUpdateResult.coercions: readonly TaskStatusCoercion[]` — one entry per child task whose status was rewritten on a terminal bundle transition (empty otherwise). Existing `{ ok, taskGraph }` destructuring continues to work.
+- `TaskStatusCoercion` — new interface `{ bundleId, taskId, from, to }` re-exported from `src/lib/task-planner/index.ts`.
+- `advanceBundleStatus({ taskGraph, bundleId, newStatus, writer, logger })` — new orchestration helper in `src/lib/task-planner/advance.ts` that calls `updateBundleStatus`, persists the normalized graph and re-rendered `tasks.md` via an injected writer, and emits one log call per coercion via an injected logger.
+- `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>` — new CLI binary that wires the helper to the local-fs atomic writer and to JSON-line structured audit logging on stderr. Stdout emits an `advance-bundle-result` JSON payload.

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/review-ledger-design.json
@@ -1,0 +1,19 @@
+{
+  "feature_id": "normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete",
+  "phase": "design",
+  "current_round": 1,
+  "status": "all_resolved",
+  "max_finding_id": 0,
+  "findings": [],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 0,
+      "open": 0,
+      "new": 0,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/review-ledger.json
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/review-ledger.json
@@ -1,0 +1,75 @@
+{
+  "feature_id": "normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete",
+  "phase": "impl",
+  "current_round": 2,
+  "status": "in_progress",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "low",
+      "category": "testing",
+      "file": "src/tests/advance-bundle.test.ts",
+      "title": "Atomicity test exercises atomicWriteText directly, not the CLI wiring",
+      "detail": "The 'atomic write pattern' test calls atomicWriteText() directly rather than asserting that the production CLI (specflow-advance-bundle.ts) invokes the atomic primitive through createLocalFsChangeArtifactStore.write. The production chain is sound (store.write → atomicWriteText, verified manually), but this seam is not directly covered by an integration test. Optional: add an end-to-end test that runs specflow-advance-bundle against a tmpdir and asserts no .tmp sidecars remain.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "low",
+      "category": "error_handling",
+      "file": "src/bin/specflow-advance-bundle.ts",
+      "title": "CLI usage/parse errors do not emit advance-bundle-result JSON",
+      "detail": "Errors before reaching advanceBundleStatus (missing args, bad NEW_STATUS, missing/invalid task-graph.json) call die() which writes a plain string to stderr and exits 1. Apply-phase errors emit a schema-compliant 'status: \"error\"' JSON to stdout. Programmatic callers parsing stdout get inconsistent shapes between pre-call and post-call failures. Consider unifying CLI errors under the same JSON envelope so consumers can always JSON.parse stdout. Not a spec violation — the schema only constrains success/error from the orchestration call itself.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "low",
+      "category": "quality",
+      "file": "src/tests/advance-bundle.test.ts",
+      "title": "Defensive renameSync type check is dead weight",
+      "detail": "Line 222 `assert.equal(typeof renameSync, \"function\")` defensively checks that node:fs still exports renameSync. This adds noise without value (Node would fail to load the module if it weren't there). Optional cleanup; harmless if kept.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 3,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "low": 3
+      }
+    },
+    {
+      "round": 2,
+      "total": 3,
+      "open": 3,
+      "new": 0,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "low": 3
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/review-ledger.json.bak
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/review-ledger.json.bak
@@ -1,0 +1,64 @@
+{
+  "feature_id": "normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "in_progress",
+  "max_finding_id": 3,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "low",
+      "category": "testing",
+      "file": "src/tests/advance-bundle.test.ts",
+      "title": "Atomicity test exercises atomicWriteText directly, not the CLI wiring",
+      "detail": "The 'atomic write pattern' test calls atomicWriteText() directly rather than asserting that the production CLI (specflow-advance-bundle.ts) invokes the atomic primitive through createLocalFsChangeArtifactStore.write. The production chain is sound (store.write → atomicWriteText, verified manually), but this seam is not directly covered by an integration test. Optional: add an end-to-end test that runs specflow-advance-bundle against a tmpdir and asserts no .tmp sidecars remain.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "low",
+      "category": "error_handling",
+      "file": "src/bin/specflow-advance-bundle.ts",
+      "title": "CLI usage/parse errors do not emit advance-bundle-result JSON",
+      "detail": "Errors before reaching advanceBundleStatus (missing args, bad NEW_STATUS, missing/invalid task-graph.json) call die() which writes a plain string to stderr and exits 1. Apply-phase errors emit a schema-compliant 'status: \"error\"' JSON to stdout. Programmatic callers parsing stdout get inconsistent shapes between pre-call and post-call failures. Consider unifying CLI errors under the same JSON envelope so consumers can always JSON.parse stdout. Not a spec violation — the schema only constrains success/error from the orchestration call itself.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "low",
+      "category": "quality",
+      "file": "src/tests/advance-bundle.test.ts",
+      "title": "Defensive renameSync type check is dead weight",
+      "detail": "Line 222 `assert.equal(typeof renameSync, \"function\")` defensively checks that node:fs still exports renameSync. This adds noise without value (Node would fail to load the module if it weren't there). Optional cleanup; harmless if kept.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 3,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "low": 3
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/specs/task-planner/spec.md
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/specs/task-planner/spec.md
@@ -1,0 +1,89 @@
+## MODIFIED Requirements
+
+### Requirement: Apply phase writes back bundle status to task graph
+
+The apply phase SHALL update bundle and task status in `task-graph.json` after execution. The status transitions SHALL be:
+- `"pending"` → `"in_progress"`: when bundle execution begins
+- `"in_progress"` → `"done"`: when bundle completion check passes
+- `"pending"` → `"skipped"`: when explicitly skipped by user or system
+
+The system SHALL provide `updateBundleStatus(taskGraph, bundleId, newStatus)` that returns a new `TaskGraph` with the specified bundle's status updated. The original task graph SHALL NOT be mutated.
+
+When the new bundle status is a **terminal** status (`"done"` or `"skipped"`), `updateBundleStatus` SHALL also **normalize all child task statuses** within that bundle so they match the bundle's terminal status in the returned `TaskGraph`:
+- `bundle.status = "done"` → every `tasks[*].status` in that bundle SHALL be `"done"`
+- `bundle.status = "skipped"` → every `tasks[*].status` in that bundle SHALL be `"skipped"`
+
+Normalization applies unconditionally regardless of the prior child status (including children that already hold a different terminal status). The bundle is the authoritative execution unit; per-task status is informational. A bundle with an empty `tasks` array is a no-op with respect to child coercion; the terminal bundle status is still applied.
+
+Normalization applies **only on terminal transitions**. Non-terminal transitions (`pending → in_progress`, and any other transition whose target is `pending` or `in_progress`) SHALL NOT modify child task statuses.
+
+The returned `TaskGraph` SHALL contain both the bundle status change and all child coercions as a single in-memory update. When the caller persists `task-graph.json`, it SHALL be written atomically (e.g., write-to-temp + rename) so that the persisted graph is either the pre-update state or the fully normalized post-update state — never a mismatched intermediate state.
+
+Whenever normalization actually changes a child task's status (from a value different from the target terminal status), the apply path SHALL emit a structured audit log entry containing at minimum: `bundle_id`, `task_id`, `from_status`, and `to_status`. Coercions that do not change a child's status (the child already matched the bundle's terminal status) SHALL NOT emit a log entry.
+
+After status update, `tasks.md` SHALL be re-rendered from the normalized `TaskGraph` returned by `updateBundleStatus` (never from an unnormalized intermediate graph) to keep the human-readable view in sync.
+
+#### Scenario: Status transitions from pending to in_progress
+
+- **WHEN** `updateBundleStatus` is called with `("pending" bundle, "in_progress")`
+- **THEN** the returned task graph SHALL have the bundle's status as `"in_progress"`
+- **AND** the original task graph SHALL be unchanged
+- **AND** every child task's status in that bundle SHALL be unchanged
+
+#### Scenario: Status transitions from in_progress to done
+
+- **WHEN** `updateBundleStatus` is called with `("in_progress" bundle, "done")`
+- **THEN** the returned task graph SHALL have the bundle's status as `"done"`
+- **AND** every child task's status in that bundle SHALL be `"done"` in the returned graph
+
+#### Scenario: Invalid status transition is rejected
+
+- **WHEN** `updateBundleStatus` is called with `("done" bundle, "pending")`
+- **THEN** it SHALL return a typed error indicating an invalid status transition
+
+#### Scenario: Bundle transition to done normalizes pending child tasks
+
+- **WHEN** `updateBundleStatus` is called with `("in_progress" bundle, "done")` and that bundle's `tasks` contains at least one task with `status = "pending"`
+- **THEN** the returned task graph SHALL have every `tasks[*].status` in that bundle equal to `"done"`
+- **AND** the original task graph SHALL be unchanged
+
+#### Scenario: Bundle transition to skipped normalizes child tasks
+
+- **WHEN** `updateBundleStatus` is called with `("pending" bundle, "skipped")`
+- **THEN** the returned task graph SHALL have every `tasks[*].status` in that bundle equal to `"skipped"`
+
+#### Scenario: Normalization force-coerces conflicting prior terminal child status
+
+- **WHEN** `updateBundleStatus` is called with a terminal target status and at least one child task already holds a different terminal status (e.g., child is `"done"` and the new bundle status is `"skipped"`)
+- **THEN** the returned task graph SHALL have that child's status rewritten to match the bundle's new terminal status
+- **AND** a structured audit log entry SHALL be emitted containing `bundle_id`, `task_id`, `from_status`, and `to_status`
+
+#### Scenario: Terminal transition on empty bundle is a no-op for children
+
+- **WHEN** `updateBundleStatus` is called with a terminal target status on a bundle whose `tasks` array is empty
+- **THEN** the returned task graph SHALL have the bundle's status set to the terminal value
+- **AND** no audit log entry for child coercion SHALL be emitted
+
+#### Scenario: Audit log suppressed when coercion does not change status
+
+- **WHEN** `updateBundleStatus` is called with a terminal target status and every child task already holds the same status as the bundle's new terminal status
+- **THEN** the returned task graph SHALL reflect the bundle terminal status
+- **AND** no audit log entry for child coercion SHALL be emitted
+
+#### Scenario: updateBundleStatus does not mutate input graph
+
+- **WHEN** `updateBundleStatus` is called with any valid arguments
+- **THEN** the original `TaskGraph` argument SHALL be structurally unchanged (bundle statuses and every `tasks[*].status` preserved)
+- **AND** any mutations SHALL only appear in the returned `TaskGraph`
+
+#### Scenario: tasks.md is re-rendered from normalized graph after terminal transition
+
+- **WHEN** a bundle status is updated to a terminal value and `task-graph.json` is persisted
+- **THEN** `tasks.md` SHALL be re-rendered from the normalized `TaskGraph` returned by `updateBundleStatus`
+- **AND** the rendered checklist for that bundle SHALL show every task's checkbox state as matching the bundle's terminal status
+
+#### Scenario: Atomic persistence avoids mismatched intermediate state
+
+- **WHEN** `task-graph.json` is written after a terminal bundle transition
+- **THEN** the persistence path SHALL use an atomic write (e.g., write-to-temp + rename) so that a concurrent reader observes either the pre-update graph or the fully normalized post-update graph
+- **AND** the persisted file SHALL NOT contain a bundle whose status is terminal while any of its child task statuses disagree

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/task-graph.json
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/task-graph.json
@@ -1,0 +1,329 @@
+{
+  "version": "1.0",
+  "change_id": "normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete",
+  "bundles": [
+    {
+      "id": "extend-status-update-types",
+      "title": "Extend status update types with coercion metadata",
+      "goal": "Introduce TaskStatusCoercion type and extend StatusUpdateResult so callers can audit child-task coercions.",
+      "depends_on": [],
+      "inputs": [
+        "src/lib/task-planner/status.ts",
+        "src/lib/task-planner/types.ts",
+        "src/lib/task-planner/index.ts"
+      ],
+      "outputs": [
+        "src/lib/task-planner/status.ts (TaskStatusCoercion + extended StatusUpdateResult)",
+        "src/lib/task-planner/index.ts (TaskStatusCoercion re-export)"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Add TaskStatusCoercion interface (bundleId, taskId, from, to) in status.ts",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Extend StatusUpdateResult with readonly coercions: readonly TaskStatusCoercion[]",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Re-export TaskStatusCoercion from src/lib/task-planner/index.ts",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "task-planner"
+      ]
+    },
+    {
+      "id": "normalize-children-in-update-bundle-status",
+      "title": "Normalize child task statuses inside updateBundleStatus",
+      "goal": "Coerce child task statuses to the terminal bundle status on done/skipped transitions while preserving purity and immutability.",
+      "depends_on": [
+        "extend-status-update-types"
+      ],
+      "inputs": [
+        "src/lib/task-planner/status.ts",
+        "src/lib/task-planner/types.ts"
+      ],
+      "outputs": [
+        "src/lib/task-planner/status.ts (normalization logic + coercions array)"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Detect terminal target status ('done' | 'skipped') inside updateBundleStatus",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Rebuild bundle.tasks immutably with each task.status set to target terminal value",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Collect one TaskStatusCoercion entry per child whose status actually changed",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Return empty coercions array for non-terminal transitions and for empty-bundle cases",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Force-coerce conflicting prior terminal child statuses (e.g. done → skipped) and emit coercion entries",
+          "status": "done"
+        },
+        {
+          "id": "6",
+          "title": "Ensure input TaskGraph is never mutated and bundles array is rebuilt immutably",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "task-planner"
+      ]
+    },
+    {
+      "id": "unit-tests-for-normalization",
+      "title": "Unit tests for status normalization and coercion reporting",
+      "goal": "Cover terminal transitions, non-terminal transitions, empty bundles, conflicting prior terminal states, and immutability guarantees.",
+      "depends_on": [
+        "normalize-children-in-update-bundle-status"
+      ],
+      "inputs": [
+        "src/tests/task-planner-core.test.ts",
+        "src/lib/task-planner/status.ts"
+      ],
+      "outputs": [
+        "src/tests/task-planner-core.test.ts (new test cases)"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Test: bundle → done coerces all pending children to done and reports coercions",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Test: bundle → skipped coerces all pending children to skipped and reports coercions",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Test: no-op children (already matching target) produce no coercion entries",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Test: non-terminal transition returns empty coercions and leaves task statuses untouched",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Test: empty-bundle terminal transition updates bundle status and returns empty coercions",
+          "status": "done"
+        },
+        {
+          "id": "6",
+          "title": "Test: conflicting prior terminal child (done when bundle → skipped) is force-coerced and logged",
+          "status": "done"
+        },
+        {
+          "id": "7",
+          "title": "Test: input TaskGraph reference and nested arrays are not mutated",
+          "status": "done"
+        },
+        {
+          "id": "8",
+          "title": "Test: rejected transitions (e.g. done → pending) still return ok:false with no coercions",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "task-planner"
+      ]
+    },
+    {
+      "id": "renderer-consistency-tests",
+      "title": "Renderer consistency tests after normalization",
+      "goal": "Verify renderTasksMd produces a tasks.md whose checkboxes match the bundle header after a terminal transition.",
+      "depends_on": [
+        "normalize-children-in-update-bundle-status"
+      ],
+      "inputs": [
+        "src/lib/task-planner/render.ts",
+        "src/tests/task-planner-core.test.ts"
+      ],
+      "outputs": [
+        "src/tests/task-planner-core.test.ts (renderer consistency cases)"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Test: after bundle → done, rendered tasks.md shows checked boxes under the done header",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Test: after bundle → skipped, rendered tasks.md reflects skipped state consistently",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Confirm renderTasksMd remains unchanged (no special-casing added)",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "task-planner"
+      ]
+    },
+    {
+      "id": "apply-phase-caller-integration",
+      "title": "Wire coercions through the apply-phase caller",
+      "goal": "Persist the normalized graph, re-render tasks.md atomically, and emit one structured log per coercion.",
+      "depends_on": [
+        "normalize-children-in-update-bundle-status",
+        "extend-status-update-types"
+      ],
+      "inputs": [
+        "apply-phase caller (persistence + logging wiring)",
+        "src/lib/task-planner/index.ts",
+        "src/lib/task-planner/render.ts"
+      ],
+      "outputs": [
+        "apply-phase caller updated to consume result.coercions",
+        "atomic write sequence for task-graph.json and tasks.md",
+        "structured audit log lines per coercion"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Invoke updateBundleStatus and branch on result.ok in the apply-phase caller",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Persist result.taskGraph to task-graph.json using existing atomic write-temp+rename pattern",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Render tasks.md via renderTasksMd(result.taskGraph) and write atomically",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Emit one structured log line per TaskStatusCoercion with bundle_id, task_id, from_status, to_status",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Ensure no log is emitted when coercions is empty (no-op silence)",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "task-planner",
+        "workflow-run-state"
+      ]
+    },
+    {
+      "id": "apply-phase-integration-tests",
+      "title": "Integration tests for apply-phase persistence and logging",
+      "goal": "Assert end-to-end that a terminal bundle transition persists a consistent graph, re-renders tasks.md, and logs exactly one line per coercion.",
+      "depends_on": [
+        "apply-phase-caller-integration"
+      ],
+      "inputs": [
+        "apply-phase caller tests",
+        "src/tests/"
+      ],
+      "outputs": [
+        "integration tests covering persistence + render + logging"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Test: apply-phase terminal transition writes consistent task-graph.json (bundle + children match)",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Test: apply-phase terminal transition writes tasks.md whose checkboxes match bundle header",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Test: exactly one audit log line is emitted per coercion entry",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Test: no audit log lines on non-terminal transitions or when all children already matched",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Test: atomic write pattern is used for both task-graph.json and tasks.md",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "task-planner",
+        "workflow-run-state"
+      ]
+    },
+    {
+      "id": "verification-and-docs",
+      "title": "Repository verification and release note",
+      "goal": "Run formatting, linting, type checking, tests, and build; document the additive API change.",
+      "depends_on": [
+        "unit-tests-for-normalization",
+        "renderer-consistency-tests",
+        "apply-phase-integration-tests"
+      ],
+      "inputs": [
+        "repository verification commands",
+        "release notes / changelog"
+      ],
+      "outputs": [
+        "green verification run",
+        "release note entry describing additive StatusUpdateResult.coercions field"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Run repository-defined format, lint, type-check, test, and build commands for affected scope",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Fix any failures surfaced by verification steps",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Add release note describing additive StatusUpdateResult.coercions and new TaskStatusCoercion export",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "task-planner"
+      ]
+    }
+  ],
+  "generated_at": "2026-04-15T05:23:39.184Z",
+  "generated_from": "design.md"
+}

--- a/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/tasks.md
+++ b/openspec/changes/archive/2026-04-15-normalize-task-statuses-and-re-render-tasks-md-when-bundles-complete/tasks.md
@@ -1,0 +1,79 @@
+## 1. Extend status update types with coercion metadata ✓
+
+> Introduce TaskStatusCoercion type and extend StatusUpdateResult so callers can audit child-task coercions.
+
+- [x] 1.1 Add TaskStatusCoercion interface (bundleId, taskId, from, to) in status.ts
+- [x] 1.2 Extend StatusUpdateResult with readonly coercions: readonly TaskStatusCoercion[]
+- [x] 1.3 Re-export TaskStatusCoercion from src/lib/task-planner/index.ts
+
+## 2. Normalize child task statuses inside updateBundleStatus ✓
+
+> Coerce child task statuses to the terminal bundle status on done/skipped transitions while preserving purity and immutability.
+
+> Depends on: extend-status-update-types
+
+- [x] 2.1 Detect terminal target status ('done' | 'skipped') inside updateBundleStatus
+- [x] 2.2 Rebuild bundle.tasks immutably with each task.status set to target terminal value
+- [x] 2.3 Collect one TaskStatusCoercion entry per child whose status actually changed
+- [x] 2.4 Return empty coercions array for non-terminal transitions and for empty-bundle cases
+- [x] 2.5 Force-coerce conflicting prior terminal child statuses (e.g. done → skipped) and emit coercion entries
+- [x] 2.6 Ensure input TaskGraph is never mutated and bundles array is rebuilt immutably
+
+## 3. Unit tests for status normalization and coercion reporting ✓
+
+> Cover terminal transitions, non-terminal transitions, empty bundles, conflicting prior terminal states, and immutability guarantees.
+
+> Depends on: normalize-children-in-update-bundle-status
+
+- [x] 3.1 Test: bundle → done coerces all pending children to done and reports coercions
+- [x] 3.2 Test: bundle → skipped coerces all pending children to skipped and reports coercions
+- [x] 3.3 Test: no-op children (already matching target) produce no coercion entries
+- [x] 3.4 Test: non-terminal transition returns empty coercions and leaves task statuses untouched
+- [x] 3.5 Test: empty-bundle terminal transition updates bundle status and returns empty coercions
+- [x] 3.6 Test: conflicting prior terminal child (done when bundle → skipped) is force-coerced and logged
+- [x] 3.7 Test: input TaskGraph reference and nested arrays are not mutated
+- [x] 3.8 Test: rejected transitions (e.g. done → pending) still return ok:false with no coercions
+
+## 4. Renderer consistency tests after normalization ✓
+
+> Verify renderTasksMd produces a tasks.md whose checkboxes match the bundle header after a terminal transition.
+
+> Depends on: normalize-children-in-update-bundle-status
+
+- [x] 4.1 Test: after bundle → done, rendered tasks.md shows checked boxes under the done header
+- [x] 4.2 Test: after bundle → skipped, rendered tasks.md reflects skipped state consistently
+- [x] 4.3 Confirm renderTasksMd remains unchanged (no special-casing added)
+
+## 5. Wire coercions through the apply-phase caller ✓
+
+> Persist the normalized graph, re-render tasks.md atomically, and emit one structured log per coercion.
+
+> Depends on: normalize-children-in-update-bundle-status, extend-status-update-types
+
+- [x] 5.1 Invoke updateBundleStatus and branch on result.ok in the apply-phase caller
+- [x] 5.2 Persist result.taskGraph to task-graph.json using existing atomic write-temp+rename pattern
+- [x] 5.3 Render tasks.md via renderTasksMd(result.taskGraph) and write atomically
+- [x] 5.4 Emit one structured log line per TaskStatusCoercion with bundle_id, task_id, from_status, to_status
+- [x] 5.5 Ensure no log is emitted when coercions is empty (no-op silence)
+
+## 6. Integration tests for apply-phase persistence and logging ✓
+
+> Assert end-to-end that a terminal bundle transition persists a consistent graph, re-renders tasks.md, and logs exactly one line per coercion.
+
+> Depends on: apply-phase-caller-integration
+
+- [x] 6.1 Test: apply-phase terminal transition writes consistent task-graph.json (bundle + children match)
+- [x] 6.2 Test: apply-phase terminal transition writes tasks.md whose checkboxes match bundle header
+- [x] 6.3 Test: exactly one audit log line is emitted per coercion entry
+- [x] 6.4 Test: no audit log lines on non-terminal transitions or when all children already matched
+- [x] 6.5 Test: atomic write pattern is used for both task-graph.json and tasks.md
+
+## 7. Repository verification and release note ✓
+
+> Run formatting, linting, type checking, tests, and build; document the additive API change.
+
+> Depends on: unit-tests-for-normalization, renderer-consistency-tests, apply-phase-integration-tests
+
+- [x] 7.1 Run repository-defined format, lint, type-check, test, and build commands for affected scope
+- [x] 7.2 Fix any failures surfaced by verification steps
+- [x] 7.3 Add release note describing additive StatusUpdateResult.coercions and new TaskStatusCoercion export

--- a/openspec/specs/task-planner/spec.md
+++ b/openspec/specs/task-planner/spec.md
@@ -165,28 +165,84 @@ The apply phase SHALL update bundle and task status in `task-graph.json` after e
 
 The system SHALL provide `updateBundleStatus(taskGraph, bundleId, newStatus)` that returns a new `TaskGraph` with the specified bundle's status updated. The original task graph SHALL NOT be mutated.
 
-After status update, `tasks.md` SHALL be re-rendered from the updated task graph to keep the human-readable view in sync.
+When the new bundle status is a **terminal** status (`"done"` or `"skipped"`), `updateBundleStatus` SHALL also **normalize all child task statuses** within that bundle so they match the bundle's terminal status in the returned `TaskGraph`:
+- `bundle.status = "done"` → every `tasks[*].status` in that bundle SHALL be `"done"`
+- `bundle.status = "skipped"` → every `tasks[*].status` in that bundle SHALL be `"skipped"`
+
+Normalization applies unconditionally regardless of the prior child status (including children that already hold a different terminal status). The bundle is the authoritative execution unit; per-task status is informational. A bundle with an empty `tasks` array is a no-op with respect to child coercion; the terminal bundle status is still applied.
+
+Normalization applies **only on terminal transitions**. Non-terminal transitions (`pending → in_progress`, and any other transition whose target is `pending` or `in_progress`) SHALL NOT modify child task statuses.
+
+The returned `TaskGraph` SHALL contain both the bundle status change and all child coercions as a single in-memory update. When the caller persists `task-graph.json`, it SHALL be written atomically (e.g., write-to-temp + rename) so that the persisted graph is either the pre-update state or the fully normalized post-update state — never a mismatched intermediate state.
+
+Whenever normalization actually changes a child task's status (from a value different from the target terminal status), the apply path SHALL emit a structured audit log entry containing at minimum: `bundle_id`, `task_id`, `from_status`, and `to_status`. Coercions that do not change a child's status (the child already matched the bundle's terminal status) SHALL NOT emit a log entry.
+
+After status update, `tasks.md` SHALL be re-rendered from the normalized `TaskGraph` returned by `updateBundleStatus` (never from an unnormalized intermediate graph) to keep the human-readable view in sync.
 
 #### Scenario: Status transitions from pending to in_progress
 
 - **WHEN** `updateBundleStatus` is called with `("pending" bundle, "in_progress")`
 - **THEN** the returned task graph SHALL have the bundle's status as `"in_progress"`
 - **AND** the original task graph SHALL be unchanged
+- **AND** every child task's status in that bundle SHALL be unchanged
 
 #### Scenario: Status transitions from in_progress to done
 
 - **WHEN** `updateBundleStatus` is called with `("in_progress" bundle, "done")`
 - **THEN** the returned task graph SHALL have the bundle's status as `"done"`
+- **AND** every child task's status in that bundle SHALL be `"done"` in the returned graph
 
 #### Scenario: Invalid status transition is rejected
 
 - **WHEN** `updateBundleStatus` is called with `("done" bundle, "pending")`
 - **THEN** it SHALL return a typed error indicating an invalid status transition
 
-#### Scenario: tasks.md is re-rendered after status update
+#### Scenario: Bundle transition to done normalizes pending child tasks
 
-- **WHEN** bundle status is updated and the task graph is persisted
-- **THEN** `tasks.md` SHALL be re-rendered from the updated task graph
+- **WHEN** `updateBundleStatus` is called with `("in_progress" bundle, "done")` and that bundle's `tasks` contains at least one task with `status = "pending"`
+- **THEN** the returned task graph SHALL have every `tasks[*].status` in that bundle equal to `"done"`
+- **AND** the original task graph SHALL be unchanged
+
+#### Scenario: Bundle transition to skipped normalizes child tasks
+
+- **WHEN** `updateBundleStatus` is called with `("pending" bundle, "skipped")`
+- **THEN** the returned task graph SHALL have every `tasks[*].status` in that bundle equal to `"skipped"`
+
+#### Scenario: Normalization force-coerces conflicting prior terminal child status
+
+- **WHEN** `updateBundleStatus` is called with a terminal target status and at least one child task already holds a different terminal status (e.g., child is `"done"` and the new bundle status is `"skipped"`)
+- **THEN** the returned task graph SHALL have that child's status rewritten to match the bundle's new terminal status
+- **AND** a structured audit log entry SHALL be emitted containing `bundle_id`, `task_id`, `from_status`, and `to_status`
+
+#### Scenario: Terminal transition on empty bundle is a no-op for children
+
+- **WHEN** `updateBundleStatus` is called with a terminal target status on a bundle whose `tasks` array is empty
+- **THEN** the returned task graph SHALL have the bundle's status set to the terminal value
+- **AND** no audit log entry for child coercion SHALL be emitted
+
+#### Scenario: Audit log suppressed when coercion does not change status
+
+- **WHEN** `updateBundleStatus` is called with a terminal target status and every child task already holds the same status as the bundle's new terminal status
+- **THEN** the returned task graph SHALL reflect the bundle terminal status
+- **AND** no audit log entry for child coercion SHALL be emitted
+
+#### Scenario: updateBundleStatus does not mutate input graph
+
+- **WHEN** `updateBundleStatus` is called with any valid arguments
+- **THEN** the original `TaskGraph` argument SHALL be structurally unchanged (bundle statuses and every `tasks[*].status` preserved)
+- **AND** any mutations SHALL only appear in the returned `TaskGraph`
+
+#### Scenario: tasks.md is re-rendered from normalized graph after terminal transition
+
+- **WHEN** a bundle status is updated to a terminal value and `task-graph.json` is persisted
+- **THEN** `tasks.md` SHALL be re-rendered from the normalized `TaskGraph` returned by `updateBundleStatus`
+- **AND** the rendered checklist for that bundle SHALL show every task's checkbox state as matching the bundle's terminal status
+
+#### Scenario: Atomic persistence avoids mismatched intermediate state
+
+- **WHEN** `task-graph.json` is written after a terminal bundle transition
+- **THEN** the persistence path SHALL use an atomic write (e.g., write-to-temp + rename) so that a concurrent reader observes either the pre-update graph or the fully normalized post-update graph
+- **AND** the persisted file SHALL NOT contain a bundle whose status is terminal while any of its child task statuses disagree
 
 ### Requirement: Legacy fallback supports changes without task graph
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"type": "module",
 	"bin": {
+		"specflow-advance-bundle": "bin/specflow-advance-bundle",
 		"specflow-analyze": "bin/specflow-analyze",
 		"specflow-create-sub-issues": "bin/specflow-create-sub-issues",
 		"specflow-design-artifacts": "bin/specflow-design-artifacts",

--- a/src/bin/specflow-advance-bundle.ts
+++ b/src/bin/specflow-advance-bundle.ts
@@ -1,0 +1,165 @@
+// specflow-advance-bundle — CLI wrapper around advanceBundleStatus.
+//
+// Reads task-graph.json for a change, advances one bundle to a new status
+// with child-task normalization, atomically persists task-graph.json and
+// tasks.md, and emits one JSON audit log line per child-task coercion.
+//
+// Usage: specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>
+
+import { ChangeArtifactType, changeRef } from "../lib/artifact-types.js";
+import { tryGit } from "../lib/git.js";
+import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
+import { advanceBundleStatus } from "../lib/task-planner/advance.js";
+import { validateTaskGraph } from "../lib/task-planner/schema.js";
+import type { BundleStatus, TaskGraph } from "../lib/task-planner/types.js";
+
+const VALID_STATUSES: readonly BundleStatus[] = [
+	"pending",
+	"in_progress",
+	"done",
+	"skipped",
+];
+
+interface DieContext {
+	readonly changeId?: string;
+	readonly bundleId?: string;
+	readonly newStatus?: string;
+}
+
+/**
+ * Emit an `advance-bundle-result` error envelope to stdout and exit 1.
+ *
+ * Unified with the post-orchestration error path so programmatic callers can
+ * always `JSON.parse(stdout)` without branching on pre- vs post-call shape.
+ * Unknown fields (e.g., `bundle_id` before args are parsed) are simply
+ * omitted; the schema only requires `status` and `error` on the error branch.
+ */
+function die(error: string, context: DieContext = {}): never {
+	const payload: Record<string, unknown> = { status: "error", error };
+	if (context.changeId !== undefined) payload.change_id = context.changeId;
+	if (context.bundleId !== undefined) payload.bundle_id = context.bundleId;
+	if (context.newStatus !== undefined) payload.new_status = context.newStatus;
+	process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+	process.exit(1);
+}
+
+function ensureGitRepo(): string {
+	const result = tryGit(["rev-parse", "--show-toplevel"], process.cwd());
+	if (result.status !== 0) {
+		die("Not in a git repository");
+	}
+	return result.stdout.trim();
+}
+
+function isBundleStatus(value: string): value is BundleStatus {
+	return (VALID_STATUSES as readonly string[]).includes(value);
+}
+
+function main(): void {
+	const args = process.argv.slice(2);
+	if (args.length < 3) {
+		die(
+			"Usage: specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>. " +
+				`NEW_STATUS must be one of: ${VALID_STATUSES.join(" | ")}`,
+		);
+	}
+
+	const [changeId, bundleId, rawStatus] = args;
+	if (!isBundleStatus(rawStatus)) {
+		die(
+			`Invalid NEW_STATUS: '${rawStatus}'. Must be one of: ${VALID_STATUSES.join(", ")}`,
+			{ changeId, bundleId, newStatus: rawStatus },
+		);
+	}
+
+	const projectRoot = ensureGitRepo();
+	const store = createLocalFsChangeArtifactStore(projectRoot);
+	const taskGraphRef = changeRef(changeId, ChangeArtifactType.TaskGraph);
+	if (!store.exists(taskGraphRef)) {
+		die(`task-graph.json not found for change '${changeId}'`, {
+			changeId,
+			bundleId,
+			newStatus: rawStatus,
+		});
+	}
+
+	let taskGraph: TaskGraph;
+	try {
+		const parsed = JSON.parse(store.read(taskGraphRef)) as unknown;
+		const validation = validateTaskGraph(parsed);
+		if (!validation.valid) {
+			die(
+				`task-graph.json schema validation failed: ${validation.errors.join("; ")}`,
+				{ changeId, bundleId, newStatus: rawStatus },
+			);
+		}
+		taskGraph = parsed as TaskGraph;
+	} catch (error) {
+		die(
+			`Failed to parse task-graph.json: ${error instanceof Error ? error.message : String(error)}`,
+			{ changeId, bundleId, newStatus: rawStatus },
+		);
+	}
+
+	const tasksRef = changeRef(changeId, ChangeArtifactType.Tasks);
+	const result = advanceBundleStatus({
+		taskGraph,
+		bundleId,
+		newStatus: rawStatus,
+		writer: {
+			writeTaskGraph(content) {
+				store.write(taskGraphRef, content);
+			},
+			writeTasksMd(content) {
+				store.write(tasksRef, content);
+			},
+		},
+		logger(coercion) {
+			// One structured JSON line per actual status change. Written to
+			// stderr so stdout stays reserved for the machine-readable result.
+			process.stderr.write(
+				`${JSON.stringify({
+					event: "task_status_coercion",
+					change_id: changeId,
+					bundle_id: coercion.bundleId,
+					task_id: coercion.taskId,
+					from_status: coercion.from,
+					to_status: coercion.to,
+				})}\n`,
+			);
+		},
+	});
+
+	if (!result.ok) {
+		process.stdout.write(
+			`${JSON.stringify(
+				{
+					status: "error",
+					change_id: changeId,
+					bundle_id: bundleId,
+					new_status: rawStatus,
+					error: result.error,
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		process.exit(1);
+	}
+
+	process.stdout.write(
+		`${JSON.stringify(
+			{
+				status: "success",
+				change_id: changeId,
+				bundle_id: bundleId,
+				new_status: rawStatus,
+				coercions: result.coercions.length,
+			},
+			null,
+			2,
+		)}\n`,
+	);
+}
+
+main();

--- a/src/contracts/orchestrators.ts
+++ b/src/contracts/orchestrators.ts
@@ -2,6 +2,14 @@ import { AssetType, type OrchestratorContract } from "../types/contracts.js";
 
 export const orchestratorContracts: readonly OrchestratorContract[] = [
 	{
+		id: "specflow-advance-bundle",
+		type: AssetType.Orchestrator,
+		filePath: "bin/specflow-advance-bundle",
+		entryModule: "dist/bin/specflow-advance-bundle.js",
+		stdoutSchemaId: "advance-bundle-result",
+		references: [],
+	},
+	{
 		id: "specflow-analyze",
 		type: AssetType.Orchestrator,
 		filePath: "bin/specflow-analyze",

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1045,6 +1045,40 @@ function generateTaskGraphResultValidator(
 	}
 }
 
+function advanceBundleResultValidator(
+	value: unknown,
+	path: string,
+	errors: ValidationErrors,
+): void {
+	const record = expectRecord(value, path, errors);
+	if (!record) {
+		return;
+	}
+	stringValidator(record.status, `${path}.status`, errors);
+	if (record.status === "success") {
+		// Success always comes from the orchestration call and carries the
+		// full identity tuple plus the coercion count.
+		stringValidator(record.change_id, `${path}.change_id`, errors);
+		stringValidator(record.bundle_id, `${path}.bundle_id`, errors);
+		stringValidator(record.new_status, `${path}.new_status`, errors);
+		numberValidator(record.coercions, `${path}.coercions`, errors);
+	}
+	if (record.status === "error") {
+		// Error may be emitted before CLI argv parsing completes, so the
+		// identity tuple is optional (populated when context is available).
+		stringValidator(record.error, `${path}.error`, errors);
+		if (record.change_id !== undefined) {
+			stringValidator(record.change_id, `${path}.change_id`, errors);
+		}
+		if (record.bundle_id !== undefined) {
+			stringValidator(record.bundle_id, `${path}.bundle_id`, errors);
+		}
+		if (record.new_status !== undefined) {
+			stringValidator(record.new_status, `${path}.new_status`, errors);
+		}
+	}
+}
+
 export const schemaValidators: Readonly<Record<SchemaId, SchemaValidator>> = {
 	"issue-metadata": issueMetadataValidator,
 	"source-metadata": sourceMetadataValidator,
@@ -1062,6 +1096,7 @@ export const schemaValidators: Readonly<Record<SchemaId, SchemaValidator>> = {
 	"create-sub-issues-input": createSubIssuesInputValidator,
 	"create-sub-issues-result": createSubIssuesResultValidator,
 	"generate-task-graph-result": generateTaskGraphResultValidator,
+	"advance-bundle-result": advanceBundleResultValidator,
 	profile: profileValidator,
 };
 

--- a/src/lib/task-planner/advance.ts
+++ b/src/lib/task-planner/advance.ts
@@ -1,0 +1,100 @@
+// advance.ts — apply-phase caller for bundle status transitions.
+//
+// Orchestrates the full "update + persist + render + log" sequence around the
+// pure `updateBundleStatus` function so the apply-phase has a single entry
+// point that guarantees task-graph.json and tasks.md stay in sync, and that
+// every child-task coercion emits exactly one structured audit log line.
+
+import { renderTasksMd } from "./render.js";
+import {
+	type StatusUpdateError,
+	type TaskStatusCoercion,
+	updateBundleStatus,
+} from "./status.js";
+import type { BundleStatus, TaskGraph } from "./types.js";
+
+/**
+ * Pluggable sink for the task-graph.json / tasks.md writes. Structured as
+ * an interface so tests can inject an in-memory writer and the production
+ * caller can pass a filesystem writer (atomic write-to-temp + rename).
+ */
+export interface AdvanceBundleWriter {
+	writeTaskGraph(content: string): void;
+	writeTasksMd(content: string): void;
+}
+
+/**
+ * Pluggable sink for structured audit log lines. One call per child-task
+ * coercion that actually changed status. No calls are made when the
+ * `coercions` array is empty (non-terminal transition, empty-bundle terminal
+ * transition, or every child already matched the target).
+ */
+export type AdvanceBundleLogger = (coercion: TaskStatusCoercion) => void;
+
+export interface AdvanceBundleOptions {
+	readonly taskGraph: TaskGraph;
+	readonly bundleId: string;
+	readonly newStatus: BundleStatus;
+	readonly writer: AdvanceBundleWriter;
+	readonly logger?: AdvanceBundleLogger;
+}
+
+export interface AdvanceBundleSuccess {
+	readonly ok: true;
+	readonly taskGraph: TaskGraph;
+	readonly coercions: readonly TaskStatusCoercion[];
+}
+
+export type AdvanceBundleResult = AdvanceBundleSuccess | StatusUpdateError;
+
+function serializeTaskGraph(taskGraph: TaskGraph): string {
+	return `${JSON.stringify(taskGraph, null, 2)}\n`;
+}
+
+/**
+ * Advance a bundle to a new status, persist the normalized task graph and
+ * rendered tasks.md, and emit audit logs for every child-task coercion that
+ * actually changed status. Persistence and logging are performed via the
+ * injected `writer` and `logger` so the orchestration stays testable.
+ *
+ * The returned `taskGraph` is the normalized graph. Callers that need to
+ * react to coercions after persistence can also read `result.coercions`.
+ *
+ * On invalid transitions or unknown bundles, no writes or logs are emitted
+ * and the original error is returned unchanged.
+ */
+export function advanceBundleStatus(
+	options: AdvanceBundleOptions,
+): AdvanceBundleResult {
+	const result = updateBundleStatus(
+		options.taskGraph,
+		options.bundleId,
+		options.newStatus,
+	);
+	if (!result.ok) {
+		return result;
+	}
+
+	// 1) Persist the normalized task graph. Writers are expected to use an
+	//    atomic write pattern (write-to-temp + rename) so crash-mid-write
+	//    leaves either the old or the fully-normalized state.
+	options.writer.writeTaskGraph(serializeTaskGraph(result.taskGraph));
+
+	// 2) Re-render tasks.md from the normalized graph (NOT an intermediate
+	//    graph) and persist with the same atomic guarantee.
+	options.writer.writeTasksMd(renderTasksMd(result.taskGraph));
+
+	// 3) Emit one audit log per coercion that actually changed status.
+	//    Empty `coercions` yields zero log calls (no-op silence).
+	if (options.logger) {
+		for (const coercion of result.coercions) {
+			options.logger(coercion);
+		}
+	}
+
+	return {
+		ok: true,
+		taskGraph: result.taskGraph,
+		coercions: result.coercions,
+	};
+}

--- a/src/lib/task-planner/index.ts
+++ b/src/lib/task-planner/index.ts
@@ -1,5 +1,13 @@
 // Task planner — specflow-owned task graph generation, rendering, and lifecycle.
 
+export type {
+	AdvanceBundleLogger,
+	AdvanceBundleOptions,
+	AdvanceBundleResult,
+	AdvanceBundleSuccess,
+	AdvanceBundleWriter,
+} from "./advance.js";
+export { advanceBundleStatus } from "./advance.js";
 export type { ArtifactChecker } from "./completion.js";
 export { checkBundleCompletion } from "./completion.js";
 export type {
@@ -8,12 +16,15 @@ export type {
 	GenerateResult,
 	LlmClient,
 } from "./generate.js";
-
 export { generateTaskGraph } from "./generate.js";
 export { renderTasksMd } from "./render.js";
 export type { ValidationResult } from "./schema.js";
 export { assertValidTaskGraph, validateTaskGraph } from "./schema.js";
-export type { StatusUpdateError, StatusUpdateResult } from "./status.js";
+export type {
+	StatusUpdateError,
+	StatusUpdateResult,
+	TaskStatusCoercion,
+} from "./status.js";
 export { updateBundleStatus } from "./status.js";
 export type {
 	Bundle,

--- a/src/lib/task-planner/status.ts
+++ b/src/lib/task-planner/status.ts
@@ -1,10 +1,37 @@
-// Immutable bundle status transitions.
+// Immutable bundle status transitions with child-task normalization on
+// terminal transitions. Normalization keeps the bundle (execution truth) and
+// its child task statuses (informational view) aligned inside the returned
+// TaskGraph, and reports every actual coercion so callers can emit audit logs.
 
-import type { BundleStatus, TaskGraph } from "./types.js";
+import type {
+	Bundle,
+	BundleStatus,
+	Task,
+	TaskGraph,
+	TaskStatus,
+} from "./types.js";
+
+/**
+ * One entry per child `Task` whose `status` was rewritten to match a terminal
+ * bundle status. Callers (apply-phase) use this to emit structured audit logs.
+ * No-op coercions (child already matched the target) are NOT included.
+ */
+export interface TaskStatusCoercion {
+	readonly bundleId: string;
+	readonly taskId: string;
+	readonly from: TaskStatus;
+	readonly to: TaskStatus;
+}
 
 export interface StatusUpdateResult {
 	readonly ok: true;
 	readonly taskGraph: TaskGraph;
+	/**
+	 * Child-task coercions applied as part of a terminal bundle transition.
+	 * Empty for non-terminal transitions, empty-`tasks` bundles, and for
+	 * terminal transitions where every child already matched the target.
+	 */
+	readonly coercions: readonly TaskStatusCoercion[];
 }
 
 export interface StatusUpdateError {
@@ -19,6 +46,44 @@ const VALID_TRANSITIONS: ReadonlyMap<BundleStatus, readonly BundleStatus[]> =
 		["done", []],
 		["skipped", []],
 	]);
+
+const TERMINAL_BUNDLE_STATUSES: ReadonlySet<BundleStatus> = new Set([
+	"done",
+	"skipped",
+]);
+
+function isTerminal(status: BundleStatus): boolean {
+	return TERMINAL_BUNDLE_STATUSES.has(status);
+}
+
+/**
+ * Rebuild a bundle's `tasks` array so every `task.status` equals `target`.
+ * Returns the rebuilt tasks plus the per-task coercion entries (only for
+ * tasks whose status actually changed).
+ */
+function normalizeChildTasks(
+	bundleId: string,
+	tasks: readonly Task[],
+	target: TaskStatus,
+): {
+	readonly tasks: readonly Task[];
+	readonly coercions: readonly TaskStatusCoercion[];
+} {
+	const coercions: TaskStatusCoercion[] = [];
+	const rebuilt = tasks.map((task) => {
+		if (task.status === target) {
+			return task;
+		}
+		coercions.push({
+			bundleId,
+			taskId: task.id,
+			from: task.status,
+			to: target,
+		});
+		return { ...task, status: target };
+	});
+	return { tasks: rebuilt, coercions };
+}
 
 export function updateBundleStatus(
 	taskGraph: TaskGraph,
@@ -39,7 +104,25 @@ export function updateBundleStatus(
 		};
 	}
 
-	const updatedBundle = { ...bundle, status: newStatus };
+	let updatedBundle: Bundle;
+	let coercions: readonly TaskStatusCoercion[];
+	if (isTerminal(newStatus)) {
+		// Terminal transitions force-coerce every child task to match. Empty
+		// `tasks` arrays are a vacuous success (no coercions emitted).
+		const normalized = normalizeChildTasks(bundle.id, bundle.tasks, newStatus);
+		updatedBundle = {
+			...bundle,
+			status: newStatus,
+			tasks: normalized.tasks,
+		};
+		coercions = normalized.coercions;
+	} else {
+		// Non-terminal transitions (e.g. pending → in_progress) do NOT touch
+		// child task statuses. Preserves the "tasks are informational" model.
+		updatedBundle = { ...bundle, status: newStatus };
+		coercions = [];
+	}
+
 	const updatedBundles = taskGraph.bundles.map((b, i) =>
 		i === bundleIndex ? updatedBundle : b,
 	);
@@ -47,5 +130,6 @@ export function updateBundleStatus(
 	return {
 		ok: true,
 		taskGraph: { ...taskGraph, bundles: updatedBundles },
+		coercions,
 	};
 }

--- a/src/tests/advance-bundle.test.ts
+++ b/src/tests/advance-bundle.test.ts
@@ -412,11 +412,10 @@ test("specflow-advance-bundle CLI: pre-orchestration errors emit advance-bundle-
 		);
 
 		// Missing args — the earliest failure path.
-		const missingArgs = spawnSync(
-			process.execPath,
-			[advanceBundleCliPath],
-			{ cwd: projectRoot, encoding: "utf8" },
-		);
+		const missingArgs = spawnSync(process.execPath, [advanceBundleCliPath], {
+			cwd: projectRoot,
+			encoding: "utf8",
+		});
 		assert.equal(missingArgs.status, 1);
 		const missingArgsPayload = JSON.parse(missingArgs.stdout) as Record<
 			string,

--- a/src/tests/advance-bundle.test.ts
+++ b/src/tests/advance-bundle.test.ts
@@ -1,0 +1,430 @@
+// Integration tests for advanceBundleStatus — the apply-phase caller around
+// the pure updateBundleStatus function. These assert end-to-end that:
+//  - A terminal bundle transition persists a consistent task-graph.json (bundle
+//    status + every child task status match).
+//  - tasks.md is re-rendered from the normalized graph (no unchecked boxes
+//    under a done / skipped bundle header).
+//  - The logger is called exactly once per TaskStatusCoercion with the
+//    expected payload.
+//  - The logger is NOT called on non-terminal transitions or when every child
+//    already matched the target (no-op silence).
+//  - Both writes use a write-to-temp + rename atomic pattern.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { ChangeArtifactType, changeRef } from "../lib/artifact-types.js";
+import { atomicWriteText } from "../lib/fs.js";
+import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
+import {
+	type AdvanceBundleWriter,
+	advanceBundleStatus,
+} from "../lib/task-planner/advance.js";
+import type { TaskStatusCoercion } from "../lib/task-planner/status.js";
+import type { TaskGraph } from "../lib/task-planner/types.js";
+
+const repoRoot = process.cwd();
+const advanceBundleCliPath = resolve(
+	repoRoot,
+	"dist/bin/specflow-advance-bundle.js",
+);
+
+function initGitRepo(repoPath: string): void {
+	spawnSync("git", ["init", "--quiet"], { cwd: repoPath, stdio: "ignore" });
+	spawnSync("git", ["symbolic-ref", "HEAD", "refs/heads/main"], {
+		cwd: repoPath,
+		stdio: "ignore",
+	});
+	spawnSync("git", ["config", "user.email", "specflow@example.com"], {
+		cwd: repoPath,
+		stdio: "ignore",
+	});
+	spawnSync("git", ["config", "user.name", "Specflow Tests"], {
+		cwd: repoPath,
+		stdio: "ignore",
+	});
+}
+
+function sampleGraph(): TaskGraph {
+	return {
+		version: "1.0",
+		change_id: "test-change",
+		generated_at: "2026-04-15T00:00:00Z",
+		generated_from: "design.md",
+		bundles: [
+			{
+				id: "implement-foo",
+				title: "Implement Foo",
+				goal: "Create the foo module",
+				depends_on: [],
+				inputs: [],
+				outputs: ["src/foo.ts"],
+				status: "in_progress",
+				tasks: [
+					{ id: "1", title: "Write foo types", status: "pending" },
+					{ id: "2", title: "Implement foo", status: "pending" },
+				],
+				owner_capabilities: ["task-planner"],
+			},
+		],
+	};
+}
+
+function captureWriter(): {
+	readonly writer: AdvanceBundleWriter;
+	readonly writes: ReadonlyArray<{
+		readonly target: string;
+		readonly content: string;
+	}>;
+} {
+	const writes: Array<{ target: string; content: string }> = [];
+	const writer: AdvanceBundleWriter = {
+		writeTaskGraph(content) {
+			writes.push({ target: "task-graph.json", content });
+		},
+		writeTasksMd(content) {
+			writes.push({ target: "tasks.md", content });
+		},
+	};
+	return { writer, writes };
+}
+
+test("advanceBundleStatus: terminal transition writes a consistent task-graph.json (bundle + children match)", () => {
+	const { writer, writes } = captureWriter();
+	const result = advanceBundleStatus({
+		taskGraph: sampleGraph(),
+		bundleId: "implement-foo",
+		newStatus: "done",
+		writer,
+	});
+	assert.equal(result.ok, true);
+	const graphWrite = writes.find((w) => w.target === "task-graph.json");
+	assert.ok(graphWrite, "task-graph.json was written");
+	const persisted = JSON.parse(graphWrite.content) as TaskGraph;
+	const bundle = persisted.bundles.find((b) => b.id === "implement-foo");
+	assert.equal(bundle?.status, "done");
+	for (const task of bundle?.tasks ?? []) {
+		assert.equal(task.status, "done");
+	}
+});
+
+test("advanceBundleStatus: terminal transition writes tasks.md whose checkboxes match bundle header", () => {
+	const { writer, writes } = captureWriter();
+	const result = advanceBundleStatus({
+		taskGraph: sampleGraph(),
+		bundleId: "implement-foo",
+		newStatus: "done",
+		writer,
+	});
+	assert.equal(result.ok, true);
+	const tasksWrite = writes.find((w) => w.target === "tasks.md");
+	assert.ok(tasksWrite, "tasks.md was written");
+	assert.ok(tasksWrite.content.includes("## 1. Implement Foo ✓"));
+	assert.ok(tasksWrite.content.includes("- [x] 1.1 Write foo types"));
+	assert.ok(tasksWrite.content.includes("- [x] 1.2 Implement foo"));
+	assert.ok(!tasksWrite.content.includes("- [ ] 1.1"));
+	assert.ok(!tasksWrite.content.includes("- [ ] 1.2"));
+});
+
+test("advanceBundleStatus: emits exactly one audit log line per coercion entry", () => {
+	const { writer } = captureWriter();
+	const logs: TaskStatusCoercion[] = [];
+	const result = advanceBundleStatus({
+		taskGraph: sampleGraph(),
+		bundleId: "implement-foo",
+		newStatus: "done",
+		writer,
+		logger: (c) => logs.push(c),
+	});
+	assert.equal(result.ok, true);
+	assert.equal(logs.length, 2);
+	for (const log of logs) {
+		assert.equal(log.bundleId, "implement-foo");
+		assert.equal(log.from, "pending");
+		assert.equal(log.to, "done");
+	}
+	assert.deepEqual(logs.map((l) => l.taskId).sort(), ["1", "2"]);
+});
+
+test("advanceBundleStatus: no audit log on non-terminal transitions", () => {
+	const base = sampleGraph();
+	const graph: TaskGraph = {
+		...base,
+		bundles: [{ ...base.bundles[0], status: "pending" }],
+	};
+	const { writer } = captureWriter();
+	const logs: TaskStatusCoercion[] = [];
+	const result = advanceBundleStatus({
+		taskGraph: graph,
+		bundleId: "implement-foo",
+		newStatus: "in_progress",
+		writer,
+		logger: (c) => logs.push(c),
+	});
+	assert.equal(result.ok, true);
+	assert.equal(logs.length, 0);
+});
+
+test("advanceBundleStatus: no audit log when every child already matched the target", () => {
+	const base = sampleGraph();
+	const graph: TaskGraph = {
+		...base,
+		bundles: [
+			{
+				...base.bundles[0],
+				status: "in_progress",
+				tasks: base.bundles[0].tasks.map((t) => ({ ...t, status: "done" })),
+			},
+		],
+	};
+	const { writer } = captureWriter();
+	const logs: TaskStatusCoercion[] = [];
+	const result = advanceBundleStatus({
+		taskGraph: graph,
+		bundleId: "implement-foo",
+		newStatus: "done",
+		writer,
+		logger: (c) => logs.push(c),
+	});
+	assert.equal(result.ok, true);
+	assert.equal(logs.length, 0);
+});
+
+test("advanceBundleStatus: atomic write pattern (write-to-temp + rename) is used for both artifacts", () => {
+	// The production writer delegates to atomicWriteText, which writes to a
+	// temp file then renames. This test drives atomicWriteText directly and
+	// asserts the rename-atomic property by observing that no .tmp sidecar
+	// lingers after the write completes and that the final content matches.
+	const dir = mkdtempSync(join(tmpdir(), "advance-bundle-atomic-"));
+	try {
+		const graphPath = join(dir, "task-graph.json");
+		const tasksPath = join(dir, "tasks.md");
+		atomicWriteText(graphPath, '{"ok":true}');
+		atomicWriteText(tasksPath, "# tasks\n");
+		// Both final files exist with expected content.
+		assert.equal(readFileSync(graphPath, "utf8"), '{"ok":true}');
+		assert.equal(readFileSync(tasksPath, "utf8"), "# tasks\n");
+		// No temp sidecar files remain under the directory.
+		const entries = existsSync(dir) ? readdirSync(dir) : [];
+		for (const entry of entries) {
+			assert.ok(!entry.endsWith(".tmp"), `no lingering tmp file: ${entry}`);
+		}
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+	// Also verify advanceBundleStatus uses a writer that can be backed by
+	// atomicWriteText. The important contract is sequencing: writeTaskGraph
+	// runs before writeTasksMd (so readers see the authoritative graph first).
+	const calls: string[] = [];
+	const writer: AdvanceBundleWriter = {
+		writeTaskGraph() {
+			calls.push("task-graph.json");
+		},
+		writeTasksMd() {
+			calls.push("tasks.md");
+		},
+	};
+	const result = advanceBundleStatus({
+		taskGraph: sampleGraph(),
+		bundleId: "implement-foo",
+		newStatus: "done",
+		writer,
+	});
+	assert.equal(result.ok, true);
+	assert.deepEqual(calls, ["task-graph.json", "tasks.md"]);
+});
+
+test("advanceBundleStatus + LocalFsChangeArtifactStore: end-to-end CLI wiring leaves no .tmp sidecars", () => {
+	// Directly exercises the production chain used by specflow-advance-bundle:
+	// createLocalFsChangeArtifactStore → store.write → atomicWriteText. The
+	// CLI wraps exactly this wiring, so the atomic-rename guarantee reaches
+	// the produced artifacts. Asserts the change directory contains only the
+	// final task-graph.json + tasks.md (no lingering .tmp files).
+	const projectRoot = mkdtempSync(join(tmpdir(), "advance-bundle-e2e-"));
+	const changeId = "test-change";
+	const changeDir = join(projectRoot, "openspec/changes", changeId);
+	try {
+		mkdirSync(changeDir, { recursive: true });
+		// Seed the input task-graph.json with a bundle in progress.
+		const initial = sampleGraph();
+		writeFileSync(
+			join(changeDir, "task-graph.json"),
+			`${JSON.stringify(initial, null, 2)}\n`,
+			"utf8",
+		);
+
+		const store = createLocalFsChangeArtifactStore(projectRoot);
+		const taskGraphRef = changeRef(changeId, ChangeArtifactType.TaskGraph);
+		const tasksRef = changeRef(changeId, ChangeArtifactType.Tasks);
+		const result = advanceBundleStatus({
+			taskGraph: initial,
+			bundleId: "implement-foo",
+			newStatus: "done",
+			writer: {
+				writeTaskGraph(content) {
+					store.write(taskGraphRef, content);
+				},
+				writeTasksMd(content) {
+					store.write(tasksRef, content);
+				},
+			},
+		});
+		assert.equal(result.ok, true);
+
+		// Final artifacts are present and consistent with the normalized graph.
+		const persisted = JSON.parse(
+			readFileSync(join(changeDir, "task-graph.json"), "utf8"),
+		) as TaskGraph;
+		const bundle = persisted.bundles.find((b) => b.id === "implement-foo");
+		assert.equal(bundle?.status, "done");
+		for (const task of bundle?.tasks ?? []) {
+			assert.equal(task.status, "done");
+		}
+		const renderedTasks = readFileSync(join(changeDir, "tasks.md"), "utf8");
+		assert.ok(renderedTasks.includes("## 1. Implement Foo ✓"));
+
+		// No .tmp sidecars remain anywhere under the change directory — the
+		// core atomic-rename guarantee the CLI relies on.
+		const entries = readdirSync(changeDir);
+		for (const entry of entries) {
+			assert.ok(!entry.endsWith(".tmp"), `no lingering tmp file: ${entry}`);
+		}
+	} finally {
+		rmSync(projectRoot, { recursive: true, force: true });
+	}
+});
+
+// --- CLI spawn-based tests (specflow-advance-bundle binary) ---
+//
+// These tests spawn the compiled CLI directly against a tmpdir to cover the
+// full production seam: argv parsing → git discovery → LocalFs store →
+// atomicWriteText. They complement the in-process tests above by catching any
+// regression in the CLI wiring that bypasses the programmatic API.
+
+test("specflow-advance-bundle CLI: end-to-end run leaves no .tmp sidecars and emits success JSON", () => {
+	if (!existsSync(advanceBundleCliPath)) {
+		// Skip gracefully when the dist has not been built yet; other CLI
+		// tests in the suite follow the same pattern.
+		return;
+	}
+	const projectRoot = mkdtempSync(join(tmpdir(), "advance-bundle-cli-"));
+	const changeId = "test-change";
+	const changeDir = join(projectRoot, "openspec/changes", changeId);
+	try {
+		initGitRepo(projectRoot);
+		mkdirSync(changeDir, { recursive: true });
+		writeFileSync(
+			join(changeDir, "task-graph.json"),
+			`${JSON.stringify(sampleGraph(), null, 2)}\n`,
+			"utf8",
+		);
+
+		const result = spawnSync(
+			process.execPath,
+			[advanceBundleCliPath, changeId, "implement-foo", "done"],
+			{ cwd: projectRoot, encoding: "utf8" },
+		);
+		assert.equal(result.status, 0, `stderr: ${result.stderr}`);
+
+		const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+		assert.equal(payload.status, "success");
+		assert.equal(payload.change_id, changeId);
+		assert.equal(payload.bundle_id, "implement-foo");
+		assert.equal(payload.new_status, "done");
+		assert.equal(payload.coercions, 2);
+
+		// Persisted artifacts match the normalized graph.
+		const persisted = JSON.parse(
+			readFileSync(join(changeDir, "task-graph.json"), "utf8"),
+		) as TaskGraph;
+		const bundle = persisted.bundles.find((b) => b.id === "implement-foo");
+		assert.equal(bundle?.status, "done");
+		for (const task of bundle?.tasks ?? []) {
+			assert.equal(task.status, "done");
+		}
+		assert.ok(
+			readFileSync(join(changeDir, "tasks.md"), "utf8").includes(
+				"## 1. Implement Foo ✓",
+			),
+		);
+
+		// No .tmp sidecars remain after the CLI exits — confirms the full
+		// CLI → store.write → atomicWriteText chain preserves atomicity.
+		for (const entry of readdirSync(changeDir)) {
+			assert.ok(!entry.endsWith(".tmp"), `no lingering tmp file: ${entry}`);
+		}
+	} finally {
+		rmSync(projectRoot, { recursive: true, force: true });
+	}
+});
+
+test("specflow-advance-bundle CLI: pre-orchestration errors emit advance-bundle-result JSON on stdout", () => {
+	if (!existsSync(advanceBundleCliPath)) {
+		return;
+	}
+	const projectRoot = mkdtempSync(join(tmpdir(), "advance-bundle-cli-err-"));
+	try {
+		initGitRepo(projectRoot);
+
+		// Missing task-graph.json — a pre-orchestration error path. Programmatic
+		// callers must still be able to JSON.parse(stdout).
+		const missing = spawnSync(
+			process.execPath,
+			[advanceBundleCliPath, "nonexistent", "some-bundle", "done"],
+			{ cwd: projectRoot, encoding: "utf8" },
+		);
+		assert.equal(missing.status, 1);
+		const missingPayload = JSON.parse(missing.stdout) as Record<
+			string,
+			unknown
+		>;
+		assert.equal(missingPayload.status, "error");
+		assert.equal(typeof missingPayload.error, "string");
+		assert.ok(
+			(missingPayload.error as string).includes("task-graph.json not found"),
+		);
+
+		// Invalid NEW_STATUS — also a pre-orchestration error path.
+		const badStatus = spawnSync(
+			process.execPath,
+			[advanceBundleCliPath, "any", "any", "not-a-status"],
+			{ cwd: projectRoot, encoding: "utf8" },
+		);
+		assert.equal(badStatus.status, 1);
+		const badStatusPayload = JSON.parse(badStatus.stdout) as Record<
+			string,
+			unknown
+		>;
+		assert.equal(badStatusPayload.status, "error");
+		assert.ok(
+			(badStatusPayload.error as string).includes("Invalid NEW_STATUS"),
+		);
+
+		// Missing args — the earliest failure path.
+		const missingArgs = spawnSync(
+			process.execPath,
+			[advanceBundleCliPath],
+			{ cwd: projectRoot, encoding: "utf8" },
+		);
+		assert.equal(missingArgs.status, 1);
+		const missingArgsPayload = JSON.parse(missingArgs.stdout) as Record<
+			string,
+			unknown
+		>;
+		assert.equal(missingArgsPayload.status, "error");
+		assert.ok((missingArgsPayload.error as string).includes("Usage:"));
+	} finally {
+		rmSync(projectRoot, { recursive: true, force: true });
+	}
+});

--- a/src/tests/task-planner-core.test.ts
+++ b/src/tests/task-planner-core.test.ts
@@ -327,3 +327,223 @@ test("updateBundleStatus: does not mutate original graph", () => {
 		assert.notEqual(result.taskGraph.bundles, original.bundles);
 	}
 });
+
+// --- Child-task normalization on terminal transitions (issue #142) ---
+
+function inProgressSchemaGraph(): TaskGraph {
+	const base = sampleGraph();
+	return {
+		...base,
+		bundles: [
+			{ ...base.bundles[0], status: "in_progress" },
+			...base.bundles.slice(1),
+		],
+	};
+}
+
+test("updateBundleStatus: bundle → done coerces all pending children to done and reports coercions", () => {
+	const graph = inProgressSchemaGraph();
+	const result = updateBundleStatus(graph, "schema", "done");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	const updated = result.taskGraph.bundles.find((b) => b.id === "schema");
+	assert.equal(updated?.status, "done");
+	for (const task of updated?.tasks ?? []) {
+		assert.equal(task.status, "done");
+	}
+	assert.equal(result.coercions.length, 2);
+	for (const coercion of result.coercions) {
+		assert.equal(coercion.bundleId, "schema");
+		assert.equal(coercion.from, "pending");
+		assert.equal(coercion.to, "done");
+	}
+	assert.deepEqual([...result.coercions].map((c) => c.taskId).sort(), [
+		"1",
+		"2",
+	]);
+});
+
+test("updateBundleStatus: bundle → skipped coerces all pending children to skipped and reports coercions", () => {
+	const result = updateBundleStatus(sampleGraph(), "schema", "skipped");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	const updated = result.taskGraph.bundles.find((b) => b.id === "schema");
+	assert.equal(updated?.status, "skipped");
+	for (const task of updated?.tasks ?? []) {
+		assert.equal(task.status, "skipped");
+	}
+	assert.equal(result.coercions.length, 2);
+	assert.ok(result.coercions.every((c) => c.to === "skipped"));
+	assert.ok(result.coercions.every((c) => c.from === "pending"));
+});
+
+test("updateBundleStatus: no-op children (already matching target) produce no coercion entries", () => {
+	const base = sampleGraph();
+	const graph: TaskGraph = {
+		...base,
+		bundles: [
+			{
+				...base.bundles[0],
+				status: "in_progress",
+				tasks: base.bundles[0].tasks.map((t) => ({ ...t, status: "done" })),
+			},
+			...base.bundles.slice(1),
+		],
+	};
+	const result = updateBundleStatus(graph, "schema", "done");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	assert.equal(result.coercions.length, 0);
+	const updated = result.taskGraph.bundles.find((b) => b.id === "schema");
+	assert.equal(updated?.status, "done");
+	for (const task of updated?.tasks ?? []) {
+		assert.equal(task.status, "done");
+	}
+});
+
+test("updateBundleStatus: non-terminal transition returns empty coercions and leaves task statuses untouched", () => {
+	const result = updateBundleStatus(sampleGraph(), "schema", "in_progress");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	assert.equal(result.coercions.length, 0);
+	const updated = result.taskGraph.bundles.find((b) => b.id === "schema");
+	for (const task of updated?.tasks ?? []) {
+		assert.equal(task.status, "pending");
+	}
+});
+
+test("updateBundleStatus: empty-bundle terminal transition updates bundle status and returns empty coercions", () => {
+	const base = sampleGraph();
+	const graph: TaskGraph = {
+		...base,
+		bundles: [
+			{ ...base.bundles[0], status: "in_progress", tasks: [] },
+			...base.bundles.slice(1),
+		],
+	};
+	const result = updateBundleStatus(graph, "schema", "done");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	assert.equal(result.coercions.length, 0);
+	const updated = result.taskGraph.bundles.find((b) => b.id === "schema");
+	assert.equal(updated?.status, "done");
+	assert.equal(updated?.tasks.length, 0);
+});
+
+test("updateBundleStatus: conflicting prior terminal child (done when bundle → skipped) is force-coerced and reported", () => {
+	const base = sampleGraph();
+	const graph: TaskGraph = {
+		...base,
+		bundles: [
+			{
+				...base.bundles[0],
+				status: "pending",
+				tasks: [
+					{ id: "1", title: "Already done", status: "done" },
+					{ id: "2", title: "Still pending", status: "pending" },
+				],
+			},
+			...base.bundles.slice(1),
+		],
+	};
+	const result = updateBundleStatus(graph, "schema", "skipped");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	const updated = result.taskGraph.bundles.find((b) => b.id === "schema");
+	assert.equal(updated?.status, "skipped");
+	for (const task of updated?.tasks ?? []) {
+		assert.equal(task.status, "skipped");
+	}
+	assert.equal(result.coercions.length, 2);
+	const byTaskId = new Map(result.coercions.map((c) => [c.taskId, c]));
+	assert.equal(byTaskId.get("1")?.from, "done");
+	assert.equal(byTaskId.get("1")?.to, "skipped");
+	assert.equal(byTaskId.get("2")?.from, "pending");
+	assert.equal(byTaskId.get("2")?.to, "skipped");
+});
+
+test("updateBundleStatus: terminal transition does not mutate input TaskGraph or nested arrays", () => {
+	const original = inProgressSchemaGraph();
+	const beforeBundles = original.bundles;
+	const beforeTasks = original.bundles[0].tasks;
+	const beforeStatuses = original.bundles[0].tasks.map((t) => t.status);
+	const result = updateBundleStatus(original, "schema", "done");
+	assert.equal(result.ok, true);
+	// Input reference equality preserved
+	assert.strictEqual(original.bundles, beforeBundles);
+	assert.strictEqual(original.bundles[0].tasks, beforeTasks);
+	// Per-task statuses on the input unchanged
+	assert.deepEqual(
+		original.bundles[0].tasks.map((t) => t.status),
+		beforeStatuses,
+	);
+	if (result.ok) {
+		// Output is a different reference
+		assert.notStrictEqual(result.taskGraph.bundles, original.bundles);
+		assert.notStrictEqual(
+			result.taskGraph.bundles[0].tasks,
+			original.bundles[0].tasks,
+		);
+	}
+});
+
+test("updateBundleStatus: rejected transitions (done → pending) return ok:false with no coercions", () => {
+	const base = sampleGraph();
+	const graph: TaskGraph = {
+		...base,
+		bundles: [{ ...base.bundles[0], status: "done" }, ...base.bundles.slice(1)],
+	};
+	const result = updateBundleStatus(graph, "schema", "pending");
+	assert.equal(result.ok, false);
+	if (!result.ok) {
+		assert.ok(result.error.includes("Invalid status transition"));
+		// Errors have no `coercions` field; this check is structural.
+		assert.equal(
+			(result as unknown as { coercions?: unknown }).coercions,
+			undefined,
+		);
+	}
+});
+
+// --- Renderer consistency after normalization (issue #142) ---
+
+test("renderTasksMd: after bundle → done, rendered checkboxes under the done header are checked", () => {
+	const graph = inProgressSchemaGraph();
+	const result = updateBundleStatus(graph, "schema", "done");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	const md = renderTasksMd(result.taskGraph);
+	// Header shows ✓ and every child task in the schema bundle renders as [x]
+	assert.ok(md.includes("## 1. Define Schema ✓"));
+	assert.ok(md.includes("- [x] 1.1 Create types.ts"));
+	assert.ok(md.includes("- [x] 1.2 Create schema.ts"));
+	// No unchecked schema task lines
+	assert.ok(!md.includes("- [ ] 1.1"), "no pending schema task checkbox");
+	assert.ok(!md.includes("- [ ] 1.2"), "no pending schema task checkbox");
+});
+
+test("renderTasksMd: after bundle → skipped, rendered section reflects skipped state consistently", () => {
+	const result = updateBundleStatus(sampleGraph(), "schema", "skipped");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	const md = renderTasksMd(result.taskGraph);
+	assert.ok(md.includes("## 1. Define Schema (skipped)"));
+	assert.ok(md.includes("- [-] 1.1 Create types.ts"));
+	assert.ok(md.includes("- [-] 1.2 Create schema.ts"));
+	// No pending schema task lines
+	assert.ok(!md.includes("- [ ] 1.1"), "no pending schema task checkbox");
+	assert.ok(!md.includes("- [ ] 1.2"), "no pending schema task checkbox");
+});
+
+test("renderTasksMd: unchanged — produces the same output when invoked directly with a normalized graph", () => {
+	// Guard that the renderer itself was not special-cased. Rendering a
+	// terminal-normalized graph via the existing function (no extra flags)
+	// must yield a consistent checklist.
+	const graph = inProgressSchemaGraph();
+	const result = updateBundleStatus(graph, "schema", "done");
+	assert.equal(result.ok, true);
+	if (!result.ok) return;
+	const first = renderTasksMd(result.taskGraph);
+	const second = renderTasksMd(result.taskGraph);
+	assert.equal(first, second);
+});

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -179,6 +179,7 @@ export type SchemaId =
 	| "create-sub-issues-input"
 	| "create-sub-issues-result"
 	| "generate-task-graph-result"
+	| "advance-bundle-result"
 	| "profile";
 
 export type ReviewSeverity = "high" | "medium" | "low" | string;


### PR DESCRIPTION
## Summary

- Tighten the `task-graph.json` ↔ `tasks.md` contract so terminal bundle transitions (`done` / `skipped`) normalize every child `task.status` in a single immutable `TaskGraph` update — eliminates the "bundle done but child checkboxes unchecked" archival inconsistency described in the issue.
- Extend `updateBundleStatus()` with a `coercions: TaskStatusCoercion[]` return field that reports every child whose status actually changed. Conflicting prior terminal child states are force-coerced; empty-bundle terminal transitions are a no-op with respect to children; non-terminal transitions never touch child statuses.
- Add `advanceBundleStatus()` orchestration helper plus a `specflow-advance-bundle` CLI that persists the normalized graph, re-renders `tasks.md`, and emits one structured audit log line per coercion — atomic writes via the existing `atomicWriteText` (write-to-temp + rename).
- +17 tests: 8 status-normalization unit tests, 3 renderer consistency checks, 6 apply-phase integration tests. All 383 tests in the suite pass; format / lint / typecheck / contracts clean.

## Issue

Closes https://github.com/skr19930617/specflow/issues/142