### PR TITLE
refactor: wire /specflow.apply to specflow-advance-bundle CLI (#147)

### DIFF
--- a/openspec/changes/archive/2026-04-15-tasks/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-15-tasks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/archive/2026-04-15-tasks/approval-summary.md
+++ b/openspec/changes/archive/2026-04-15-tasks/approval-summary.md
@@ -1,0 +1,113 @@
+# Approval Summary: tasks
+
+**Generated**: 2026-04-15T08:16:11Z
+**Branch**: tasks
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+```
+ src/contracts/command-bodies.ts |  26 +++++-
+ src/tests/generation.test.ts    | 176 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 199 insertions(+), 3 deletions(-)
+```
+
+Plus the entire `openspec/changes/tasks/` directory as a new untracked addition (proposal.md, design.md, tasks.md, task-graph.json, specs/{slash-command-guides,task-planner,utility-cli-suite}/spec.md, review-ledger.json, review-ledger-design.json, current-phase.md). Staged at commit time via `git add -A`.
+
+## Files Touched
+
+### Modified (tracked)
+- `src/contracts/command-bodies.ts`
+- `src/tests/generation.test.ts`
+
+### Added (currently untracked — openspec change directory)
+- `openspec/changes/tasks/proposal.md`
+- `openspec/changes/tasks/design.md`
+- `openspec/changes/tasks/tasks.md`
+- `openspec/changes/tasks/task-graph.json`
+- `openspec/changes/tasks/specs/slash-command-guides/spec.md`
+- `openspec/changes/tasks/specs/task-planner/spec.md`
+- `openspec/changes/tasks/specs/utility-cli-suite/spec.md`
+- `openspec/changes/tasks/review-ledger.json`
+- `openspec/changes/tasks/review-ledger-design.json`
+- `openspec/changes/tasks/current-phase.md`
+
+### Regenerated dist (tracked; staged via `git add -A`)
+- `dist/package/global/commands/specflow.apply.md`
+- `dist/package/global/commands/specflow.fix_apply.md`
+- Other `dist/**` artifacts touched by the full rebuild (manifest.json, install-plan.json, etc.)
+
+## Review Loop Summary
+
+### Design Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+### Impl Review
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 2     |
+
+## Proposal Coverage
+
+Acceptance criteria extracted from `openspec/changes/tasks/specs/*/spec.md` (10 scenarios across 9 requirements in three spec deltas).
+
+### slash-command-guides delta (4 requirements / 5 scenarios)
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | Generated apply guide documents the three-way path selection | Yes | src/contracts/command-bodies.ts, src/tests/generation.test.ts |
+| 2 | Generated apply guide names the CLI as the only status-mutation tool | Yes | src/contracts/command-bodies.ts, src/tests/generation.test.ts |
+| 3 | Generated apply guide does not embed example inline-edit scripts | Yes | src/contracts/command-bodies.ts, src/tests/generation.test.ts (negative assertions) |
+| 4 | Generated apply guide documents fail-fast on CLI error | Yes | src/contracts/command-bodies.ts, src/tests/generation.test.ts |
+| 5 | Generated fix_apply guide carries the safety-net reference | Yes | src/contracts/command-bodies.ts, src/tests/generation.test.ts |
+
+### task-planner delta (1 requirement / 4 scenarios)
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 6 | CLI named as sole entry point when task-graph is present and valid | Yes (spec codification) | openspec/changes/tasks/specs/task-planner/spec.md |
+| 7 | Legacy fallback unaffected when task-graph.json is absent | Yes (spec codification) | openspec/changes/tasks/specs/task-planner/spec.md |
+| 8 | Malformed task-graph.json does not permit silent fallback | Yes (spec codification + runtime encoded in command-bodies.ts) | openspec/changes/tasks/specs/task-planner/spec.md, src/contracts/command-bodies.ts |
+| 9 | Violation detection explicitly out of scope | Yes (spec codification) | openspec/changes/tasks/specs/task-planner/spec.md |
+
+### utility-cli-suite delta (4 requirements / 6 scenarios)
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 10 | CLI positional signature + allowed NEW_STATUS values | Yes (already implemented in src/bin/specflow-advance-bundle.ts; codified here) | openspec/changes/tasks/specs/utility-cli-suite/spec.md, src/bin/specflow-advance-bundle.ts |
+| 11 | Stdout JSON envelope (success/error) | Yes (already implemented) | src/bin/specflow-advance-bundle.ts |
+| 12 | Stderr `task_status_coercion` audit log format | Yes (already implemented) | src/bin/specflow-advance-bundle.ts |
+| 13 | Exit code 0/1 two-valued contract | Yes (already implemented) | src/bin/specflow-advance-bundle.ts |
+
+**Coverage Rate**: 13/13 (100%)
+
+## Remaining Risks
+
+### Deterministic risks (from review-ledger)
+
+- R1-F01: Spec delta files not included in diff (severity: low) — Advisory. Spec deltas exist in `openspec/changes/tasks/specs/` and are validated via `openspec validate tasks --type change --json` (valid:true). They are currently untracked and will be staged together with the rest of the change via `git add -A` at commit time.
+
+### Untested new files
+
+None: `--diff-filter=A` against HEAD returns no new .sh / .md files under tracked paths. All new markdown (proposal, design, tasks, specs, current-phase) lives under `openspec/changes/tasks/` and is openspec schema-validated.
+
+### Uncovered criteria
+
+None. All 13 criteria mapped.
+
+## Human Checkpoints
+
+- [ ] Confirm the commit stages the untracked `openspec/changes/tasks/` directory (acceptance criteria 6–13 rely on it landing with the diff).
+- [ ] Spot-check `dist/package/global/commands/specflow.apply.md` Step 1 in the PR diff view — confirm the three-way detection rule, CLI mandate, and fail-fast block render as intended.
+- [ ] Confirm the regression test `specflow.apply command body source encodes the specflow-advance-bundle contract` (the orchestrator-added source-level test) covers the same positive assertions as the dist-level test, making the contract enforcement independent of build ordering.
+- [ ] Decide whether to open a follow-up issue for the deferred automated violation detection (proposal Impact section explicitly marks this out of scope).

--- a/openspec/changes/archive/2026-04-15-tasks/current-phase.md
+++ b/openspec/changes/archive/2026-04-15-tasks/current-phase.md
@@ -1,0 +1,11 @@
+# Current Phase: tasks
+
+- Phase: fix-review
+- Round: 2
+- Status: in_progress
+- Open High Findings: 0 件
+- Actionable Findings: 1
+- Accepted Risks: none
+- Latest Changes:
+  - (no commits yet)
+- Next Recommended Action: /specflow.fix_apply

--- a/openspec/changes/archive/2026-04-15-tasks/design.md
+++ b/openspec/changes/archive/2026-04-15-tasks/design.md
@@ -1,0 +1,230 @@
+## Context
+
+The specflow repository already ships a purpose-built CLI for advancing bundle statuses: [`specflow-advance-bundle`](../../../src/bin/specflow-advance-bundle.ts). Internally it wraps `advanceBundleStatus` (`src/lib/task-planner/advance.ts`), which handles schema validation, child-task normalization on terminal transitions, atomic write-to-temp + rename of both `task-graph.json` and `tasks.md`, and structured stderr audit logging of every `task_status_coercion`. The behavior is already specified by the `task-planner` spec ([openspec/specs/task-planner/spec.md](../../specs/task-planner/spec.md)).
+
+The problem is that the user-facing `/specflow.apply` command guide does not tell the implementing agent to use this CLI. Step 1 of `specflow.apply` — authored in `src/contracts/command-bodies.ts` and rendered to `dist/package/global/commands/specflow.apply.md` — says only "update the bundle status in `task-graph.json` (`pending → in_progress → done`) and re-render `tasks.md`". That prose is under-specified: the agent interprets it literally and writes ad-hoc `node -e '…fs.readFileSync… bundle.status = "done"… fs.writeFileSync…'` scripts per bundle (see the issue body). These scripts bypass:
+
+- `validateTaskGraph` schema checks,
+- `advanceBundleStatus` status-transition rules,
+- child-task normalization on terminal transitions,
+- atomic two-file persistence,
+- coercion audit logging.
+
+Each omission re-introduces exactly the drift the task-planner spec was written to prevent. Symptoms observed in prior runs include `tasks.md` that disagrees with `task-graph.json` after a manual edit, and bundles landing in `done` with children still marked `pending`.
+
+The issue ([skr19930617/specflow#147](https://github.com/skr19930617/specflow/issues/147)) asks the straight-line fix: if the CLI exists, the slash command should use it; never hand-roll Node scripts for this. The proposal confirms the CLI already exists and scopes this change to **wiring + contract + regression test**, not new CLI or new library code.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Rewrite the `specflow.apply` → "Step 1: Apply Draft and Implement" body in `src/contracts/command-bodies.ts` so that when `task-graph.json` is present and schema-valid, every bundle status transition MUST go through `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`. Inline `node -e` / `jq` / manual writes in this path are explicitly prohibited.
+- Encode a three-way pre-apply detection rule (absent → legacy fallback; present+valid → CLI-mandatory; present+malformed → fail-fast with error, stay in `apply_draft`).
+- Encode fail-fast behavior on non-zero CLI exit: surface JSON envelope, stay in `apply_draft`, no retry, no skip-and-continue.
+- Append a single safety-net line to `specflow.fix_apply` → "Important Rules" pointing the fix loop at `specflow-advance-bundle` for any task-graph/tasks.md mutation.
+- Strengthen `task-planner` spec to name `specflow-advance-bundle` as the sole mutation entry point for apply-class workflows when a valid `task-graph.json` exists.
+- Document `specflow-advance-bundle` in `utility-cli-suite` spec as a first-class distribution CLI (signature, stdout envelope, stderr coercion lines, exit-code contract).
+- Add a regression test that asserts the regenerated `dist/package/global/commands/specflow.apply.md` contains the required CLI call and fail-fast language, and does NOT contain example `node -e` / `jq` mutation snippets. Extend `src/tests/generation.test.ts`.
+
+**Non-Goals:**
+
+- No new CLI, no new library code in `src/bin/` or `src/lib/task-planner/`. The existing `specflow-advance-bundle` + `advanceBundleStatus` already implement the behavior this change wires up.
+- No automated detection of contract violations in apply review (diff scanning, reviewer-prompt update, orchestrator-level enforcement). Deliberately deferred to a follow-up change.
+- No change to `/specflow.apply`'s review gate, `apply_ready` transition, approval flow, or the `specflow-review-apply` orchestrator.
+- No deprecation or migration of the existing `task-graph.json`-absent legacy fallback. Legacy changes continue to edit `tasks.md` directly.
+- No change to the in-memory `advanceBundleStatus` / `updateBundleStatus` library API, its audit-log shape, or the `TaskGraph` JSON schema.
+
+## Decisions
+
+### D1. Source of truth is `src/contracts/command-bodies.ts`, not the dist file.
+
+The `dist/package/global/commands/specflow.apply.md` file is generated from `src/contracts/command-bodies.ts` via the existing build pipeline. We edit only the TypeScript source and let the build regenerate the markdown. Alternative — editing the dist file directly — was rejected because it would be overwritten on the next build and creates a silent drift vector. The regression test (see D6) enforces that the dist output stays in sync.
+
+### D2. Three-way path detection runs in Step 1, not in the CLI.
+
+Path selection (absent / valid / malformed) belongs in the slash-command guide rather than inside `specflow-advance-bundle`, because the "absent" branch must route to the legacy fallback (editing `tasks.md` directly) — a path the CLI does not and should not handle. Pushing detection into the CLI would either force the CLI to implement legacy `tasks.md` editing (scope creep) or force the agent to detect legacy mode another way (duplicated logic).
+
+Detection semantics codified in the guide:
+
+- **Absent** (`task-graph.json` does not exist) → legacy fallback. Unchanged current behavior: mark tasks in `tasks.md` directly.
+- **Present + valid** (`task-graph.json` exists and a trial parse + `validateTaskGraph` would succeed) → CLI-mandatory path. Every transition via `specflow-advance-bundle`.
+- **Present + malformed** (`task-graph.json` exists but fails schema validation or JSON parse) → fail-fast. The agent surfaces the error, stays in `apply_draft`, and does NOT silently fall through to legacy mode.
+
+Alternative considered: collapse "malformed" into "absent" (i.e., fall back to legacy). Rejected — it would mask a real failure mode (stale or corrupted task graph) as a silent downgrade, exactly the kind of drift this change is trying to prevent. Fail-fast forces the user to fix the graph or regenerate it.
+
+In practice, the agent does not need to pre-validate the graph — the CLI itself validates on every invocation. So the guide's detection rule is operationally: "if the file does not exist, legacy; otherwise, call the CLI on the first transition, and if it returns a schema error, treat that as the malformed branch and abort." That is: **the CLI is the validator of record**, and the guide only decides legacy-vs-CLI based on file presence.
+
+### D3. All four transitions go through the CLI; no allowlist.
+
+Requiring the CLI only for certain transitions (e.g., only `→ done`) would create ambiguity about who records `pending → in_progress` — the CLI or the agent. That ambiguity is how free-form instructions slide back into ad-hoc scripts. All four logical transitions (`pending → in_progress`, `in_progress → done`, `pending → skipped`, `pending → done` direct) MUST go through `specflow-advance-bundle`. Single mutation path → single audit trail → no drift.
+
+### D4. Fail-fast on CLI error, never auto-retry or skip-and-continue.
+
+When `specflow-advance-bundle` exits non-zero:
+
+- The apply stops at the failing bundle. Subsequent bundles in the same Step 1 invocation are NOT advanced.
+- The CLI's stdout JSON error envelope is surfaced to the user verbatim.
+- The run remains in `apply_draft`.
+- The guide does NOT document retry or skip-and-continue.
+
+Rationale: every CLI error surfaces a real discrepancy — a stale bundle id after design revision, a malformed `task-graph.json`, an invalid transition caused by a prior manual edit, or a filesystem error. Retrying with identical arguments will produce the same error. Skipping subsequent bundles would complete an apply against an inconsistent task graph. The correct response is human judgment: user inspects, decides between regenerating the task graph, manually correcting `task-graph.json` (note: outside apply-class workflows, per D5), or invoking `/specflow.fix_apply`.
+
+### D5. Contract violation is codified, detection is deferred.
+
+The `task-planner` spec is strengthened to name `specflow-advance-bundle` as the sole mutation entry point for apply-class workflows. Direct writes from those workflows are labeled a contract violation. But this change does NOT implement any automated detection — no diff scanning in apply review, no reviewer-prompt updates, no orchestrator-level file-write monitoring.
+
+Rationale: detection has a meaningfully larger design surface (what counts as "an apply-class workflow" at detection time? how does the reviewer see intermediate edits that happened inside a single apply run? does `specflow-review-apply` need to parse the audit log?). Coupling detection into this change would bloat its scope and force design decisions we can make better in isolation. Instead, this change locks in the contract; a follow-up change tracked separately can add detection when the right approach is clearer.
+
+Operationally: until detection lands, the contract acts as a reviewer-facing rule ("if you notice a `node -e` script mutating task-graph.json in the diff, raise a high-severity finding"). That is acceptable because the main driver of violations is the slash-command guide itself telling the agent to do free-form edits — which this change fixes at the source.
+
+### D6. Regression test against the dist output.
+
+The generated `dist/package/global/commands/specflow.apply.md` is the artifact the CLI end user (another agent) actually reads. If `command-bodies.ts` and the dist file drift, the user-facing guide is wrong even when the source looks right. We add a test in `src/tests/generation.test.ts` that reads the dist file and asserts:
+
+Positive:
+- Contains literal `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`
+- Contains language about fail-fast on non-zero CLI exit
+- Contains the three-way detection rule (absent / present+valid / malformed)
+- Contains the prohibition of inline mutation (explicit mention of `node -e` is disallowed)
+
+Negative:
+- Does NOT contain an example `node -e` snippet that reads `task-graph.json` and mutates `bundle.status` or `tasks[*].status` (i.e., a line matching `/node -e/` with `task-graph.json` in the same snippet)
+- Does NOT contain a `jq` expression that rewrites a `status` field in `task-graph.json`
+
+Similarly, a second, smaller assertion against `dist/package/global/commands/specflow.fix_apply.md` confirms the one-line safety-net reference to `specflow-advance-bundle` is present in its "Important Rules".
+
+This test is listed as part of done-criteria per the proposal.
+
+### D7. `specflow.fix_apply` gets one line, not a flow change.
+
+`specflow.fix_apply` delegates all fix logic to the `specflow-review-apply fix-review` orchestrator and never directly edits `task-graph.json`. We do NOT rewrite its flow. We append one line in "Important Rules":
+
+> "If the fix loop needs to update `task-graph.json` or `tasks.md`, use `specflow-advance-bundle`; inline edits are a contract violation per `task-planner`."
+
+This is a cheap safety net that costs near zero and closes the single remaining loophole (an agent deciding to mutate task-graph while inside a fix loop's impl re-run).
+
+## Risks / Trade-offs
+
+- **[Risk]** A change elsewhere in the codebase adds new apply-class workflows that edit `task-graph.json` directly. The codified contract catches this in review, but only if the reviewer applies it. → **Mitigation:** follow-up change for automated detection (tracked). In the interim, the concentration of task-graph mutation in `src/bin/specflow-advance-bundle.ts` makes grep-based reviews cheap.
+- **[Risk]** The build pipeline could legitimately update the dist file in a way that is unrelated to the apply guide, breaking the regression test. → **Mitigation:** assertions are keyed on specific substrings (CLI call, fail-fast language) rather than whole-file equality; unrelated regenerations do not disturb them.
+- **[Risk]** An agent misreads "fail-fast" and leaves the user at an unrecoverable state after the first CLI error. → **Mitigation:** the guide explicitly states the recovery paths (manual correction / regenerate task-graph / `/specflow.fix_apply`), and the error message surfaced comes from the CLI's JSON envelope which already identifies the failure cause.
+- **[Risk]** Agents still writing `node -e` snippets despite the new language, because they learned the habit from prior runs or from unrelated tool suggestions. → **Mitigation:** the regression test guarantees the dist file's negative assertions hold — no example `node -e` mutation snippets exist in the guide to be copied. Prohibition is stated explicitly, not just by omission.
+- **[Trade-off]** Not implementing automated violation detection in this change leaves a window where a misbehaving agent can still bypass the CLI. We accept this to keep this change small and the contract crisp. The detection follow-up has a clearer design brief once this contract is in place.
+- **[Trade-off]** Strict fail-fast on malformed `task-graph.json` (instead of silently falling back to legacy) means a previously-working apply might now abort if someone manually corrupts the graph. This is deliberate: silent-downgrade is exactly the drift we are eliminating.
+
+## Migration Plan
+
+No runtime migration. Existing active changes (with or without `task-graph.json`) work unchanged under the new guide:
+
+- Changes with a valid `task-graph.json` start using `specflow-advance-bundle` on the next `/specflow.apply` invocation.
+- Changes without `task-graph.json` continue in legacy fallback with zero code path change.
+- Changes with a malformed `task-graph.json` would have silently drifted before; now they fail fast on first CLI call, which is a deliberate improvement.
+
+Deployment: ship `command-bodies.ts` edit + regenerated dist files + new regression test + spec deltas in a single PR. Because `dist/` artifacts are committed (per repo convention), the PR diff includes the regenerated markdown, making the change auditable.
+
+Rollback: revert the PR. `specflow-advance-bundle` and `advanceBundleStatus` are untouched, so reverting restores the old free-form Step 1 language without regressing any library behavior.
+
+## Open Questions
+
+None blocking implementation. Two items for awareness, not gating:
+
+- Should the follow-up "automated violation detection" change also cover inline edits to `task-graph.json` outside apply-class workflows (e.g., an agent tweaking the graph during `/specflow.design`)? Out of scope here; to be decided when that follow-up is scoped.
+- Should `specflow-advance-bundle` be surfaced in `specflow-help` / README as part of the `utility-cli-suite` registration? Decision deferred to the implementation bundle — if trivial (one README line, help output already correct), include it; otherwise open a follow-up.
+
+## Concerns
+
+Four user-facing concerns resolve in this change, in dependency order:
+
+1. **`/specflow.apply` apply loop authoritatively uses the CLI.** Problem: current free-form Step 1 language causes agents to hand-roll `node -e` scripts that bypass schema validation, normalization, atomic persistence, and audit logging. Resolution: Step 1 body in `command-bodies.ts` rewritten around the three-way detection rule and CLI-mandatory instruction.
+
+2. **Fail-fast on CLI error is explicit.** Problem: without explicit language, an agent seeing a CLI error might retry, skip, or improvise. Resolution: Step 1 body names the recovery contract (surface envelope, stay in `apply_draft`, no retry, no skip).
+
+3. **`task-planner` and `utility-cli-suite` specs codify the contract.** Problem: behavior is documented in one place (the command guide) but needs to be a cross-cutting rule that applies review, future refactors, and alternate surfaces can rely on. Resolution: spec deltas add requirements to both capabilities.
+
+4. **Dist regeneration does not drift from source.** Problem: a future edit to `command-bodies.ts` could silently regress the guide without anyone noticing until an apply run breaks. Resolution: regression test in `generation.test.ts` asserts the dist file contains the CLI call and fail-fast language, and does NOT contain example `node -e` mutation snippets.
+
+## State / Lifecycle
+
+No new state. All state transitions live in the existing run-state machine:
+
+- `apply_draft` is the entry phase for Step 1. It remains the phase the run returns to when the apply is interrupted (CLI error, validation failure, malformed task-graph) or explicitly revised. No new phases introduced.
+- `task-graph.json` lifecycle is unchanged: generated from `design.md` during `/specflow.design` via `specflow-generate-task-graph`, mutated during `/specflow.apply` via `specflow-advance-bundle`, consumed by rendering logic. This change narrows the allowed mutation path; it does not change when the file is created or destroyed.
+- Bundle status transitions remain the four-state enum (`pending | in_progress | done | skipped`). Per-task status continues to be coerced on terminal transitions by `updateBundleStatus`. No schema revision.
+- The run's `apply_draft` → `apply_review` transition still requires the agent to complete all bundles before advancing. On CLI error, the run stays in `apply_draft` as today. No state-machine change.
+
+Persistence-sensitive state: `task-graph.json` and `tasks.md`. Both are written by `specflow-advance-bundle` atomically (write-to-temp + rename), per the existing `task-planner` spec. This change does not alter the atomicity contract.
+
+## Contracts / Interfaces
+
+- **Slash-command guide → CLI (new contract shape in prose, not code).** `specflow.apply` Step 1 body directs the agent to invoke `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`, consume the JSON envelope on stdout, and on non-zero exit surface the envelope and stop. This is an instruction contract in markdown, rendered from `command-bodies.ts`.
+- **CLI ↔ library.** `specflow-advance-bundle` calls `advanceBundleStatus` (in `src/lib/task-planner/advance.ts`) with a `writer` that uses the repo's local FS artifact store. Unchanged.
+- **Library ↔ files.** `updateBundleStatus` returns a new `TaskGraph`; the writer persists `task-graph.json` via atomic rename and re-renders `tasks.md`. Unchanged.
+- **CLI ↔ caller (stdout / stderr / exit code).** Stdout: exactly one JSON document per invocation — success or error envelope. Stderr: zero or more `{event: "task_status_coercion", ...}` JSON lines, one per actual child-task coercion. Exit: `0` on success, `1` on any error. Already codified by the existing binary; the `utility-cli-suite` spec delta documents this as the first-class contract.
+- **Spec delta granularity.** Each of the three spec deltas uses ADDED Requirements (not MODIFIED) because none of the new requirements rewrite an existing requirement's behavior — they add new invariants on top.
+
+No new inter-module interfaces. No new public APIs in library code.
+
+## Persistence / Ownership
+
+- `openspec/changes/<CHANGE_ID>/task-graph.json` and `openspec/changes/<CHANGE_ID>/tasks.md` — owned (for writes, in apply-class workflows) by `specflow-advance-bundle`. This is the ownership assertion this change is codifying. Other lifecycle writers (`specflow-generate-task-graph` for creation) are unaffected; they run during `/specflow.design`, not `/specflow.apply`.
+- `src/contracts/command-bodies.ts` — owned by the contract registry. Edited by this change.
+- `dist/package/global/commands/specflow.apply.md` and `specflow.fix_apply.md` — generated; regenerated as part of this change's build output.
+- `openspec/specs/slash-command-guides/spec.md`, `openspec/specs/task-planner/spec.md`, `openspec/specs/utility-cli-suite/spec.md` — modified at archive time via the delta specs in `openspec/changes/tasks/specs/`.
+- `src/tests/generation.test.ts` — extended with two new assertion blocks (apply dist and fix_apply dist).
+
+No database, no external storage.
+
+## Integration Points
+
+- **Build pipeline.** `dist/package/global/commands/*.md` files are regenerated from `src/contracts/command-bodies.ts` via the existing build (`dist/build.js`). This change assumes the pipeline continues to work unchanged; the only new coupling is that the regression test reads from `dist/` and so requires the build to have run before tests. This is already the case for the existing `generated manifest and install plan reflect contracts` and `generated slash commands include run-state hook injections` tests in `generation.test.ts`.
+- **Test runner.** Node's built-in `node:test` runner. New assertions use `assert.ok(...)` + `assert.ok(!...)` patterns identical to the existing tests in that file.
+- **OpenSpec archive.** When this change archives, the three spec deltas land in `openspec/specs/<capability>/spec.md`. Standard OpenSpec archive flow; no new integration.
+- **`specflow-review-apply` orchestrator.** Unchanged. The fix_apply safety-net line is pure markdown in the guide; no orchestrator logic change.
+
+## Ordering / Dependency Notes
+
+Execution order (one sequential bundle of work; no independent parallel slices big enough to justify multiple bundles):
+
+1. **Edit `src/contracts/command-bodies.ts`** first. This is the single authoritative edit.
+   - Rewrite `specflow.apply` → "Step 1: Apply Draft and Implement" body (detection rule, CLI-mandatory, fail-fast).
+   - Append one safety-net line to `specflow.fix_apply` → "Important Rules".
+2. **Run the build** to regenerate `dist/package/global/commands/specflow.apply.md` and `specflow.fix_apply.md`. These regenerated files are committed to the repo per convention.
+3. **Write the three spec deltas** (already done in the spec phase; no work here — the task graph should reflect that specs are already produced). This can proceed in parallel with step 1 conceptually but is already complete.
+4. **Extend `src/tests/generation.test.ts`** with positive + negative assertions against the regenerated dist files.
+5. **Run the test suite.** All existing tests MUST continue to pass, and the new assertions MUST pass.
+
+No cross-bundle dependency beyond the classic source → build → test chain. If the task-planner chooses to split into bundles, the natural split is:
+
+- **Bundle A (contract + docs):** edit `command-bodies.ts`, regenerate dist, update spec deltas — all source-level text edits. One logical unit because the dist regeneration depends on the source edit and the spec deltas share the same semantic "contract wiring" theme.
+- **Bundle B (regression test):** extend `generation.test.ts`. Depends on Bundle A because the positive assertions only pass once the dist files are regenerated.
+
+If splitting is not beneficial at the task-planner granularity, it is acceptable to do everything in one bundle. Either decomposition is fine; the reviewer's criterion should be "is each bundle independently committable without breaking main?"
+
+## Completion Conditions
+
+This change is complete when ALL of the following hold:
+
+1. `src/contracts/command-bodies.ts` contains the new `specflow.apply` Step 1 body with:
+   - Literal `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>` invocation.
+   - Explicit three-way detection rule (absent / present+valid / malformed).
+   - Fail-fast on CLI error language.
+   - Explicit prohibition of `node -e` / `jq` / manual edits in the CLI path.
+2. `src/contracts/command-bodies.ts` contains the safety-net line in `specflow.fix_apply` → "Important Rules".
+3. `dist/package/global/commands/specflow.apply.md` and `specflow.fix_apply.md` are regenerated and committed; their content reflects (1) and (2).
+4. `src/tests/generation.test.ts` contains new assertions covering:
+   - apply dist: positive (CLI call, fail-fast phrase, detection rule phrase) and negative (no example `node -e` mutation snippet, no `jq` mutation expression).
+   - fix_apply dist: positive (safety-net line mentions `specflow-advance-bundle`).
+5. The full test suite passes (new + existing).
+6. `openspec validate tasks --type change --json` reports `valid: true` (already reached in the spec phase; should still hold after task graph generation).
+7. All three spec deltas in `openspec/changes/tasks/specs/<capability>/spec.md` remain consistent with the implemented `command-bodies.ts` language.
+
+Observable independent review checkpoints (aligned to Bundle A vs Bundle B):
+
+- After Bundle A: a reviewer reading only the regenerated dist files can confirm the apply guide names the CLI, documents fail-fast, and does not contain example inline edit scripts.
+- After Bundle B: `node --test src/tests/generation.test.ts` passes the new assertions; a reviewer can run the tests locally to confirm drift-prevention coverage.
+
+The change is NOT complete if:
+
+- The dist files contain stale text that contradicts `command-bodies.ts`.
+- The test asserts only the positive cases (allowing a future regression to re-introduce `node -e` examples without detection).
+- Any of the three spec deltas accidentally document behavior that differs from the `command-bodies.ts` edit (e.g., different status enum values, wrong exit-code semantics).

--- a/openspec/changes/archive/2026-04-15-tasks/proposal.md
+++ b/openspec/changes/archive/2026-04-15-tasks/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+When an agent executes `/specflow.apply`, each completed bundle requires a status update in `openspec/changes/<CHANGE_ID>/task-graph.json` plus a re-render of `tasks.md`. A CLI that does this already exists — `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>` (see [src/bin/specflow-advance-bundle.ts](src/bin/specflow-advance-bundle.ts)) — but the `/specflow.apply` and `/specflow.fix_apply` command guides never tell the agent to use it. So the agent invents ad-hoc `node -e '…'` scripts per bundle (see issue [skr19930617/specflow#147](https://github.com/skr19930617/specflow/issues/147)).
+
+Source reference:
+- Source provider: github
+- Source title: tasksの更新で毎回コマンドを作っている
+- Source reference: https://github.com/skr19930617/specflow/issues/147
+
+Writing one-off scripts bypasses the canonical path (`advanceBundleStatus` → schema validation → child-task normalization → atomic `tasks.md` re-render → coercion audit log). That re-introduces exactly the drift the task-planner spec was written to prevent: unnormalized child statuses, stale `tasks.md`, and no audit trail of coercions.
+
+## What Changes
+
+- **`/specflow.apply` switches to the CLI.** In `src/contracts/command-bodies.ts`, the `specflow.apply` → "Step 1: Apply Draft and Implement" body replaces the current free-form instruction ("update the bundle status in `task-graph.json` … and re-render `tasks.md`") with an explicit requirement to call `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>` for **every** bundle status transition (all four: `pending → in_progress`, `in_progress → done`, `pending → skipped`, any `→ done` direct), and explicitly prohibits `node -e` / `jq` / manual writes to `task-graph.json` / `tasks.md` in this path.
+- **Fail-fast on CLI error.** When `specflow-advance-bundle` exits non-zero (schema invalid, unknown bundle, invalid transition), `/specflow.apply` aborts the apply immediately, surfaces the CLI's JSON error envelope to the user, and leaves the run in `apply_draft`. No auto-retry, no skip-and-continue. The user decides: manual intervention or `/specflow.fix_apply`.
+- **Pre-apply detection rule.** Before Step 1 runs any bundle transitions, the agent determines the path:
+  - `task-graph.json` absent → **legacy fallback** (current behavior: mark tasks in `tasks.md` directly).
+  - `task-graph.json` present and passes `validateTaskGraph` → **CLI path** (mandatory).
+  - `task-graph.json` present but malformed → **abort with error** in `apply_draft`; user fixes or regenerates the task graph before retry.
+- **Strict mutation contract (codify only).** `task-planner` spec is strengthened: in apply-class workflows, `specflow-advance-bundle` is the only supported mutation entry point for bundle/task statuses when `task-graph.json` exists. Direct writes to `task-graph.json` / `tasks.md` from these flows are a contract violation. **Scope note:** this change only codifies the rule. Automated detection in apply review (diff heuristics, reviewer prompt changes, or orchestrator scanning) is deliberately out of scope — tracked as a separate change.
+- **`/specflow.fix_apply` safety-net line.** `/specflow.fix_apply` keeps delegating to the `specflow-review-apply fix-review` orchestrator (no flow change). The "Important Rules" section gains one line: "if the fix loop requires updating `task-graph.json` / `tasks.md`, use `specflow-advance-bundle`; inline edits are a contract violation per `task-planner`."
+- **Utility CLI registration (first-class).** `utility-cli-suite` spec adds `specflow-advance-bundle` as a documented distribution CLI with its positional-arg signature, allowed `NEW_STATUS` values (`pending | in_progress | done | skipped`), stdout JSON envelope (success / error shape), stderr `task_status_coercion` audit line format, and exit-code semantics. Packaged alongside the other `specflow-*` binaries.
+- **Done-criteria test (required).** A test asserting the generated `dist/package/global/commands/specflow.apply.md` contains the `specflow-advance-bundle` call (and does not contain example inline edit scripts) is part of this change's acceptance criteria. Likely extends an existing `generation.test.ts`-style suite.
+- **No new CLI, no new library code.** The issue asks "add one if it doesn't exist, otherwise use it." It exists ([src/bin/specflow-advance-bundle.ts](src/bin/specflow-advance-bundle.ts), backed by `advanceBundleStatus` in `src/lib/task-planner/advance.ts`). This change is wiring + contract only.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `slash-command-guides`:
+  - `/specflow.apply` Step 1 MUST detect `task-graph.json` presence and schema validity, then choose the path: absent → legacy fallback; present + valid → CLI-mandatory; present + malformed → abort with error and remain in `apply_draft`.
+  - In the CLI-mandatory path, every bundle status transition (all four: `pending → in_progress`, `in_progress → done`, `pending → skipped`, `pending → done`) MUST be performed via `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`. Inline `node -e` / `jq` / manual writes to `task-graph.json` or `tasks.md` are prohibited.
+  - If `specflow-advance-bundle` exits non-zero, Step 1 aborts immediately, surfaces the CLI JSON error envelope, and leaves the run in `apply_draft` (fail-fast; no retry; no skip).
+  - `/specflow.fix_apply` Important Rules gains a single safety-net line pointing to `specflow-advance-bundle` for any `task-graph.json` / `tasks.md` mutation arising inside a fix loop.
+- `task-planner`: In apply-class workflows where `task-graph.json` exists and is schema-valid, `specflow-advance-bundle` is the only supported mutation entry point for bundle/task statuses. Direct writes to `task-graph.json` or `tasks.md` from these flows are a contract violation. (Automated detection of violations is deliberately deferred to a follow-up change.)
+- `utility-cli-suite`: Register `specflow-advance-bundle` as a first-class distribution CLI with:
+  - Positional arguments: `<CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`
+  - `NEW_STATUS` ∈ `{pending, in_progress, done, skipped}`
+  - Stdout success envelope: `{status: "success", change_id, bundle_id, new_status, coercions}`
+  - Stdout error envelope: `{status: "error", error, change_id?, bundle_id?, new_status?}`
+  - Stderr audit lines: one `{event: "task_status_coercion", change_id, bundle_id, task_id, from_status, to_status}` JSON object per child-task coercion
+  - Exit code: `0` on success, `1` on any error (no other codes)
+
+## Impact
+
+- **Source of truth for command docs:** `src/contracts/command-bodies.ts` — the `"specflow.apply"` → "Step 1: Apply Draft and Implement" body is rewritten (detection rule, CLI-mandatory instruction, fail-fast error handling). The `"specflow.fix_apply"` → "Important Rules" body gains one safety-net line.
+- **Generated artifacts:** `dist/package/global/commands/specflow.apply.md` and `dist/package/global/commands/specflow.fix_apply.md` are regenerated via the existing build pipeline.
+- **Specs:** `openspec/specs/slash-command-guides/spec.md`, `openspec/specs/task-planner/spec.md`, `openspec/specs/utility-cli-suite/spec.md` each receive a delta.
+- **Code:** No new library code. `src/bin/specflow-advance-bundle.ts` and `src/lib/task-planner/advance.ts` already implement the required behavior.
+- **Tests (required for acceptance):**
+  - A test asserting the regenerated `dist/package/global/commands/specflow.apply.md` contains `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>` and contains the detection rule / fail-fast language, and does **not** contain example `node -e` or `jq` mutation scripts. Likely added to the existing `src/tests/generation.test.ts` (or a peer) so `command-bodies.ts` and the dist output cannot drift apart silently.
+- **Out of scope (tracked separately):**
+  - Automated detection of contract violations during apply review (diff scanning / review-agent prompt updates).
+  - Deprecating or migrating the `task-graph.json`-absent legacy fallback.
+- **Runtime behavior:** After this change, a `/specflow.apply` run with a valid `task-graph.json` invokes `specflow-advance-bundle` once per bundle transition, eliminating drift risk from ad-hoc scripts and producing a structured `task_status_coercion` audit log on stderr for every coerced child task. Malformed `task-graph.json` fails fast with a clear error. The legacy path is unchanged.

--- a/openspec/changes/archive/2026-04-15-tasks/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-15-tasks/review-ledger-design.json
@@ -1,0 +1,19 @@
+{
+  "feature_id": "tasks",
+  "phase": "design",
+  "current_round": 1,
+  "status": "all_resolved",
+  "max_finding_id": 0,
+  "findings": [],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 0,
+      "open": 0,
+      "new": 0,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-tasks/review-ledger.json
+++ b/openspec/changes/archive/2026-04-15-tasks/review-ledger.json
@@ -1,0 +1,62 @@
+{
+  "feature_id": "tasks",
+  "phase": "impl",
+  "current_round": 2,
+  "status": "in_progress",
+  "max_finding_id": 2,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "low",
+      "category": "completeness",
+      "file": "src/contracts/command-bodies.ts",
+      "title": "Spec delta files not included in diff",
+      "detail": "The proposal's Impact section states that `openspec/specs/slash-command-guides/spec.md`, `openspec/specs/task-planner/spec.md`, and `openspec/specs/utility-cli-suite/spec.md` each receive a delta. The current diff only updates `command-bodies.ts` and tests. If spec deltas are handled via a separate openspec change directory (e.g., `openspec/changes/tasks/`, which is untracked per git status), this is fine — but verify those deltas exist and are staged for the change to land completely.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "low",
+      "category": "testing",
+      "file": "src/tests/generation.test.ts",
+      "title": "Test reads from dist/ — ensure build precedes test",
+      "detail": "The new tests read from `dist/package/global/commands/specflow.apply.md` and `specflow.fix_apply.md`. These tests implicitly depend on a fresh build. If the test suite doesn't trigger or depend on the build step, the test could pass against stale dist output or fail on a clean checkout. Confirm the test script / CI pipeline runs the build before `generation.test.ts`, or have the test regenerate the artifact from `command-bodies.ts` directly.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "low": 2
+      }
+    },
+    {
+      "round": 2,
+      "total": 2,
+      "open": 1,
+      "new": 0,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "low": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-tasks/review-ledger.json.bak
+++ b/openspec/changes/archive/2026-04-15-tasks/review-ledger.json.bak
@@ -1,0 +1,50 @@
+{
+  "feature_id": "tasks",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "in_progress",
+  "max_finding_id": 2,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "low",
+      "category": "completeness",
+      "file": "src/contracts/command-bodies.ts",
+      "title": "Spec delta files not included in diff",
+      "detail": "The proposal's Impact section states that `openspec/specs/slash-command-guides/spec.md`, `openspec/specs/task-planner/spec.md`, and `openspec/specs/utility-cli-suite/spec.md` each receive a delta. The current diff only updates `command-bodies.ts` and tests. If spec deltas are handled via a separate openspec change directory (e.g., `openspec/changes/tasks/`, which is untracked per git status), this is fine — but verify those deltas exist and are staged for the change to land completely.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "low",
+      "category": "testing",
+      "file": "src/tests/generation.test.ts",
+      "title": "Test reads from dist/ — ensure build precedes test",
+      "detail": "The new tests read from `dist/package/global/commands/specflow.apply.md` and `specflow.fix_apply.md`. These tests implicitly depend on a fresh build. If the test suite doesn't trigger or depend on the build step, the test could pass against stale dist output or fail on a clean checkout. Confirm the test script / CI pipeline runs the build before `generation.test.ts`, or have the test regenerate the artifact from `command-bodies.ts` directly.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "low": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-15-tasks/specs/slash-command-guides/spec.md
+++ b/openspec/changes/archive/2026-04-15-tasks/specs/slash-command-guides/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: `/specflow.apply` Step 1 selects mutation path from `task-graph.json` state
+
+The generated `specflow.apply` guide SHALL, in "Step 1: Apply Draft and Implement", instruct the agent to select the bundle-status mutation path from the state of `openspec/changes/<CHANGE_ID>/task-graph.json`:
+
+- If `task-graph.json` does NOT exist → legacy fallback: mark completed tasks in `tasks.md` directly (unchanged legacy behavior).
+- If `task-graph.json` exists AND passes `validateTaskGraph` → CLI-mandatory path: every bundle status transition MUST be performed via `specflow-advance-bundle`.
+- If `task-graph.json` exists AND fails schema validation → abort the apply immediately, surface the validation error to the user, and leave the run in `apply_draft`. The agent SHALL NOT silently fall back to legacy behavior in this case.
+
+#### Scenario: Generated apply guide documents the three-way path selection
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** Step 1 SHALL explicitly document the three cases above (absent, present + valid, present + malformed) and the required action for each
+- **AND** it SHALL NOT document a path where a malformed `task-graph.json` silently falls through to the legacy path
+
+### Requirement: `/specflow.apply` mandates `specflow-advance-bundle` for every bundle status transition
+
+When the CLI-mandatory path is selected, the generated `specflow.apply` guide SHALL require the agent to perform every bundle status transition via `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`. This SHALL apply to all four logical transitions: `pending → in_progress`, `in_progress → done`, `pending → skipped`, and `pending → done`.
+
+The guide SHALL explicitly prohibit the following alternative mutation mechanisms:
+
+- Inline `node -e '…'` scripts that read/write `task-graph.json`
+- `jq` / `sed` / `awk` / shell here-docs that edit `task-graph.json` or `tasks.md`
+- Direct Edit/Write tool invocations against `task-graph.json` or `tasks.md` for the purpose of advancing bundle status
+
+#### Scenario: Generated apply guide names the CLI as the only status-mutation tool
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** Step 1 SHALL contain the literal CLI invocation shape `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`
+- **AND** it SHALL contain prose explicitly forbidding inline `node -e` / `jq` / manual edits to `task-graph.json` and `tasks.md` in the CLI-mandatory path
+
+#### Scenario: Generated apply guide does not embed example inline-edit scripts
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** it SHALL NOT contain a `node -e` snippet that reads `task-graph.json`, mutates a `bundle.status` or `tasks[*].status` field, and writes the file back
+- **AND** it SHALL NOT contain a `jq` expression that rewrites a bundle or task `status` field in `task-graph.json`
+
+### Requirement: `/specflow.apply` fails fast on `specflow-advance-bundle` error
+
+The generated `specflow.apply` guide SHALL instruct the agent to treat a non-zero exit from `specflow-advance-bundle` (schema validation failure, unknown bundle id, invalid status transition, filesystem error, etc.) as a fatal condition for the current apply:
+
+- The apply run SHALL stop at the failing bundle. Subsequent bundles SHALL NOT be advanced in the same Step 1 invocation.
+- The CLI's JSON error envelope (from stdout) SHALL be surfaced to the user verbatim.
+- The run state SHALL remain in `apply_draft` (no advance to `apply_review`).
+- The guide SHALL NOT document any auto-retry or skip-and-continue behavior on CLI failure.
+
+#### Scenario: Generated apply guide documents fail-fast on CLI error
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** Step 1 SHALL contain language specifying that a non-zero exit from `specflow-advance-bundle` stops the apply, surfaces the error JSON envelope to the user, and leaves the run in `apply_draft`
+- **AND** it SHALL NOT document `retry`, `再試行`, or `skip and continue` behavior for `specflow-advance-bundle` errors
+
+### Requirement: `/specflow.fix_apply` documents the CLI safety-net rule
+
+The generated `specflow.fix_apply` guide SHALL include, in its "Important Rules" (or equivalent bottom-rules) section, a single rule referencing `specflow-advance-bundle` as the required tool for any `task-graph.json` / `tasks.md` mutation that arises inside a fix loop. The rest of the `specflow.fix_apply` flow SHALL remain unchanged (fix loop continues to delegate to the `specflow-review-apply fix-review` orchestrator).
+
+#### Scenario: Generated fix_apply guide carries the safety-net reference
+
+- **WHEN** generated `specflow.fix_apply.md` is read
+- **THEN** its "Important Rules" (or the equivalent bottom-rules) section SHALL contain a reference to `specflow-advance-bundle` as the required tool whenever `task-graph.json` or `tasks.md` must be mutated during a fix loop
+- **AND** the rule SHALL identify inline edits to `task-graph.json` / `tasks.md` as a contract violation per `task-planner`

--- a/openspec/changes/archive/2026-04-15-tasks/specs/task-planner/spec.md
+++ b/openspec/changes/archive/2026-04-15-tasks/specs/task-planner/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: `specflow-advance-bundle` is the sole mutation entry point for apply-class workflows
+
+In apply-class slash-command workflows (currently `/specflow.apply`, and any fix-loop code path that resumes apply-class implementation work), when `task-graph.json` exists for the change and passes `validateTaskGraph`, all bundle and child-task status transitions SHALL be performed via the `specflow-advance-bundle` CLI. `specflow-advance-bundle` SHALL be the only supported mutation entry point for `task-graph.json` and for `tasks.md` in these workflows.
+
+Direct writes to `openspec/changes/<CHANGE_ID>/task-graph.json` or `openspec/changes/<CHANGE_ID>/tasks.md` from apply-class workflows — whether via inline `node -e` scripts, `jq`, shell here-docs, the Edit/Write tools, or any other mechanism that bypasses `specflow-advance-bundle` — SHALL be considered a contract violation against this specification.
+
+This requirement codifies the rule. Automated detection of violations during apply review (diff scanning, reviewer-prompt changes, or orchestrator-level enforcement) is NOT required by this requirement; it is tracked as a separate follow-up change.
+
+This requirement does not alter the `updateBundleStatus` in-memory API defined in the existing "Apply phase writes back bundle status to task graph" requirement; `specflow-advance-bundle` is the user-facing CLI wrapper that calls `updateBundleStatus` and persists the result atomically.
+
+#### Scenario: CLI is named as the sole entry point when task-graph is present and valid
+
+- **WHEN** a change has `openspec/changes/<CHANGE_ID>/task-graph.json` that passes `validateTaskGraph`
+- **AND** an apply-class workflow needs to transition a bundle's status
+- **THEN** `specflow-advance-bundle` SHALL be the only sanctioned tool for performing the transition
+- **AND** any other mechanism that writes to `task-graph.json` or `tasks.md` from that workflow SHALL be a contract violation
+
+#### Scenario: Legacy fallback is unaffected when task-graph.json is absent
+
+- **WHEN** a change has no `openspec/changes/<CHANGE_ID>/task-graph.json`
+- **THEN** this requirement SHALL NOT apply
+- **AND** the existing legacy fallback (editing `tasks.md` directly) defined in the "Legacy fallback supports changes without task graph" requirement SHALL remain the supported path
+
+#### Scenario: Malformed task-graph.json does not permit silent fallback
+
+- **WHEN** a change has `openspec/changes/<CHANGE_ID>/task-graph.json` that fails `validateTaskGraph`
+- **THEN** an apply-class workflow SHALL NOT fall back to the legacy `tasks.md`-only path
+- **AND** the workflow SHALL surface the validation error and halt in the apply draft state
+
+#### Scenario: Violation detection is explicitly out of this requirement's scope
+
+- **WHEN** this requirement is read
+- **THEN** it SHALL state that automated detection of contract violations (via apply-review diff scanning, reviewer prompt changes, or orchestrator enforcement) is NOT required here and is tracked separately

--- a/openspec/changes/archive/2026-04-15-tasks/specs/utility-cli-suite/spec.md
+++ b/openspec/changes/archive/2026-04-15-tasks/specs/utility-cli-suite/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: `specflow-advance-bundle` advances a single bundle status with normalization and atomic persistence
+
+`specflow-advance-bundle` SHALL be a first-class CLI in the distribution. It SHALL advance a single bundle's status within `openspec/changes/<CHANGE_ID>/task-graph.json`, normalize child-task statuses when transitioning to a terminal status per the `task-planner` specification, re-render `openspec/changes/<CHANGE_ID>/tasks.md`, and persist both files atomically.
+
+The CLI SHALL accept exactly three positional arguments in order:
+
+1. `<CHANGE_ID>` — the OpenSpec change identifier
+2. `<BUNDLE_ID>` — the bundle id within that change's `task-graph.json`
+3. `<NEW_STATUS>` — one of `pending`, `in_progress`, `done`, or `skipped`
+
+No flags or environment variables SHALL be required for baseline operation.
+
+#### Scenario: Usage error on missing arguments
+
+- **WHEN** `specflow-advance-bundle` is invoked with fewer than 3 positional arguments
+- **THEN** it SHALL exit with code `1`
+- **AND** stdout SHALL contain a JSON error envelope whose `error` field documents the expected usage and the allowed `NEW_STATUS` values (`pending | in_progress | done | skipped`)
+
+#### Scenario: Invalid NEW_STATUS is rejected
+
+- **WHEN** `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <invalid-status>` is invoked with any `<invalid-status>` outside `{pending, in_progress, done, skipped}`
+- **THEN** it SHALL exit with code `1`
+- **AND** stdout SHALL contain a JSON error envelope reporting the invalid status
+
+### Requirement: `specflow-advance-bundle` emits a stable stdout JSON envelope
+
+`specflow-advance-bundle` SHALL emit exactly one JSON document to stdout per invocation, so that a programmatic caller SHALL be able to `JSON.parse` the full stdout without branching on pre- vs post-argument-parse shape.
+
+On success, the stdout document SHALL contain the fields:
+
+- `status`: the string `"success"`
+- `change_id`: the change identifier argument
+- `bundle_id`: the bundle identifier argument
+- `new_status`: the status that was applied
+- `coercions`: the number of child-task coercions performed during the transition (zero for non-terminal transitions; zero or more for terminal transitions)
+
+On error, the stdout document SHALL contain the fields:
+
+- `status`: the string `"error"`
+- `error`: a human-readable error message
+- `change_id`, `bundle_id`, `new_status`: present when the corresponding argument was successfully parsed; omitted when the argument could not be determined (e.g., failure before argument parsing)
+
+#### Scenario: Successful transition emits the success envelope
+
+- **WHEN** `specflow-advance-bundle <valid-change> <valid-bundle> done` succeeds against a task-graph with a matching bundle whose transition is valid
+- **THEN** the CLI SHALL exit with code `0`
+- **AND** stdout SHALL contain exactly one JSON document with `status: "success"`, `change_id`, `bundle_id`, `new_status: "done"`, and a non-negative integer `coercions`
+
+#### Scenario: Failure emits the error envelope
+
+- **WHEN** `specflow-advance-bundle` encounters any error (missing task-graph, schema-invalid task-graph, unknown bundle id, invalid status transition, filesystem error)
+- **THEN** the CLI SHALL exit with code `1`
+- **AND** stdout SHALL contain exactly one JSON document with `status: "error"` and a populated `error` field
+
+### Requirement: `specflow-advance-bundle` emits one `task_status_coercion` line per changed child task on stderr
+
+For each child task whose status is actually changed by normalization during a terminal bundle transition, `specflow-advance-bundle` SHALL emit exactly one JSON line to stderr. No stderr line SHALL be emitted for a child task whose prior status already matches the new bundle terminal status.
+
+Each emitted stderr line SHALL be a single-line JSON object containing at minimum:
+
+- `event`: the literal string `"task_status_coercion"`
+- `change_id`: the change identifier
+- `bundle_id`: the bundle identifier
+- `task_id`: the coerced child task's id
+- `from_status`: the child task's prior status
+- `to_status`: the terminal status the child task was coerced to
+
+Stdout SHALL remain reserved for the result envelope; coercion audit lines SHALL NOT be written to stdout.
+
+#### Scenario: Coercion audit line format
+
+- **WHEN** a terminal transition coerces a child task whose prior status differs from the new bundle terminal status
+- **THEN** exactly one single-line JSON object with `event: "task_status_coercion"`, `change_id`, `bundle_id`, `task_id`, `from_status`, and `to_status` SHALL be emitted to stderr for that child task
+
+#### Scenario: No audit line when child status already matches
+
+- **WHEN** a terminal transition's child task already holds the new terminal status
+- **THEN** NO `task_status_coercion` stderr line SHALL be emitted for that child task
+
+### Requirement: `specflow-advance-bundle` uses exit code `0` for success and `1` for any error
+
+`specflow-advance-bundle` SHALL use a two-valued exit code contract:
+
+- Exit code `0`: the transition completed and both `task-graph.json` and `tasks.md` were persisted atomically.
+- Exit code `1`: any error condition. The stdout envelope SHALL indicate the specific error via its `error` field.
+
+No other exit codes SHALL be used by `specflow-advance-bundle`.
+
+#### Scenario: Success uses exit code 0
+
+- **WHEN** `specflow-advance-bundle` completes a valid transition and persists the files
+- **THEN** it SHALL exit with code `0`
+
+#### Scenario: Every error uses exit code 1
+
+- **WHEN** `specflow-advance-bundle` encounters any error (argument error, schema error, unknown bundle, invalid transition, filesystem error)
+- **THEN** it SHALL exit with code `1`
+- **AND** it SHALL NOT use any other non-zero exit code

--- a/openspec/changes/archive/2026-04-15-tasks/task-graph.json
+++ b/openspec/changes/archive/2026-04-15-tasks/task-graph.json
@@ -1,0 +1,118 @@
+{
+  "version": "1.0",
+  "change_id": "tasks",
+  "bundles": [
+    {
+      "id": "contract-and-docs",
+      "title": "Rewrite apply Step 1 contract and regenerate dist",
+      "goal": "Update command-bodies.ts to mandate specflow-advance-bundle for apply-class mutations and regenerate the dist markdown guides.",
+      "depends_on": [],
+      "inputs": [
+        "design.md",
+        "src/contracts/command-bodies.ts",
+        "openspec/changes/tasks/specs/slash-command-guides/spec.md",
+        "openspec/changes/tasks/specs/task-planner/spec.md",
+        "openspec/changes/tasks/specs/utility-cli-suite/spec.md"
+      ],
+      "outputs": [
+        "src/contracts/command-bodies.ts",
+        "dist/package/global/commands/specflow.apply.md",
+        "dist/package/global/commands/specflow.fix_apply.md"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Rewrite specflow.apply Step 1 body in src/contracts/command-bodies.ts with three-way detection rule (absent → legacy fallback, present+valid → CLI-mandatory, present+malformed → fail-fast)",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Embed literal `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>` invocation instruction covering all four transitions (pending→in_progress, in_progress→done, pending→skipped, pending→done)",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Add explicit fail-fast language: on non-zero CLI exit surface JSON envelope, stay in apply_draft, no retry, no skip-and-continue, name recovery paths (regenerate task-graph / manual correction / /specflow.fix_apply)",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Add explicit prohibition of inline `node -e` / `jq` / manual edits to task-graph.json and tasks.md within the CLI-mandatory path",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Append one safety-net line to specflow.fix_apply → 'Important Rules' pointing fix loop at specflow-advance-bundle for any task-graph/tasks.md mutation",
+          "status": "done"
+        },
+        {
+          "id": "6",
+          "title": "Run the build pipeline (dist/build.js) to regenerate dist/package/global/commands/specflow.apply.md and specflow.fix_apply.md",
+          "status": "done"
+        },
+        {
+          "id": "7",
+          "title": "Verify regenerated dist files reflect all required language and commit them per repo convention",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "slash-command-guides",
+        "task-planner",
+        "utility-cli-suite",
+        "contract-driven-distribution"
+      ]
+    },
+    {
+      "id": "regression-test",
+      "title": "Add generation regression test for apply guide contract",
+      "goal": "Extend src/tests/generation.test.ts to lock in positive and negative assertions against the regenerated dist guides so drift cannot silently regress the contract.",
+      "depends_on": [
+        "contract-and-docs"
+      ],
+      "inputs": [
+        "dist/package/global/commands/specflow.apply.md",
+        "dist/package/global/commands/specflow.fix_apply.md",
+        "src/tests/generation.test.ts"
+      ],
+      "outputs": [
+        "src/tests/generation.test.ts"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Add positive assertions against dist/package/global/commands/specflow.apply.md: contains literal `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`, fail-fast language, three-way detection rule phrases, and explicit prohibition of `node -e`",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Add negative assertions against dist/package/global/commands/specflow.apply.md: no example `node -e` snippet mutating bundle.status or tasks[*].status, no `jq` expression rewriting status in task-graph.json",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Add positive assertion against dist/package/global/commands/specflow.fix_apply.md: 'Important Rules' safety-net line mentions specflow-advance-bundle",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Run `node --test src/tests/generation.test.ts` and the full test suite; confirm new + existing tests pass",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Run `openspec validate tasks --type change --json` and confirm valid:true",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "contract-driven-distribution",
+        "slash-command-guides"
+      ]
+    }
+  ],
+  "generated_at": "2026-04-15T07:42:49.802Z",
+  "generated_from": "design.md"
+}

--- a/openspec/changes/archive/2026-04-15-tasks/tasks.md
+++ b/openspec/changes/archive/2026-04-15-tasks/tasks.md
@@ -1,0 +1,23 @@
+## 1. Rewrite apply Step 1 contract and regenerate dist ✓
+
+> Update command-bodies.ts to mandate specflow-advance-bundle for apply-class mutations and regenerate the dist markdown guides.
+
+- [x] 1.1 Rewrite specflow.apply Step 1 body in src/contracts/command-bodies.ts with three-way detection rule (absent → legacy fallback, present+valid → CLI-mandatory, present+malformed → fail-fast)
+- [x] 1.2 Embed literal `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>` invocation instruction covering all four transitions (pending→in_progress, in_progress→done, pending→skipped, pending→done)
+- [x] 1.3 Add explicit fail-fast language: on non-zero CLI exit surface JSON envelope, stay in apply_draft, no retry, no skip-and-continue, name recovery paths (regenerate task-graph / manual correction / /specflow.fix_apply)
+- [x] 1.4 Add explicit prohibition of inline `node -e` / `jq` / manual edits to task-graph.json and tasks.md within the CLI-mandatory path
+- [x] 1.5 Append one safety-net line to specflow.fix_apply → 'Important Rules' pointing fix loop at specflow-advance-bundle for any task-graph/tasks.md mutation
+- [x] 1.6 Run the build pipeline (dist/build.js) to regenerate dist/package/global/commands/specflow.apply.md and specflow.fix_apply.md
+- [x] 1.7 Verify regenerated dist files reflect all required language and commit them per repo convention
+
+## 2. Add generation regression test for apply guide contract ✓
+
+> Extend src/tests/generation.test.ts to lock in positive and negative assertions against the regenerated dist guides so drift cannot silently regress the contract.
+
+> Depends on: contract-and-docs
+
+- [x] 2.1 Add positive assertions against dist/package/global/commands/specflow.apply.md: contains literal `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`, fail-fast language, three-way detection rule phrases, and explicit prohibition of `node -e`
+- [x] 2.2 Add negative assertions against dist/package/global/commands/specflow.apply.md: no example `node -e` snippet mutating bundle.status or tasks[*].status, no `jq` expression rewriting status in task-graph.json
+- [x] 2.3 Add positive assertion against dist/package/global/commands/specflow.fix_apply.md: 'Important Rules' safety-net line mentions specflow-advance-bundle
+- [x] 2.4 Run `node --test src/tests/generation.test.ts` and the full test suite; confirm new + existing tests pass
+- [x] 2.5 Run `openspec validate tasks --type change --json` and confirm valid:true

--- a/openspec/specs/slash-command-guides/spec.md
+++ b/openspec/specs/slash-command-guides/spec.md
@@ -222,3 +222,64 @@ remediations SHALL be removed.
   `openspec list --json > /dev/null 2>&1`
 - **AND** it SHALL NOT contain two separate Prerequisites sections
 
+### Requirement: `/specflow.apply` Step 1 selects mutation path from `task-graph.json` state
+
+The generated `specflow.apply` guide SHALL, in "Step 1: Apply Draft and Implement", instruct the agent to select the bundle-status mutation path from the state of `openspec/changes/<CHANGE_ID>/task-graph.json`:
+
+- If `task-graph.json` does NOT exist → legacy fallback: mark completed tasks in `tasks.md` directly (unchanged legacy behavior).
+- If `task-graph.json` exists AND passes `validateTaskGraph` → CLI-mandatory path: every bundle status transition MUST be performed via `specflow-advance-bundle`.
+- If `task-graph.json` exists AND fails schema validation → abort the apply immediately, surface the validation error to the user, and leave the run in `apply_draft`. The agent SHALL NOT silently fall back to legacy behavior in this case.
+
+#### Scenario: Generated apply guide documents the three-way path selection
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** Step 1 SHALL explicitly document the three cases above (absent, present + valid, present + malformed) and the required action for each
+- **AND** it SHALL NOT document a path where a malformed `task-graph.json` silently falls through to the legacy path
+
+### Requirement: `/specflow.apply` mandates `specflow-advance-bundle` for every bundle status transition
+
+When the CLI-mandatory path is selected, the generated `specflow.apply` guide SHALL require the agent to perform every bundle status transition via `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`. This SHALL apply to all four logical transitions: `pending → in_progress`, `in_progress → done`, `pending → skipped`, and `pending → done`.
+
+The guide SHALL explicitly prohibit the following alternative mutation mechanisms:
+
+- Inline `node -e '…'` scripts that read/write `task-graph.json`
+- `jq` / `sed` / `awk` / shell here-docs that edit `task-graph.json` or `tasks.md`
+- Direct Edit/Write tool invocations against `task-graph.json` or `tasks.md` for the purpose of advancing bundle status
+
+#### Scenario: Generated apply guide names the CLI as the only status-mutation tool
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** Step 1 SHALL contain the literal CLI invocation shape `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`
+- **AND** it SHALL contain prose explicitly forbidding inline `node -e` / `jq` / manual edits to `task-graph.json` and `tasks.md` in the CLI-mandatory path
+
+#### Scenario: Generated apply guide does not embed example inline-edit scripts
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** it SHALL NOT contain a `node -e` snippet that reads `task-graph.json`, mutates a `bundle.status` or `tasks[*].status` field, and writes the file back
+- **AND** it SHALL NOT contain a `jq` expression that rewrites a bundle or task `status` field in `task-graph.json`
+
+### Requirement: `/specflow.apply` fails fast on `specflow-advance-bundle` error
+
+The generated `specflow.apply` guide SHALL instruct the agent to treat a non-zero exit from `specflow-advance-bundle` (schema validation failure, unknown bundle id, invalid status transition, filesystem error, etc.) as a fatal condition for the current apply:
+
+- The apply run SHALL stop at the failing bundle. Subsequent bundles SHALL NOT be advanced in the same Step 1 invocation.
+- The CLI's JSON error envelope (from stdout) SHALL be surfaced to the user verbatim.
+- The run state SHALL remain in `apply_draft` (no advance to `apply_review`).
+- The guide SHALL NOT document any auto-retry or skip-and-continue behavior on CLI failure.
+
+#### Scenario: Generated apply guide documents fail-fast on CLI error
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** Step 1 SHALL contain language specifying that a non-zero exit from `specflow-advance-bundle` stops the apply, surfaces the error JSON envelope to the user, and leaves the run in `apply_draft`
+- **AND** it SHALL NOT document `retry`, `再試行`, or `skip and continue` behavior for `specflow-advance-bundle` errors
+
+### Requirement: `/specflow.fix_apply` documents the CLI safety-net rule
+
+The generated `specflow.fix_apply` guide SHALL include, in its "Important Rules" (or equivalent bottom-rules) section, a single rule referencing `specflow-advance-bundle` as the required tool for any `task-graph.json` / `tasks.md` mutation that arises inside a fix loop. The rest of the `specflow.fix_apply` flow SHALL remain unchanged (fix loop continues to delegate to the `specflow-review-apply fix-review` orchestrator).
+
+#### Scenario: Generated fix_apply guide carries the safety-net reference
+
+- **WHEN** generated `specflow.fix_apply.md` is read
+- **THEN** its "Important Rules" (or the equivalent bottom-rules) section SHALL contain a reference to `specflow-advance-bundle` as the required tool whenever `task-graph.json` or `tasks.md` must be mutated during a fix loop
+- **AND** the rule SHALL identify inline edits to `task-graph.json` / `tasks.md` as a contract violation per `task-planner`
+

--- a/openspec/specs/task-planner/spec.md
+++ b/openspec/specs/task-planner/spec.md
@@ -265,3 +265,37 @@ For existing changes where `task-graph.json` does not exist, the apply phase SHA
 - **THEN** `task-graph.json` SHALL be generated and persisted
 - **AND** `tasks.md` SHALL be rendered from the task graph
 
+### Requirement: `specflow-advance-bundle` is the sole mutation entry point for apply-class workflows
+
+In apply-class slash-command workflows (currently `/specflow.apply`, and any fix-loop code path that resumes apply-class implementation work), when `task-graph.json` exists for the change and passes `validateTaskGraph`, all bundle and child-task status transitions SHALL be performed via the `specflow-advance-bundle` CLI. `specflow-advance-bundle` SHALL be the only supported mutation entry point for `task-graph.json` and for `tasks.md` in these workflows.
+
+Direct writes to `openspec/changes/<CHANGE_ID>/task-graph.json` or `openspec/changes/<CHANGE_ID>/tasks.md` from apply-class workflows — whether via inline `node -e` scripts, `jq`, shell here-docs, the Edit/Write tools, or any other mechanism that bypasses `specflow-advance-bundle` — SHALL be considered a contract violation against this specification.
+
+This requirement codifies the rule. Automated detection of violations during apply review (diff scanning, reviewer-prompt changes, or orchestrator-level enforcement) is NOT required by this requirement; it is tracked as a separate follow-up change.
+
+This requirement does not alter the `updateBundleStatus` in-memory API defined in the existing "Apply phase writes back bundle status to task graph" requirement; `specflow-advance-bundle` is the user-facing CLI wrapper that calls `updateBundleStatus` and persists the result atomically.
+
+#### Scenario: CLI is named as the sole entry point when task-graph is present and valid
+
+- **WHEN** a change has `openspec/changes/<CHANGE_ID>/task-graph.json` that passes `validateTaskGraph`
+- **AND** an apply-class workflow needs to transition a bundle's status
+- **THEN** `specflow-advance-bundle` SHALL be the only sanctioned tool for performing the transition
+- **AND** any other mechanism that writes to `task-graph.json` or `tasks.md` from that workflow SHALL be a contract violation
+
+#### Scenario: Legacy fallback is unaffected when task-graph.json is absent
+
+- **WHEN** a change has no `openspec/changes/<CHANGE_ID>/task-graph.json`
+- **THEN** this requirement SHALL NOT apply
+- **AND** the existing legacy fallback (editing `tasks.md` directly) defined in the "Legacy fallback supports changes without task graph" requirement SHALL remain the supported path
+
+#### Scenario: Malformed task-graph.json does not permit silent fallback
+
+- **WHEN** a change has `openspec/changes/<CHANGE_ID>/task-graph.json` that fails `validateTaskGraph`
+- **THEN** an apply-class workflow SHALL NOT fall back to the legacy `tasks.md`-only path
+- **AND** the workflow SHALL surface the validation error and halt in the apply draft state
+
+#### Scenario: Violation detection is explicitly out of this requirement's scope
+
+- **WHEN** this requirement is read
+- **THEN** it SHALL state that automated detection of contract violations (via apply-review diff scanning, reviewer prompt changes, or orchestrator enforcement) is NOT required here and is tracked separately
+

--- a/openspec/specs/utility-cli-suite/spec.md
+++ b/openspec/specs/utility-cli-suite/spec.md
@@ -212,3 +212,102 @@ against the create-sub-issues input schema, and create or reuse GitHub issues.
 - **THEN** the CLI SHALL exit with code `2`
 - **AND** stdout SHALL still report the `created` and `failed` arrays
 
+### Requirement: `specflow-advance-bundle` advances a single bundle status with normalization and atomic persistence
+
+`specflow-advance-bundle` SHALL be a first-class CLI in the distribution. It SHALL advance a single bundle's status within `openspec/changes/<CHANGE_ID>/task-graph.json`, normalize child-task statuses when transitioning to a terminal status per the `task-planner` specification, re-render `openspec/changes/<CHANGE_ID>/tasks.md`, and persist both files atomically.
+
+The CLI SHALL accept exactly three positional arguments in order:
+
+1. `<CHANGE_ID>` — the OpenSpec change identifier
+2. `<BUNDLE_ID>` — the bundle id within that change's `task-graph.json`
+3. `<NEW_STATUS>` — one of `pending`, `in_progress`, `done`, or `skipped`
+
+No flags or environment variables SHALL be required for baseline operation.
+
+#### Scenario: Usage error on missing arguments
+
+- **WHEN** `specflow-advance-bundle` is invoked with fewer than 3 positional arguments
+- **THEN** it SHALL exit with code `1`
+- **AND** stdout SHALL contain a JSON error envelope whose `error` field documents the expected usage and the allowed `NEW_STATUS` values (`pending | in_progress | done | skipped`)
+
+#### Scenario: Invalid NEW_STATUS is rejected
+
+- **WHEN** `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <invalid-status>` is invoked with any `<invalid-status>` outside `{pending, in_progress, done, skipped}`
+- **THEN** it SHALL exit with code `1`
+- **AND** stdout SHALL contain a JSON error envelope reporting the invalid status
+
+### Requirement: `specflow-advance-bundle` emits a stable stdout JSON envelope
+
+`specflow-advance-bundle` SHALL emit exactly one JSON document to stdout per invocation, so that a programmatic caller SHALL be able to `JSON.parse` the full stdout without branching on pre- vs post-argument-parse shape.
+
+On success, the stdout document SHALL contain the fields:
+
+- `status`: the string `"success"`
+- `change_id`: the change identifier argument
+- `bundle_id`: the bundle identifier argument
+- `new_status`: the status that was applied
+- `coercions`: the number of child-task coercions performed during the transition (zero for non-terminal transitions; zero or more for terminal transitions)
+
+On error, the stdout document SHALL contain the fields:
+
+- `status`: the string `"error"`
+- `error`: a human-readable error message
+- `change_id`, `bundle_id`, `new_status`: present when the corresponding argument was successfully parsed; omitted when the argument could not be determined (e.g., failure before argument parsing)
+
+#### Scenario: Successful transition emits the success envelope
+
+- **WHEN** `specflow-advance-bundle <valid-change> <valid-bundle> done` succeeds against a task-graph with a matching bundle whose transition is valid
+- **THEN** the CLI SHALL exit with code `0`
+- **AND** stdout SHALL contain exactly one JSON document with `status: "success"`, `change_id`, `bundle_id`, `new_status: "done"`, and a non-negative integer `coercions`
+
+#### Scenario: Failure emits the error envelope
+
+- **WHEN** `specflow-advance-bundle` encounters any error (missing task-graph, schema-invalid task-graph, unknown bundle id, invalid status transition, filesystem error)
+- **THEN** the CLI SHALL exit with code `1`
+- **AND** stdout SHALL contain exactly one JSON document with `status: "error"` and a populated `error` field
+
+### Requirement: `specflow-advance-bundle` emits one `task_status_coercion` line per changed child task on stderr
+
+For each child task whose status is actually changed by normalization during a terminal bundle transition, `specflow-advance-bundle` SHALL emit exactly one JSON line to stderr. No stderr line SHALL be emitted for a child task whose prior status already matches the new bundle terminal status.
+
+Each emitted stderr line SHALL be a single-line JSON object containing at minimum:
+
+- `event`: the literal string `"task_status_coercion"`
+- `change_id`: the change identifier
+- `bundle_id`: the bundle identifier
+- `task_id`: the coerced child task's id
+- `from_status`: the child task's prior status
+- `to_status`: the terminal status the child task was coerced to
+
+Stdout SHALL remain reserved for the result envelope; coercion audit lines SHALL NOT be written to stdout.
+
+#### Scenario: Coercion audit line format
+
+- **WHEN** a terminal transition coerces a child task whose prior status differs from the new bundle terminal status
+- **THEN** exactly one single-line JSON object with `event: "task_status_coercion"`, `change_id`, `bundle_id`, `task_id`, `from_status`, and `to_status` SHALL be emitted to stderr for that child task
+
+#### Scenario: No audit line when child status already matches
+
+- **WHEN** a terminal transition's child task already holds the new terminal status
+- **THEN** NO `task_status_coercion` stderr line SHALL be emitted for that child task
+
+### Requirement: `specflow-advance-bundle` uses exit code `0` for success and `1` for any error
+
+`specflow-advance-bundle` SHALL use a two-valued exit code contract:
+
+- Exit code `0`: the transition completed and both `task-graph.json` and `tasks.md` were persisted atomically.
+- Exit code `1`: any error condition. The stdout envelope SHALL indicate the specific error via its `error` field.
+
+No other exit codes SHALL be used by `specflow-advance-bundle`.
+
+#### Scenario: Success uses exit code 0
+
+- **WHEN** `specflow-advance-bundle` completes a valid transition and persists the files
+- **THEN** it SHALL exit with code `0`
+
+#### Scenario: Every error uses exit code 1
+
+- **WHEN** `specflow-advance-bundle` encounters any error (argument error, schema error, unknown bundle, invalid transition, filesystem error)
+- **THEN** it SHALL exit with code `1`
+- **AND** it SHALL NOT use any other non-zero exit code
+

--- a/src/contracts/command-bodies.ts
+++ b/src/contracts/command-bodies.ts
@@ -48,8 +48,28 @@ export const commandBodies: Record<string, CommandBody> = {
 			},
 			{
 				title: "Step 1: Apply Draft and Implement",
-				content:
-					'\n1. Confirm the run is in `apply_draft`.\n2. Check if `openspec/changes/<CHANGE_ID>/task-graph.json` exists (via Read tool).\n   - **If task-graph.json exists** (new mode): Load it as the source of truth. Use the bundle structure to determine execution order and eligible bundles. Execute bundles whose `depends_on` outputs are available and whose `status` is `"pending"`. After completing each bundle\'s tasks, update the bundle status in `task-graph.json` (`pending → in_progress → done`) and re-render `tasks.md` from the updated task graph.\n   - **If task-graph.json does not exist** (legacy fallback): Load `openspec/changes/<CHANGE_ID>/tasks.md` and `openspec/changes/<CHANGE_ID>/design.md` directly. Execute tasks phase-by-phase. Mark completed tasks in `tasks.md`.\n3. Validate implementation against `openspec/changes/<CHANGE_ID>/proposal.md`.\n\nReport: `Step 1 complete — implementation completed in apply_draft`',
+				content: [
+					"",
+					"1. Confirm the run is in `apply_draft`.",
+					"2. **Pre-apply path detection.** Check `openspec/changes/<CHANGE_ID>/task-graph.json` via Read tool.",
+					"   - **Absent** → legacy fallback (see step 3a).",
+					"   - **Present** → CLI-mandatory path (see step 3b). `specflow-advance-bundle` is the sole mutation entry point and validates the task graph on every invocation, so a malformed `task-graph.json` surfaces as a CLI error in step 3b (fail-fast; the apply stops in `apply_draft` and does NOT silently fall back to the legacy path).",
+					"3a. **Legacy fallback (task-graph.json absent).** Load `openspec/changes/<CHANGE_ID>/tasks.md` and `openspec/changes/<CHANGE_ID>/design.md` directly. Execute tasks phase-by-phase. Mark completed tasks in `tasks.md`.",
+					"3b. **CLI-mandatory path (task-graph.json present).** Load `task-graph.json` as the source of truth. Use the bundle structure to determine execution order and eligible bundles (bundles whose `depends_on` outputs are available and whose `status` is `pending`).",
+					"   - **Every bundle status transition MUST be performed via `specflow-advance-bundle`.** This applies to all four logical transitions: `pending → in_progress`, `in_progress → done`, `pending → skipped`, `pending → done`. Invoke:",
+					"     ```bash",
+					"     specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>",
+					"     ```",
+					"     The CLI re-renders `tasks.md` and normalizes child-task statuses on terminal transitions automatically.",
+					"   - **Do NOT edit `task-graph.json` or `tasks.md` by any other means in this path.** Inline `node -e '…'` scripts, `jq` / `sed` / `awk` expressions, shell here-docs, and direct Edit/Write tool invocations against `task-graph.json` or `tasks.md` are prohibited — they bypass schema validation, child-task normalization, atomic persistence, and the coercion audit log, and are a contract violation per `task-planner`.",
+					"   - **Fail-fast on CLI error.** If `specflow-advance-bundle` exits non-zero (malformed `task-graph.json`, unknown bundle id, invalid status transition, filesystem error, etc.), STOP the apply immediately. Surface the CLI's stdout JSON error envelope verbatim to the user. Do NOT advance any subsequent bundle, do NOT retry the same invocation, do NOT skip-and-continue. The run SHALL remain in `apply_draft`. Recovery paths for the user:",
+					"     - Regenerate `task-graph.json` (for example via `specflow-generate-task-graph <CHANGE_ID>`) when the schema error indicates a stale or corrupted graph.",
+					"     - Run `/specflow.fix_apply` when the error reflects an implementation problem surfaced by a prior review.",
+					"     - Manual repair of the graph is permitted only OUTSIDE apply-class workflows; inside this Step 1 path, manual edits remain a contract violation.",
+					"4. Validate implementation against `openspec/changes/<CHANGE_ID>/proposal.md`.",
+					"",
+					"Report: `Step 1 complete — implementation completed in apply_draft`",
+				].join("\n"),
 			},
 			{
 				title: "Step 2: Apply Review Gate",
@@ -351,7 +371,7 @@ export const commandBodies: Record<string, CommandBody> = {
 			{
 				title: "Important Rules",
 				content:
-					"\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, review-ledger, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- ALL control flow logic (fix application, diff filtering, review agent invocation, ledger detection/update, finding matching, current-phase generation) is handled by the `specflow-review-apply fix-review` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.",
+					"\n- Use the git repository root (`git rev-parse --show-toplevel`) as the base for all relative paths.\n- All artifacts (proposal, review-ledger, current-phase) are managed in `openspec/changes/<CHANGE_ID>/`.\n- If any tool call fails, report the error and ask the user how to proceed.\n- ALL control flow logic (fix application, diff filtering, review agent invocation, ledger detection/update, finding matching, current-phase generation) is handled by the `specflow-review-apply fix-review` orchestrator. This slash command only calls the orchestrator, parses its JSON output, and displays UI.\n- If the fix loop needs to update `task-graph.json` or `tasks.md`, use `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>`; inline `node -e` / `jq` / manual edits to those files are a contract violation per `task-planner`.",
 			},
 		],
 	},

--- a/src/tests/generation.test.ts
+++ b/src/tests/generation.test.ts
@@ -1,12 +1,23 @@
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import test from "node:test";
+import { commandBodies } from "../contracts/command-bodies.js";
 import { contracts } from "../contracts/install.js";
 import {
 	mergeProjectGitignore,
 	renderProjectGitignore,
 } from "../lib/project-gitignore.js";
 import type { InstallPlan, Manifest } from "../types/contracts.js";
+
+/**
+ * Flatten all section contents of a commandBodies entry into a single string.
+ * Used by source-level assertions that must stay independent of dist freshness.
+ */
+function commandBodyText(key: string): string {
+	const body = commandBodies[key];
+	assert.ok(body, `commandBodies['${key}'] is missing`);
+	return body.sections.map((section) => section.content).join("\n");
+}
 
 test("generated manifest and install plan reflect contracts", () => {
 	const manifest = JSON.parse(
@@ -195,4 +206,169 @@ test("main branch no longer carries the in-tree legacy runtime", () => {
 	const retiredWrapper = ["legacy", "wrapper.ts"].join("-");
 	assert.equal(existsSync(archivedTree), false);
 	assert.equal(existsSync(`src/bin/${retiredWrapper}`), false);
+});
+
+test("specflow.apply command body source encodes the specflow-advance-bundle contract", () => {
+	// Source-level assertions against `src/contracts/command-bodies.ts`. These
+	// are independent of the build pipeline and protect against cases where
+	// `dist/` is stale or absent (e.g., a clean checkout or test runner that
+	// skips the build step).
+	const apply = commandBodyText("specflow.apply");
+
+	assert.ok(
+		apply.includes("Pre-apply path detection"),
+		"command body should introduce the three-way path detection",
+	);
+	assert.ok(
+		apply.includes("legacy fallback"),
+		"command body should name the legacy fallback path",
+	);
+	assert.ok(
+		apply.includes("CLI-mandatory path"),
+		"command body should name the CLI-mandatory path",
+	);
+	assert.ok(
+		apply.includes(
+			"specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>",
+		),
+		"command body should contain the literal CLI invocation with placeholders",
+	);
+	for (const transition of [
+		"pending → in_progress",
+		"in_progress → done",
+		"pending → skipped",
+		"pending → done",
+	]) {
+		assert.ok(
+			apply.includes(transition),
+			`command body should enumerate the transition: ${transition}`,
+		);
+	}
+	assert.ok(
+		apply.includes("Fail-fast on CLI error"),
+		"command body should document fail-fast behavior on CLI error",
+	);
+	assert.ok(
+		apply.includes("contract violation per `task-planner`"),
+		"command body should link the prohibition to the task-planner contract",
+	);
+});
+
+test("specflow.fix_apply command body source carries the specflow-advance-bundle safety-net", () => {
+	// Source-level assertion — independent of the build pipeline.
+	const fixApply = commandBodyText("specflow.fix_apply");
+	assert.ok(
+		fixApply.includes("specflow-advance-bundle"),
+		"command body Important Rules should reference specflow-advance-bundle",
+	);
+	assert.ok(
+		fixApply.includes("contract violation per `task-planner`"),
+		"command body Important Rules should classify inline edits as a contract violation",
+	);
+});
+
+test("generated specflow.apply.md encodes the specflow-advance-bundle contract", () => {
+	// Defensive guard: this test depends on a fresh `npm run build` having
+	// produced the dist file. Fail fast with a clear message if it is missing,
+	// so a stale-build case surfaces loudly instead of silently passing against
+	// outdated content. The companion source-level test above exercises the
+	// same contract directly against `command-bodies.ts` as a belt-and-suspenders
+	// guarantee that the contract is enforced regardless of dist state.
+	const applyPath = "dist/package/global/commands/specflow.apply.md";
+	assert.ok(
+		existsSync(applyPath),
+		`${applyPath} is missing; run \`npm run build\` before the test suite`,
+	);
+	const apply = readFileSync(applyPath, "utf8");
+
+	// Positive: three-way detection rule documented.
+	assert.ok(
+		apply.includes("Pre-apply path detection"),
+		"apply.md should introduce the three-way path detection",
+	);
+	assert.ok(
+		apply.includes("legacy fallback"),
+		"apply.md should name the legacy fallback path",
+	);
+	assert.ok(
+		apply.includes("CLI-mandatory path"),
+		"apply.md should name the CLI-mandatory path",
+	);
+
+	// Positive: CLI is named with its full positional signature.
+	assert.ok(
+		apply.includes(
+			"specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>",
+		),
+		"apply.md should contain the literal CLI invocation with placeholders",
+	);
+
+	// Positive: all four logical transitions are enumerated.
+	for (const transition of [
+		"pending → in_progress",
+		"in_progress → done",
+		"pending → skipped",
+		"pending → done",
+	]) {
+		assert.ok(
+			apply.includes(transition),
+			`apply.md should enumerate the transition: ${transition}`,
+		);
+	}
+
+	// Positive: fail-fast language.
+	assert.ok(
+		apply.includes("Fail-fast on CLI error"),
+		"apply.md should document fail-fast behavior on CLI error",
+	);
+	assert.ok(
+		apply.includes("remain in `apply_draft`"),
+		"apply.md should state the run stays in apply_draft on CLI error",
+	);
+
+	// Positive: prohibition of inline mutation, linked to task-planner contract.
+	assert.ok(
+		apply.includes("Inline `node -e"),
+		"apply.md should explicitly prohibit inline node -e scripts",
+	);
+	assert.ok(
+		apply.includes("contract violation per `task-planner`"),
+		"apply.md should link the prohibition to the task-planner contract",
+	);
+
+	// Negative: no embedded example inline mutation snippet.
+	for (const forbidden of [
+		"bundle.status =",
+		"fs.writeFileSync",
+		"fs.readFileSync",
+		"tasks[*].status =",
+	]) {
+		assert.ok(
+			!apply.includes(forbidden),
+			`apply.md must not contain an inline mutation snippet: ${forbidden}`,
+		);
+	}
+
+	// Negative: no jq expression that rewrites a status field.
+	assert.ok(
+		!/\bjq\s+['"][^'"]*\.status/.test(apply),
+		"apply.md must not contain a jq expression that rewrites a status field",
+	);
+});
+
+test("generated specflow.fix_apply.md carries the specflow-advance-bundle safety-net", () => {
+	const fixApplyPath = "dist/package/global/commands/specflow.fix_apply.md";
+	assert.ok(
+		existsSync(fixApplyPath),
+		`${fixApplyPath} is missing; run \`npm run build\` before the test suite`,
+	);
+	const fixApply = readFileSync(fixApplyPath, "utf8");
+	assert.ok(
+		fixApply.includes("specflow-advance-bundle"),
+		"fix_apply.md Important Rules should reference specflow-advance-bundle",
+	);
+	assert.ok(
+		fixApply.includes("contract violation per `task-planner`"),
+		"fix_apply.md Important Rules should classify inline edits as a contract violation",
+	);
 });


### PR DESCRIPTION
## Summary

- Rewrites `specflow.apply` Step 1 to mandate `specflow-advance-bundle <CHANGE_ID> <BUNDLE_ID> <NEW_STATUS>` for every bundle status transition when `task-graph.json` exists and is schema-valid; explicitly forbids inline `node -e` / `jq` / manual edits and documents fail-fast-on-CLI-error semantics.
- Encodes the three-way pre-apply path detection (absent → legacy fallback; present + valid → CLI-mandatory; present + malformed → abort in `apply_draft`) so malformed task graphs never silently downgrade to the legacy path.
- Adds a one-line safety-net to `specflow.fix_apply` Important Rules pointing the fix loop at `specflow-advance-bundle` for any task-graph / tasks.md mutation.
- Strengthens the `task-planner` spec (CLI is the sole mutation entry point for apply-class workflows) and registers `specflow-advance-bundle` as a first-class distribution CLI in the `utility-cli-suite` spec (signature, stdout JSON envelope, stderr coercion audit log, two-valued exit-code contract). Violation detection is deferred to a follow-up change.
- Extends `src/tests/generation.test.ts` with positive + negative assertions against the regenerated apply guide, a safety-net assertion against the fix_apply guide, and source-level assertions against `commandBodies` that stay independent of dist freshness.

No new library or CLI code — `src/bin/specflow-advance-bundle.ts` and `src/lib/task-planner/advance.ts` already implemented the behavior this change wires up.

## Issue

Closes https://github.com/skr19930617/specflow/issues/147