### PR TITLE
feat: define canonical workflow state semantics (#164)

### DIFF
--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/approval-summary.md
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/approval-summary.md
@@ -1,0 +1,90 @@
+# Approval Summary: define-canonical-workflow-state-semantics-independent-of-local-execution-environment
+
+**Generated**: 2026-04-18T03:42:37Z
+**Branch**: define-canonical-workflow-state-semantics-independent-of-local-execution-environment
+**Status**: ✅ No unresolved high
+
+## What Changed
+
+All files are newly added under the change directory (spec-only change, no prior HEAD entries):
+
+```
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/.openspec.yaml
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/current-phase.md
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/design.md
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/proposal.md
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/review-ledger-design.json
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/canonical-workflow-state/spec.md
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/workflow-run-state/spec.md
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/task-graph.json
+ openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/tasks.md
+```
+
+No source code (`src/**`), test (`src/tests/**`), or configuration files outside the change directory were modified.
+
+## Files Touched
+
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/.openspec.yaml`
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/current-phase.md`
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/design.md`
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/proposal.md`
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/review-ledger-design.json`
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/canonical-workflow-state/spec.md`
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/workflow-run-state/spec.md`
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/task-graph.json`
+- `openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/tasks.md`
+
+## Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+### Impl Review
+
+⚠️ No impl ledger — apply review produced no reviewable changes (spec-only change).
+
+## Proposal Coverage
+
+Acceptance criteria are taken from `proposal.md` (seeded from issue #164):
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | run-state が「workflow canonical state」と「adapter execution state」に意味論上分けて説明されている | Yes | specs/canonical-workflow-state/spec.md (runtime-agnostic, nine-roles, exclusion-rule requirements) |
+| 2 | server/UI が依存してよい state surface が明確 | Yes | specs/canonical-workflow-state/spec.md (external-consumer requirement) |
+| 3 | local reference implementation に残してよい state が明確 | Yes | specs/canonical-workflow-state/spec.md (local-reference-implementation requirement); specs/workflow-run-state/spec.md (conformance requirement) |
+| 4 | canonical state は runtime-agnostic であることが明文化されている | Yes | specs/canonical-workflow-state/spec.md (runtime-agnostic requirement) |
+| 5 | core runtime は canonical state を前提に説明できる | Yes | specs/canonical-workflow-state/spec.md (conformance-authority requirement); specs/workflow-run-state/spec.md (normative reference) |
+
+**Coverage Rate**: 5/5 (100%)
+
+## Remaining Risks
+
+**Deterministic risks:** none (design ledger `all_resolved` with 0 findings; no impl ledger produced).
+
+**Untested new files:**
+
+- ℹ️ `specs/canonical-workflow-state/spec.md` and `specs/workflow-run-state/spec.md` are the intended spec outputs of this change; they are not test targets.
+- ℹ️ `design.md`, `tasks.md`, `task-graph.json`, `proposal.md`, `current-phase.md`, `review-ledger-design.json`, `.openspec.yaml` are workflow-managed artifacts under the change directory, not reviewable implementation files.
+
+No untracked-new-file risk requires human attention for a spec-only change.
+
+**Uncovered criteria:** none (5/5 covered).
+
+**Structural note (non-blocking):**
+
+- This change is spec-only by design; no `CoreRunState` / `LocalRunState` type edits ship with it. If a future runtime consumer discovers that a canonical role cannot be expressed via the current type partition, the discrepancy path declared in `specs/workflow-run-state/spec.md` (`discrepancy-surfacing` scenario) requires recording and handling it in a separate change.
+
+## Human Checkpoints
+
+- [ ] Confirm the nine canonical roles (run identity, change identity, current phase, lifecycle status, allowed events, actor identity, source metadata, history, previous run linkage) exactly match your mental model of "what a workflow instance is" — adding a tenth role later is additive, but removing one later is a breaking spec change.
+- [ ] Confirm the exclusion rule (adapter execution state = everything not in the nine canonical roles) is the right maintenance strategy vs. an explicit registry — this was clarification C3 in the proposal.
+- [ ] Confirm the normative reference added to `workflow-run-state` is the desired coupling direction (canonical spec is source of truth; types conform) — once merged, future drift between types and canonical semantics is a spec violation.
+- [ ] Confirm that leaving interchange format and stability policy as explicit Non-Goals (C5, C2) is still the intended staging — they are unblocked by this change but not scheduled.
+- [ ] Confirm you want issue #164 closed by this PR (the commit message will include `Closes`).

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/current-phase.md
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/current-phase.md
@@ -1,0 +1,11 @@
+# Current Phase: define-canonical-workflow-state-semantics-independent-of-local-execution-environment
+
+- Phase: design-review
+- Round: 1
+- Status: all_resolved
+- Open High/Critical Findings: 0 件
+- Actionable Findings: 0
+- Accepted Risks: none
+- Latest Changes:
+  - (no commits yet)
+- Next Recommended Action: /specflow.apply

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/design.md
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/design.md
@@ -1,0 +1,345 @@
+# Design — Define canonical workflow state semantics independent of local execution environment
+
+## Context
+
+Today the specflow repository persists workflow run-state under
+`.specflow/runs/<run_id>/run.json`. Its shape is defined by three
+TypeScript aliases in `src/types/contracts.ts`:
+
+- `CoreRunState` — runtime-agnostic fields (12 fields: `run_id`,
+  `change_name`, `current_phase`, `status`, `allowed_events`, `agents`,
+  `history`, `source`, `created_at`, `updated_at`, `previous_run_id`,
+  `run_kind`).
+- `LocalRunState` — local filesystem / git-backed adapter fields
+  (6 fields: `project_id`, `repo_name`, `repo_path`, `branch_name`,
+  `worktree_path`, `last_summary_path`).
+- `RunState = CoreRunState & LocalRunState` — the compatibility alias.
+
+The partition was introduced in the `runstate-adapter-extension`
+capability for type-level reasons (enabling `RunState<TAdapter>` for
+alternate adapters). However, the repository currently has no spec that
+defines the **semantic meaning** of "canonical workflow state" —
+i.e. what the canonical surface represents as a contract, independent
+of any concrete type or persistence format. Issue #164 asks us to fix
+that by producing a dedicated semantic contract spec, without touching
+implementation fields.
+
+Stakeholders:
+- **specflow core maintainers** — need a stable semantic anchor before
+  designing server-backed runtimes or alternate UIs.
+- **future adapter authors** — need to know which state they are free
+  to own privately vs. which state must conform to canonical meaning.
+- **future consumers** (server, UI, review transport) — need a
+  runtime-agnostic surface they can depend on.
+
+Constraint: this change is **spec-only**. The type-level partition
+already conforms to the canonical semantics we will formalize, so no
+TypeScript source edits, no CLI behavior edits, and no artifact-store
+changes are in scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Publish `openspec/specs/canonical-workflow-state/spec.md` as the
+  normative source of truth for the semantic meaning of workflow state.
+- Enumerate the nine canonical semantic roles once, in one place, with
+  each role's purpose and the invariants it carries.
+- Define adapter execution state by an exclusion rule so the canonical
+  surface is future-proof against new adapters.
+- Add a normative reference inside `openspec/specs/workflow-run-state/spec.md`
+  declaring that the existing `CoreRunState` / `LocalRunState` partition
+  conforms to the canonical semantics, without modifying field lists or
+  scenarios.
+- Preserve backward compatibility: every existing consumer of `RunState`,
+  `CoreRunState`, or `LocalRunState` continues to compile untouched.
+
+**Non-Goals:**
+
+- Moving, renaming, adding, or removing any field in `CoreRunState` /
+  `LocalRunState` / `RunState`.
+- Defining an interchange / serialization format (JSON Schema,
+  protobuf, OpenAPI) for the canonical surface.
+- Specifying a stability / breaking-change / semver policy for canonical
+  state.
+- Designing a server, review transport, event streaming, or DB schema.
+- Implementing any runtime that consumes canonical state non-locally.
+
+## Decisions
+
+### D1. Represent canonical meaning as a dedicated capability spec
+
+**Choice:** Create a new `canonical-workflow-state` capability spec that
+owns the semantic contract.
+
+**Alternatives considered:**
+- (a) Extend `workflow-run-state` with the semantic definitions inline.
+- (b) Extend `runstate-adapter-extension` with the semantic definitions.
+
+**Rationale:** Both existing specs describe implementation contracts —
+the CLI / state-machine behavior for (a), and the type-level adapter
+mechanism for (b). The canonical semantics is conceptually upstream of
+both: it defines the meaning that those implementations must conform
+to. Placing it in a standalone capability makes the source-of-truth
+direction explicit and avoids expanding the scope of either existing
+capability.
+
+### D2. Nine canonical roles, enumerated by purpose — not by field
+
+**Choice:** The canonical surface SHALL be described as nine semantic
+**roles** (run identity, change identity, current phase, lifecycle
+status, allowed events, actor identity, source metadata, history,
+previous run linkage), not as a field-level list.
+
+**Alternatives considered:**
+- (a) Enumerate concrete field names (`run_id`, `change_name`, …) in
+  the canonical spec.
+- (b) Leave the roles undefined and rely on `CoreRunState`'s existing
+  field names.
+
+**Rationale:** The issue explicitly says *"field 移動ではなく canonical
+meaning の確定にある"* — the spec should anchor meaning that survives
+future renames. Role-level definitions let alternate runtimes choose
+different field encodings while still conforming. `CoreRunState`
+becomes one representation of the canonical surface, not its
+definition.
+
+### D3. Adapter execution state is defined by exclusion
+
+**Choice:** A field is adapter execution state iff it does not map to
+any of the nine canonical roles. No exhaustive normative list of
+adapter-private fields.
+
+**Alternatives considered:**
+- (a) Exhaustively list current `LocalRunState` fields as normative
+  adapter-private fields.
+- (b) Require every adapter to register its private fields in the spec.
+
+**Rationale:** (a) and (b) both grow the spec each time a new adapter
+appears; the exclusion rule is stable. Informative examples of current
+local-adapter fields remain (for readability) but carry no normative
+force.
+
+### D4. Reference from `workflow-run-state` is normative and additive
+
+**Choice:** Add one `ADDED Requirement` to the `workflow-run-state`
+delta declaring that `CoreRunState` / `LocalRunState` conforms to the
+canonical semantics, without touching existing requirements or
+scenarios.
+
+**Alternatives considered:**
+- (a) `MODIFIED Requirement` that rewrites the existing "Run-state
+  types are partitioned into core and local-adapter partitions"
+  requirement to cite the canonical spec.
+- (b) Do not modify `workflow-run-state` at all; keep the new spec
+  standalone.
+
+**Rationale:** (a) rewrites a requirement whose concrete scenarios are
+already validated and archived, risking spurious diffs in scenario
+text. (b) leaves the two specs mutually silent, making it possible for
+a future drift between the type partition and the canonical semantics
+to go unnoticed. An additive normative reference is the minimal
+coupling that makes the conformance relationship discoverable from
+either direction.
+
+### D5. Discovered discrepancies are recorded, not silently reconciled
+
+**Choice:** If writing the canonical spec surfaces a mismatch between
+the nine canonical roles and current `CoreRunState` / `LocalRunState`
+fields, the spec records the discrepancy and defers reconciliation to
+a separate change.
+
+**Alternatives considered:**
+- (a) Block this change until the type partition is fixed in the same
+  commit.
+- (b) Silently reclassify fields to match.
+
+**Rationale:** (a) inflates scope (the issue explicitly excludes field
+moves); (b) hides state from reviewers. A "surface, don't fix"
+discipline matches the issue's Non-Goals.
+
+### D6. No interchange format, no stability policy in this change
+
+**Choice:** Both are listed as Non-Goals in the spec and deferred to
+separate future capabilities.
+
+**Rationale:** An interchange format presumes a canonical meaning to
+serialize; a stability policy presumes a surface to version. Writing
+meaning first is the correct dependency order. Attempting both now
+dilutes the scope and forces premature commitments.
+
+## Risks / Trade-offs
+
+- **Risk: The nine roles are over- or under-specified.** → Mitigation:
+  each role's definition cites the information it must carry and the
+  invariants it enforces, without prescribing fields or encoding. If a
+  tenth role is later needed, adding it is an additive spec change; if
+  a role turns out to be redundant, merging is also additive.
+- **Risk: Future readers conflate the canonical spec with the type
+  partition.** → Mitigation: D4's normative-reference requirement
+  explicitly states the direction — canonical spec is source of truth;
+  types are a conforming representation.
+- **Risk: The exclusion rule is ambiguous for borderline fields
+  (e.g. a field that is "mostly" canonical).** → Mitigation: borderline
+  cases become Open Questions and are resolved per-field rather than
+  by blanket rule. D5 makes the discrepancy-handling path explicit.
+- **Risk: Drift between types and canonical spec goes undetected.** →
+  Mitigation: the workflow-run-state delta's conformance scenario is
+  testable by inspection; a future compile-time or lint-time check
+  could mechanize it, but is out of scope here.
+- **Trade-off: Spec-only change delivers no runtime behavior.** The
+  value is foundational — it unblocks subsequent capabilities (server
+  runtime, interchange format, versioning policy) by fixing a shared
+  vocabulary. This is accepted explicitly by the issue.
+
+## Migration Plan
+
+No runtime migration. The change is spec-only; no code ships with it.
+
+Rollback: revert the change's commits. No data migration, no config
+change, no release artifact. Downstream consumers of the existing
+`CoreRunState` / `LocalRunState` types are not affected.
+
+## Open Questions
+
+None requiring resolution before spec acceptance. Follow-up work that
+this change enables — but that this change does not decide:
+
+- Should the canonical semantics be expressed machine-readably
+  (JSON Schema, TypeSpec) alongside the prose spec?
+- Should a compile-time assertion be added that
+  `keyof CoreRunState` exactly covers the nine canonical roles?
+- Should the canonical spec gain a stability-policy addendum as the
+  first alternate runtime (server / DB-backed) is designed?
+
+Each is a candidate for its own change; none blocks this one.
+
+---
+
+## Concerns
+
+Concern → problem resolved:
+
+- **C-1: Canonical semantics is undefined.** Today the repository has a
+  type partition (`CoreRunState` / `LocalRunState`) without a spec that
+  says *why* the partition is drawn where it is. This change resolves
+  that by producing the definitional spec.
+- **C-2: External runtime authors have no contract to target.** Without
+  a canonical surface spec, a hypothetical server-backed runtime cannot
+  know which fields are required semantics vs. which are local-only
+  metadata. This change resolves that by listing the nine canonical
+  roles.
+- **C-3: Local-adapter fields are implicitly privileged.** Current
+  `LocalRunState` reads as "the rest of run.json" rather than "the
+  adapter-private extension of the canonical surface". This change
+  resolves that by defining adapter execution state via exclusion from
+  the canonical surface.
+- **C-4: Type partition and canonical meaning can drift undetected.**
+  This change resolves that by adding a normative conformance reference
+  from `workflow-run-state` back to the new canonical spec.
+
+## State / Lifecycle
+
+- **Canonical state** (per the new spec): the nine roles
+  (run identity, change identity, current phase, lifecycle status,
+  allowed events, actor identity, source metadata, history,
+  previous run linkage). Runtime-agnostic; persisted by any conforming
+  runtime.
+- **Adapter execution state** (per the new spec, exclusion-defined):
+  everything else that a given adapter chooses to persist alongside
+  canonical state. Informative current examples (local adapter):
+  `project_id`, `repo_name`, `repo_path`, `branch_name`,
+  `worktree_path`, `last_summary_path`.
+- **Derived state**: `allowed_events` is computed from
+  `current_phase` × `status` × workflow machine. This change does not
+  redefine the derivation rule; it only classifies `allowed_events` as
+  part of the canonical surface.
+- **Lifecycle boundaries**: canonical state crosses runtime boundaries
+  unchanged; adapter execution state is reconstructed per-adapter on
+  ingest and is not transported between runtimes.
+- **Persistence-sensitive state**: `history` is append-only; this
+  invariant is already enforced by `workflow-run-state` and is
+  reaffirmed — not re-specified — by citing `history` as a canonical
+  role.
+
+## Contracts / Interfaces
+
+- **Spec → spec contract:** `workflow-run-state` declares conformance
+  to `canonical-workflow-state`. Interface: the nine semantic roles.
+- **Spec → type contract (existing, unchanged):** `CoreRunState` /
+  `LocalRunState` / `RunState` in `src/types/contracts.ts`. No surface
+  change.
+- **Spec → CLI contract (existing, unchanged):** `specflow-run`,
+  `specflow-prepare-change` observable behavior is untouched.
+- **No new layer interfaces** are introduced (no UI, API, persistence,
+  renderer, or external-service interfaces added).
+
+## Persistence / Ownership
+
+- **Canonical state ownership:** logically owned by the workflow core;
+  every conforming runtime must be able to produce it. No physical
+  owner changes in this change.
+- **Adapter execution state ownership:** owned by the concrete
+  adapter. The local filesystem adapter retains ownership of its
+  current private fields; no migration.
+- **Artifact ownership:**
+  - `openspec/specs/canonical-workflow-state/spec.md` — new, owned by
+    this change (and then by the capability post-archive).
+  - `openspec/specs/workflow-run-state/spec.md` — an additive
+    requirement is appended via delta; existing requirements remain
+    under their original ownership.
+
+## Integration Points
+
+- **External systems:** none added.
+- **Cross-layer dependency points:** the new spec becomes the upstream
+  semantic reference for any future non-local runtime (server, DB,
+  review transport). This change creates the reference point but does
+  not integrate any new consumer.
+- **Regeneration / retry / save / restore boundaries:** unchanged. The
+  existing `workflow-run-state` requirements (retry lineage,
+  suspend/resume, atomic writes) already cover these boundaries and
+  are not edited here.
+
+## Ordering / Dependency Notes
+
+- **Foundational:** the new `canonical-workflow-state` spec — writing
+  it unblocks the normative reference in `workflow-run-state`.
+- **Dependent:** the `workflow-run-state` delta requirement depends on
+  the new spec existing (it cites paths under
+  `openspec/specs/canonical-workflow-state/`).
+- **Parallelizable:** there is no parallelizable work inside this
+  change — the two spec files are written in a fixed order. However,
+  this change itself is independent of every other open change and can
+  land in any order relative to them.
+- **Post-archive:** once archived, the new spec moves from
+  `openspec/changes/<id>/specs/canonical-workflow-state/spec.md` to
+  `openspec/specs/canonical-workflow-state/spec.md`. The
+  `workflow-run-state` additive requirement is merged into the
+  baseline spec by OpenSpec's archive flow.
+
+## Completion Conditions
+
+- **`openspec/changes/<id>/specs/canonical-workflow-state/spec.md`**
+  exists, `openspec validate` passes, and contains:
+  - the runtime-agnostic requirement
+  - the nine-roles requirement
+  - the exclusion-rule requirement
+  - the external-consumer requirement
+  - the local-reference-implementation requirement
+  - the conformance-authority requirement
+  - the non-goals requirement
+- **`openspec/changes/<id>/specs/workflow-run-state/spec.md`** exists
+  and contains exactly one `ADDED Requirement` declaring conformance,
+  with four scenarios (coverage, exclusion, no-field-change,
+  discrepancy-surfacing).
+- **`design.md`** (this file) exists with the seven planning sections.
+- **`tasks.md` / `task-graph.json`** generated by
+  `specflow-generate-task-graph` exist and enumerate the spec-writing
+  tasks.
+- **Review:** design review gate (`/specflow.review_design`) passes
+  without outstanding findings.
+- Each spec file is independently reviewable: the
+  `canonical-workflow-state` spec is reviewable against issue #164's
+  acceptance criteria in isolation; the `workflow-run-state` delta is
+  reviewable against the existing baseline spec in isolation.

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/proposal.md
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+specflow の core が actor や execution environment を越えて成立するためには、
+`RunState` が「workflow instance の正本として何を表すのか」が意味論として固定されて
+いる必要がある。現状の run-state 型は runtime-agnostic な workflow state と
+local filesystem / git-backed reference implementation の execution metadata
+を同じ surface に同居させており、どこまでが canonical で、どこからが adapter-private
+なのかが仕様上明示されていない。この境界が曖昧な限り、server-side runtime や
+alternate UI が依存できる state surface を薄く定義できない。
+
+この change は、型分離そのものではなく **canonical workflow state が意味論として
+何を指すのか** を spec レベルで固定することを目的とする。既存の
+`workflow-run-state` / `runstate-adapter-extension` は type-level mechanics と
+CLI contract を定めているが、「どの field が canonical か」「どの field が
+adapter-private か」を規定する semantic contract が独立した capability としては
+まだ存在しない。
+
+Issue: https://github.com/skr19930617/specflow/issues/164
+
+## What Changes
+
+- `canonical-workflow-state` capability を新規に追加し、workflow core が保持すべき
+  canonical state の意味論と、adapter execution state との境界を明文化する。
+  - runtime-agnostic に保持されるべき canonical field 群とその semantic role
+    (run identity / change identity / current phase / lifecycle status /
+     allowed events / actor identity / source metadata / history /
+     previous run linkage) を規定する。
+  - adapter execution state (local filesystem path, git worktree path,
+    cached summary path 等) が canonical surface に含まれない根拠と位置づけを
+    規定する。
+  - server / UI / alternate runtime が依存してよい state surface を
+    「canonical surface」として明文化する。
+  - local reference implementation に残してよい adapter-private state の
+    範囲を明文化する。
+- 既存の `workflow-run-state` capability には SEMANTIC REFERENCE を追加し、
+  type-level partition (`CoreRunState` / `LocalRunState`) が新規 capability
+  の semantic contract に準拠することを明示する。
+  - 既存 field list の変更・追加・削除は行わない (non-goal)。
+
+## Capabilities
+
+### New Capabilities
+- `canonical-workflow-state`: workflow instance の canonical state semantics を
+  runtime-agnostic に定義し、adapter execution state との境界を明文化する
+  semantic contract。
+
+### Modified Capabilities
+- `workflow-run-state`: 既存の `CoreRunState` / `LocalRunState` 型分離が
+  `canonical-workflow-state` の semantic contract に準拠する、という
+  normative reference を追加する。field 追加・削除・改名は行わない。
+
+## Impact
+
+- 仕様面:
+  - `openspec/specs/canonical-workflow-state/spec.md` が新規に追加される。
+  - `openspec/specs/workflow-run-state/spec.md` に semantic reference 節が追加される。
+- 実装面:
+  - この change 単独では field 移動・型改名・CLI 挙動変更を伴わない。
+  - 将来の server / UI / alternate runtime 実装は新 capability を canonical
+    surface のソースとして参照できる。
+- Non-goals:
+  - DB schema の設計。
+  - server / review transport / event streaming の実装。
+  - interchange / serialization format (JSON schema, protobuf 等) の規定。
+  - canonical surface の stability / versioning policy (semver 等) の規定。
+  - `CoreRunState` / `LocalRunState` の field 構成変更。
+
+## Clarification Decisions
+
+Proposal challenge (C1–C6) に対する解像度。design phase 以降はこれらを前提とする。
+
+- **C1 semantic role 粒度**: canonical surface を構成する 9 role
+  (run identity / change identity / current phase / lifecycle status /
+   allowed events / actor identity / source metadata / history /
+   previous run linkage) については、この spec 内で各 role の意味論
+  (purpose, runtime-agnostic であることの根拠, 含まれるべき情報の概要) を
+  個別に明文化する。field-by-field の型定義は既存
+  `workflow-run-state` の記述を継続して使用する。
+- **C2 stability guarantee**: canonical surface の semver / breaking
+  change policy はこの spec のスコープ外 (Non-goal 参照)。本 spec は
+  「canonical surface が contract point として存在する」ことまでを
+  固定し、stability policy は後続 capability に委ねる。
+- **C3 adapter-private 定義戦略**: exclusion rule を採用する。
+  canonical surface に含まれない state は全て adapter-private と
+  みなされる。既知の local adapter field は informative example として
+  記載するが、normative な exhaustive list は作成しない。
+- **C4 現行型との不整合発見時の扱い**: この change 内では既存
+  `CoreRunState` / `LocalRunState` の field 構成を変更しない。
+  semantic contract を書き下した結果として不整合が検出された場合は、
+  本 spec の Notes section に discrepancy を記録し、別 change として
+  follow-up する。
+- **C5 serialization / transport format**: 明示的にスコープ外
+  (Non-goal に追加済み)。canonical surface が意味論として固定された後に、
+  別 capability で interchange format を定義する余地を残す。
+- **C6 `workflow-run-state` への reference の性質**: **normative**。
+  新 capability が canonical semantics の source of truth となり、
+  `workflow-run-state` の型分離は canonical semantics に準拠する、
+  という関係を宣言する。既存 scenario の書き換えや削除は行わない。

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/review-ledger-design.json
@@ -1,0 +1,19 @@
+{
+  "feature_id": "define-canonical-workflow-state-semantics-independent-of-local-execution-environment",
+  "phase": "design",
+  "current_round": 1,
+  "status": "all_resolved",
+  "max_finding_id": 0,
+  "findings": [],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 0,
+      "open": 0,
+      "new": 0,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/canonical-workflow-state/spec.md
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/canonical-workflow-state/spec.md
@@ -1,0 +1,203 @@
+## ADDED Requirements
+
+### Requirement: Canonical workflow state is runtime-agnostic
+
+The system SHALL define "canonical workflow state" as the authoritative state of a
+workflow instance that is independent of any specific execution environment. The
+canonical state SHALL NOT depend on local filesystem paths, git worktree paths,
+cached local artifacts, or any execution metadata specific to a particular adapter
+or runtime. A workflow instance in canonical state SHALL be fully describable by
+the canonical surface alone, such that two different runtimes (local filesystem,
+server-backed DB, in-memory test harness) holding the same canonical values SHALL
+be understood as representing the same workflow instance at the same logical
+position.
+
+#### Scenario: Canonical state excludes local filesystem information
+
+- **WHEN** the canonical workflow state of a run is inspected
+- **THEN** it SHALL NOT contain any field whose meaning depends on the presence
+  of a local filesystem (e.g., local absolute paths, worktree locations,
+  cached file references)
+
+#### Scenario: Canonical state excludes git execution information
+
+- **WHEN** the canonical workflow state of a run is inspected
+- **THEN** it SHALL NOT contain any field whose meaning depends on a specific
+  git worktree, working directory, or local git configuration
+
+#### Scenario: Equivalent canonical state implies equivalent workflow instance
+
+- **WHEN** two runtimes hold run-state values with identical canonical fields
+- **AND** their canonical fields carry identical semantic values
+- **THEN** both runtimes SHALL be understood as representing the same workflow
+  instance at the same logical phase, regardless of adapter-private differences
+
+### Requirement: Canonical surface comprises nine semantic roles
+
+The canonical workflow state surface SHALL consist of exactly the following nine
+semantic roles. Each role SHALL be defined by its purpose and the kind of
+information it conveys about a workflow instance, independent of any particular
+field encoding.
+
+1. **Run identity** — a stable identifier that uniquely distinguishes this
+   workflow run across retries and across adapter boundaries.
+2. **Change identity** — a reference to the logical change that the run is
+   progressing (nullable for synthetic runs that are not bound to a change).
+3. **Current phase** — the workflow machine state the run is currently in.
+4. **Lifecycle status** — whether the run is active, suspended, or terminal.
+5. **Allowed events** — the set of events that can legally be applied at the
+   current phase + status combination.
+6. **Actor identity** — the provenance of the acting party (main agent, review
+   agent, automation, or human) authorized to drive the run.
+7. **Source metadata** — the description of where the run's specification
+   originated (e.g., issue URL, inline text), such that the run can be retraced
+   to its origin without consulting the local execution environment.
+8. **History** — the immutable append-only record of phase transitions, events,
+   and per-entry actor provenance applied to the run.
+9. **Previous run linkage** — the reference to a prior terminal run for the
+   same change, establishing retry lineage.
+
+Any role outside this list SHALL NOT be considered canonical. Any runtime
+persisting canonical workflow state SHALL be able to express all nine roles.
+
+#### Scenario: All nine roles are present in any canonical view
+
+- **WHEN** a runtime exposes the canonical state of a run
+- **THEN** it SHALL provide an expression for every one of the nine roles:
+  run identity, change identity, current phase, lifecycle status, allowed
+  events, actor identity, source metadata, history, previous run linkage
+- **AND** roles whose value is logically absent (e.g., no previous run)
+  SHALL be represented as a well-defined "absent" value rather than omitted
+  from the canonical surface
+
+#### Scenario: Roles outside the nine are not canonical
+
+- **WHEN** a state field cannot be mapped to any of the nine canonical roles
+- **THEN** the field SHALL be classified as adapter execution state, not
+  canonical workflow state
+
+### Requirement: Adapter execution state is defined by exclusion
+
+The system SHALL define "adapter execution state" as any state held by a
+specific adapter or runtime that is NOT part of the canonical surface. Adapter
+execution state SHALL be treated as adapter-private and SHALL NOT be relied upon
+by any consumer that targets the canonical surface. The membership of adapter
+execution state SHALL be derived by exclusion from the canonical surface —
+there is no normative exhaustive enumeration of adapter-private fields.
+
+#### Scenario: Exclusion rule classifies adapter-private state
+
+- **WHEN** a field exists in a concrete run-state representation
+- **AND** the field does not correspond to any of the nine canonical roles
+- **THEN** the field SHALL be classified as adapter execution state
+- **AND** it SHALL NOT be required of alternate runtimes
+
+#### Scenario: Informative examples do not constrain adapters
+
+- **WHEN** the specification lists informative examples of adapter execution
+  state (e.g., local filesystem path, git worktree path, cached summary path)
+- **THEN** the list SHALL be treated as informative only
+- **AND** it SHALL NOT be interpreted as an exhaustive or required set
+
+### Requirement: External runtimes depend only on the canonical surface
+
+Consumers targeting semantic portability SHALL depend only on the canonical
+surface and SHALL NOT require any field classified as adapter execution state.
+This applies to server-side runtimes, alternate UIs, and non-local adapters. A
+consumer that reads canonical fields SHALL be able to operate against any
+conforming runtime without adapter-specific knowledge.
+
+#### Scenario: Server or UI sees canonical fields only
+
+- **WHEN** a server-side runtime or an alternate UI reads run state through a
+  conforming transport
+- **THEN** it SHALL observe expressions of the nine canonical roles
+- **AND** it SHALL NOT require any adapter-private field to fulfill its
+  responsibilities
+
+#### Scenario: Absence of adapter-private state does not break canonical consumers
+
+- **WHEN** a conforming runtime omits all adapter-private state
+- **THEN** a canonical-surface consumer SHALL still operate correctly
+
+### Requirement: Local reference implementation may carry adapter-private state
+
+The local filesystem / git-backed reference implementation SHALL be permitted to
+carry adapter-private execution state alongside the canonical surface, provided
+that the adapter-private state does not alter the semantic value of any
+canonical role. The local reference implementation SHALL expose the canonical
+surface faithfully so that non-local consumers may read it without reference to
+adapter-private fields.
+
+#### Scenario: Local adapter persists both surfaces
+
+- **WHEN** the local reference implementation persists a run
+- **THEN** it MAY include adapter-private fields (e.g., project identity,
+  repository path, branch name, worktree path, cached summary path)
+- **AND** these fields SHALL NOT modify or contradict the canonical roles
+
+#### Scenario: Canonical extraction from the local shape is well-defined
+
+- **WHEN** a non-local consumer reads a run persisted by the local adapter
+- **THEN** it SHALL be able to extract the canonical surface unambiguously by
+  ignoring adapter-private fields
+- **AND** the extracted canonical surface SHALL convey all nine roles
+
+### Requirement: Canonical semantics is the contract authority for type-level partitions
+
+Any type-level partition of run state SHALL conform to the canonical semantics
+defined by this specification, including the existing `CoreRunState` /
+`LocalRunState` partition in `src/types/contracts.ts`. Where a partition exists,
+its canonical partition SHALL cover all nine canonical roles, and its adapter
+partition SHALL hold only state classifiable as adapter execution state. The
+type-level partition SHALL NOT be treated as the source of truth for canonical
+meaning; this specification SHALL be the source of truth, and the type-level
+partition SHALL be a representation conforming to it.
+
+#### Scenario: Existing partition conforms to canonical semantics
+
+- **WHEN** the `CoreRunState` / `LocalRunState` partition is evaluated against
+  the canonical semantics
+- **THEN** the canonical partition SHALL cover expressions of all nine
+  canonical roles
+- **AND** the adapter partition SHALL contain only adapter execution state
+
+#### Scenario: Discovered discrepancy triggers a follow-up change
+
+- **WHEN** a discrepancy is observed between the canonical semantics and an
+  existing type-level partition (a canonical role missing from the canonical
+  partition, or adapter-private state appearing in the canonical partition)
+- **THEN** the discrepancy SHALL be recorded
+- **AND** reconciliation SHALL be handled by a separate change, not by silently
+  altering either surface
+
+### Requirement: Non-goals of the canonical semantics specification
+
+The canonical workflow state specification SHALL NOT prescribe the following
+concerns, which are out of scope and left to subsequent capabilities:
+
+- database schema design for canonical state
+- interchange / serialization format (e.g., JSON schema, protobuf) for
+  canonical state
+- server, review transport, or event streaming implementations
+- stability guarantees, versioning policy, or breaking-change policy for the
+  canonical surface
+- field-level type definitions of `CoreRunState` / `LocalRunState`
+
+#### Scenario: Interchange format is out of scope
+
+- **WHEN** the canonical semantics specification is evaluated for applicability
+  to an interchange format question (e.g., "what JSON field name SHALL
+  represent current_phase?")
+- **THEN** the specification SHALL NOT answer the question
+- **AND** the question SHALL be deferred to a separate interchange-format
+  capability
+
+#### Scenario: Stability policy is out of scope
+
+- **WHEN** the canonical semantics specification is evaluated for applicability
+  to a stability or versioning question (e.g., "how SHALL a breaking change to
+  a canonical role be versioned?")
+- **THEN** the specification SHALL NOT answer the question
+- **AND** the question SHALL be deferred to a separate versioning-policy
+  capability

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/workflow-run-state/spec.md
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/workflow-run-state/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Run-state type partition conforms to canonical workflow state semantics
+
+The `CoreRunState` and `LocalRunState` type partitions SHALL conform to the
+canonical workflow state semantics defined in
+`openspec/specs/canonical-workflow-state/spec.md`. This is a normative
+reference: the canonical semantics SHALL be the source of truth for which
+fields belong to the canonical surface, and the type-level partition SHALL be
+a representation conforming to it. This requirement SHALL NOT add, remove, or
+rename any field in `CoreRunState` or `LocalRunState`; the observable type
+shape remains governed by the existing requirements in this specification.
+
+#### Scenario: CoreRunState covers the canonical surface
+
+- **WHEN** the `CoreRunState` type is evaluated against the canonical
+  workflow state semantics
+- **THEN** every field in `CoreRunState` SHALL be classifiable as an
+  expression of one of the nine canonical roles defined in the
+  `canonical-workflow-state` capability
+- **AND** the nine canonical roles SHALL each be expressible via `CoreRunState`
+  fields (directly or in combination)
+
+#### Scenario: LocalRunState contains only adapter execution state
+
+- **WHEN** the `LocalRunState` type is evaluated against the canonical
+  workflow state semantics
+- **THEN** every field in `LocalRunState` SHALL be classifiable as adapter
+  execution state per the exclusion rule defined in the
+  `canonical-workflow-state` capability
+- **AND** no `LocalRunState` field SHALL be required of a non-local runtime
+
+#### Scenario: Field membership is not altered by this reference
+
+- **WHEN** this normative reference is added
+- **THEN** no field SHALL be added, removed, or renamed in `CoreRunState` or
+  `LocalRunState` as a consequence
+- **AND** all existing consumers importing `RunState`, `CoreRunState`, or
+  `LocalRunState` SHALL continue to compile without code change
+
+#### Scenario: Discrepancy is surfaced, not silently reconciled
+
+- **WHEN** a field in `CoreRunState` or `LocalRunState` cannot be cleanly
+  classified under the canonical semantics (e.g., a canonical role has no
+  corresponding field, or a field resists classification)
+- **THEN** the discrepancy SHALL be recorded
+- **AND** reconciliation SHALL be handled by a separate change, not by
+  silently editing the partition in this specification

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/task-graph.json
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/task-graph.json
@@ -1,0 +1,120 @@
+{
+  "version": "1.0",
+  "change_id": "define-canonical-workflow-state-semantics-independent-of-local-execution-environment",
+  "bundles": [
+    {
+      "id": "canonical-workflow-state-spec",
+      "title": "Write canonical-workflow-state capability spec",
+      "goal": "Publish the canonical-workflow-state spec defining the nine semantic roles, the exclusion rule for adapter state, and the conformance-authority contract.",
+      "depends_on": [],
+      "inputs": [
+        "openspec/specs/workflow-run-state/spec.md",
+        "src/types/contracts.ts"
+      ],
+      "outputs": [
+        "openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/canonical-workflow-state/spec.md"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Draft the runtime-agnostic requirement: canonical workflow state is defined independently of any persistence format or execution environment",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Draft the nine-roles requirement enumerating each semantic role (run identity, change identity, current phase, lifecycle status, allowed events, actor identity, source metadata, history, previous run linkage) with purpose and invariants",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Draft the exclusion-rule requirement: a field is adapter execution state iff it does not map to any canonical role",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Draft the external-consumer requirement: any conforming runtime must produce all nine canonical roles",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Draft the local-reference-implementation requirement: CoreRunState is one conforming representation, with informative examples of LocalRunState as adapter-private fields",
+          "status": "done"
+        },
+        {
+          "id": "6",
+          "title": "Draft the conformance-authority requirement: this spec is the upstream source of truth; type partitions are conforming representations",
+          "status": "done"
+        },
+        {
+          "id": "7",
+          "title": "Draft the non-goals requirement: no interchange format, no stability policy, no field-level prescription",
+          "status": "done"
+        },
+        {
+          "id": "8",
+          "title": "Run openspec validate on the new spec file and fix any structural issues",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "workflow-run-state",
+        "run-identity-model"
+      ]
+    },
+    {
+      "id": "workflow-run-state-conformance-delta",
+      "title": "Add conformance reference to workflow-run-state",
+      "goal": "Append one ADDED Requirement to the workflow-run-state delta declaring that the CoreRunState/LocalRunState partition conforms to canonical-workflow-state semantics.",
+      "depends_on": [
+        "canonical-workflow-state-spec"
+      ],
+      "inputs": [
+        "openspec/specs/workflow-run-state/spec.md",
+        "openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/canonical-workflow-state/spec.md"
+      ],
+      "outputs": [
+        "openspec/changes/define-canonical-workflow-state-semantics-independent-of-local-execution-environment/specs/workflow-run-state/spec.md"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Draft the ADDED Requirement declaring CoreRunState/LocalRunState conformance to canonical-workflow-state",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Write scenario: coverage — every canonical role maps to at least one CoreRunState field",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Write scenario: exclusion — every LocalRunState field is absent from the canonical roles",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Write scenario: no-field-change — no fields are added, removed, or renamed by this requirement",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Write scenario: discrepancy-surfacing — if a mismatch is found it is recorded, not silently reconciled",
+          "status": "done"
+        },
+        {
+          "id": "6",
+          "title": "Run openspec validate on the updated delta spec and fix any structural issues",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "workflow-run-state",
+        "run-identity-model"
+      ]
+    }
+  ],
+  "generated_at": "2026-04-18T03:37:22.327Z",
+  "generated_from": "design.md"
+}

--- a/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/tasks.md
+++ b/openspec/changes/archive/2026-04-18-define-canonical-workflow-state-semantics-independent-of-local-execution-environment/tasks.md
@@ -1,0 +1,25 @@
+## 1. Write canonical-workflow-state capability spec ✓
+
+> Publish the canonical-workflow-state spec defining the nine semantic roles, the exclusion rule for adapter state, and the conformance-authority contract.
+
+- [x] 1.1 Draft the runtime-agnostic requirement: canonical workflow state is defined independently of any persistence format or execution environment
+- [x] 1.2 Draft the nine-roles requirement enumerating each semantic role (run identity, change identity, current phase, lifecycle status, allowed events, actor identity, source metadata, history, previous run linkage) with purpose and invariants
+- [x] 1.3 Draft the exclusion-rule requirement: a field is adapter execution state iff it does not map to any canonical role
+- [x] 1.4 Draft the external-consumer requirement: any conforming runtime must produce all nine canonical roles
+- [x] 1.5 Draft the local-reference-implementation requirement: CoreRunState is one conforming representation, with informative examples of LocalRunState as adapter-private fields
+- [x] 1.6 Draft the conformance-authority requirement: this spec is the upstream source of truth; type partitions are conforming representations
+- [x] 1.7 Draft the non-goals requirement: no interchange format, no stability policy, no field-level prescription
+- [x] 1.8 Run openspec validate on the new spec file and fix any structural issues
+
+## 2. Add conformance reference to workflow-run-state ✓
+
+> Append one ADDED Requirement to the workflow-run-state delta declaring that the CoreRunState/LocalRunState partition conforms to canonical-workflow-state semantics.
+
+> Depends on: canonical-workflow-state-spec
+
+- [x] 2.1 Draft the ADDED Requirement declaring CoreRunState/LocalRunState conformance to canonical-workflow-state
+- [x] 2.2 Write scenario: coverage — every canonical role maps to at least one CoreRunState field
+- [x] 2.3 Write scenario: exclusion — every LocalRunState field is absent from the canonical roles
+- [x] 2.4 Write scenario: no-field-change — no fields are added, removed, or renamed by this requirement
+- [x] 2.5 Write scenario: discrepancy-surfacing — if a mismatch is found it is recorded, not silently reconciled
+- [x] 2.6 Run openspec validate on the updated delta spec and fix any structural issues

--- a/openspec/specs/canonical-workflow-state/spec.md
+++ b/openspec/specs/canonical-workflow-state/spec.md
@@ -1,0 +1,207 @@
+# canonical-workflow-state Specification
+
+## Purpose
+TBD - created by archiving change define-canonical-workflow-state-semantics-independent-of-local-execution-environment. Update Purpose after archive.
+## Requirements
+### Requirement: Canonical workflow state is runtime-agnostic
+
+The system SHALL define "canonical workflow state" as the authoritative state of a
+workflow instance that is independent of any specific execution environment. The
+canonical state SHALL NOT depend on local filesystem paths, git worktree paths,
+cached local artifacts, or any execution metadata specific to a particular adapter
+or runtime. A workflow instance in canonical state SHALL be fully describable by
+the canonical surface alone, such that two different runtimes (local filesystem,
+server-backed DB, in-memory test harness) holding the same canonical values SHALL
+be understood as representing the same workflow instance at the same logical
+position.
+
+#### Scenario: Canonical state excludes local filesystem information
+
+- **WHEN** the canonical workflow state of a run is inspected
+- **THEN** it SHALL NOT contain any field whose meaning depends on the presence
+  of a local filesystem (e.g., local absolute paths, worktree locations,
+  cached file references)
+
+#### Scenario: Canonical state excludes git execution information
+
+- **WHEN** the canonical workflow state of a run is inspected
+- **THEN** it SHALL NOT contain any field whose meaning depends on a specific
+  git worktree, working directory, or local git configuration
+
+#### Scenario: Equivalent canonical state implies equivalent workflow instance
+
+- **WHEN** two runtimes hold run-state values with identical canonical fields
+- **AND** their canonical fields carry identical semantic values
+- **THEN** both runtimes SHALL be understood as representing the same workflow
+  instance at the same logical phase, regardless of adapter-private differences
+
+### Requirement: Canonical surface comprises nine semantic roles
+
+The canonical workflow state surface SHALL consist of exactly the following nine
+semantic roles. Each role SHALL be defined by its purpose and the kind of
+information it conveys about a workflow instance, independent of any particular
+field encoding.
+
+1. **Run identity** — a stable identifier that uniquely distinguishes this
+   workflow run across retries and across adapter boundaries.
+2. **Change identity** — a reference to the logical change that the run is
+   progressing (nullable for synthetic runs that are not bound to a change).
+3. **Current phase** — the workflow machine state the run is currently in.
+4. **Lifecycle status** — whether the run is active, suspended, or terminal.
+5. **Allowed events** — the set of events that can legally be applied at the
+   current phase + status combination.
+6. **Actor identity** — the provenance of the acting party (main agent, review
+   agent, automation, or human) authorized to drive the run.
+7. **Source metadata** — the description of where the run's specification
+   originated (e.g., issue URL, inline text), such that the run can be retraced
+   to its origin without consulting the local execution environment.
+8. **History** — the immutable append-only record of phase transitions, events,
+   and per-entry actor provenance applied to the run.
+9. **Previous run linkage** — the reference to a prior terminal run for the
+   same change, establishing retry lineage.
+
+Any role outside this list SHALL NOT be considered canonical. Any runtime
+persisting canonical workflow state SHALL be able to express all nine roles.
+
+#### Scenario: All nine roles are present in any canonical view
+
+- **WHEN** a runtime exposes the canonical state of a run
+- **THEN** it SHALL provide an expression for every one of the nine roles:
+  run identity, change identity, current phase, lifecycle status, allowed
+  events, actor identity, source metadata, history, previous run linkage
+- **AND** roles whose value is logically absent (e.g., no previous run)
+  SHALL be represented as a well-defined "absent" value rather than omitted
+  from the canonical surface
+
+#### Scenario: Roles outside the nine are not canonical
+
+- **WHEN** a state field cannot be mapped to any of the nine canonical roles
+- **THEN** the field SHALL be classified as adapter execution state, not
+  canonical workflow state
+
+### Requirement: Adapter execution state is defined by exclusion
+
+The system SHALL define "adapter execution state" as any state held by a
+specific adapter or runtime that is NOT part of the canonical surface. Adapter
+execution state SHALL be treated as adapter-private and SHALL NOT be relied upon
+by any consumer that targets the canonical surface. The membership of adapter
+execution state SHALL be derived by exclusion from the canonical surface —
+there is no normative exhaustive enumeration of adapter-private fields.
+
+#### Scenario: Exclusion rule classifies adapter-private state
+
+- **WHEN** a field exists in a concrete run-state representation
+- **AND** the field does not correspond to any of the nine canonical roles
+- **THEN** the field SHALL be classified as adapter execution state
+- **AND** it SHALL NOT be required of alternate runtimes
+
+#### Scenario: Informative examples do not constrain adapters
+
+- **WHEN** the specification lists informative examples of adapter execution
+  state (e.g., local filesystem path, git worktree path, cached summary path)
+- **THEN** the list SHALL be treated as informative only
+- **AND** it SHALL NOT be interpreted as an exhaustive or required set
+
+### Requirement: External runtimes depend only on the canonical surface
+
+Consumers targeting semantic portability SHALL depend only on the canonical
+surface and SHALL NOT require any field classified as adapter execution state.
+This applies to server-side runtimes, alternate UIs, and non-local adapters. A
+consumer that reads canonical fields SHALL be able to operate against any
+conforming runtime without adapter-specific knowledge.
+
+#### Scenario: Server or UI sees canonical fields only
+
+- **WHEN** a server-side runtime or an alternate UI reads run state through a
+  conforming transport
+- **THEN** it SHALL observe expressions of the nine canonical roles
+- **AND** it SHALL NOT require any adapter-private field to fulfill its
+  responsibilities
+
+#### Scenario: Absence of adapter-private state does not break canonical consumers
+
+- **WHEN** a conforming runtime omits all adapter-private state
+- **THEN** a canonical-surface consumer SHALL still operate correctly
+
+### Requirement: Local reference implementation may carry adapter-private state
+
+The local filesystem / git-backed reference implementation SHALL be permitted to
+carry adapter-private execution state alongside the canonical surface, provided
+that the adapter-private state does not alter the semantic value of any
+canonical role. The local reference implementation SHALL expose the canonical
+surface faithfully so that non-local consumers may read it without reference to
+adapter-private fields.
+
+#### Scenario: Local adapter persists both surfaces
+
+- **WHEN** the local reference implementation persists a run
+- **THEN** it MAY include adapter-private fields (e.g., project identity,
+  repository path, branch name, worktree path, cached summary path)
+- **AND** these fields SHALL NOT modify or contradict the canonical roles
+
+#### Scenario: Canonical extraction from the local shape is well-defined
+
+- **WHEN** a non-local consumer reads a run persisted by the local adapter
+- **THEN** it SHALL be able to extract the canonical surface unambiguously by
+  ignoring adapter-private fields
+- **AND** the extracted canonical surface SHALL convey all nine roles
+
+### Requirement: Canonical semantics is the contract authority for type-level partitions
+
+Any type-level partition of run state SHALL conform to the canonical semantics
+defined by this specification, including the existing `CoreRunState` /
+`LocalRunState` partition in `src/types/contracts.ts`. Where a partition exists,
+its canonical partition SHALL cover all nine canonical roles, and its adapter
+partition SHALL hold only state classifiable as adapter execution state. The
+type-level partition SHALL NOT be treated as the source of truth for canonical
+meaning; this specification SHALL be the source of truth, and the type-level
+partition SHALL be a representation conforming to it.
+
+#### Scenario: Existing partition conforms to canonical semantics
+
+- **WHEN** the `CoreRunState` / `LocalRunState` partition is evaluated against
+  the canonical semantics
+- **THEN** the canonical partition SHALL cover expressions of all nine
+  canonical roles
+- **AND** the adapter partition SHALL contain only adapter execution state
+
+#### Scenario: Discovered discrepancy triggers a follow-up change
+
+- **WHEN** a discrepancy is observed between the canonical semantics and an
+  existing type-level partition (a canonical role missing from the canonical
+  partition, or adapter-private state appearing in the canonical partition)
+- **THEN** the discrepancy SHALL be recorded
+- **AND** reconciliation SHALL be handled by a separate change, not by silently
+  altering either surface
+
+### Requirement: Non-goals of the canonical semantics specification
+
+The canonical workflow state specification SHALL NOT prescribe the following
+concerns, which are out of scope and left to subsequent capabilities:
+
+- database schema design for canonical state
+- interchange / serialization format (e.g., JSON schema, protobuf) for
+  canonical state
+- server, review transport, or event streaming implementations
+- stability guarantees, versioning policy, or breaking-change policy for the
+  canonical surface
+- field-level type definitions of `CoreRunState` / `LocalRunState`
+
+#### Scenario: Interchange format is out of scope
+
+- **WHEN** the canonical semantics specification is evaluated for applicability
+  to an interchange format question (e.g., "what JSON field name SHALL
+  represent current_phase?")
+- **THEN** the specification SHALL NOT answer the question
+- **AND** the question SHALL be deferred to a separate interchange-format
+  capability
+
+#### Scenario: Stability policy is out of scope
+
+- **WHEN** the canonical semantics specification is evaluated for applicability
+  to a stability or versioning question (e.g., "how SHALL a breaking change to
+  a canonical role be versioned?")
+- **THEN** the specification SHALL NOT answer the question
+- **AND** the question SHALL be deferred to a separate versioning-policy
+  capability
+

--- a/openspec/specs/workflow-run-state/spec.md
+++ b/openspec/specs/workflow-run-state/spec.md
@@ -865,3 +865,50 @@ typed error and the CLI SHALL map the error to a non-zero exit code.
   `unparseable_baseline` error
 - **AND** the CLI SHALL exit non-zero without transitioning the run
 
+### Requirement: Run-state type partition conforms to canonical workflow state semantics
+
+The `CoreRunState` and `LocalRunState` type partitions SHALL conform to the
+canonical workflow state semantics defined in
+`openspec/specs/canonical-workflow-state/spec.md`. This is a normative
+reference: the canonical semantics SHALL be the source of truth for which
+fields belong to the canonical surface, and the type-level partition SHALL be
+a representation conforming to it. This requirement SHALL NOT add, remove, or
+rename any field in `CoreRunState` or `LocalRunState`; the observable type
+shape remains governed by the existing requirements in this specification.
+
+#### Scenario: CoreRunState covers the canonical surface
+
+- **WHEN** the `CoreRunState` type is evaluated against the canonical
+  workflow state semantics
+- **THEN** every field in `CoreRunState` SHALL be classifiable as an
+  expression of one of the nine canonical roles defined in the
+  `canonical-workflow-state` capability
+- **AND** the nine canonical roles SHALL each be expressible via `CoreRunState`
+  fields (directly or in combination)
+
+#### Scenario: LocalRunState contains only adapter execution state
+
+- **WHEN** the `LocalRunState` type is evaluated against the canonical
+  workflow state semantics
+- **THEN** every field in `LocalRunState` SHALL be classifiable as adapter
+  execution state per the exclusion rule defined in the
+  `canonical-workflow-state` capability
+- **AND** no `LocalRunState` field SHALL be required of a non-local runtime
+
+#### Scenario: Field membership is not altered by this reference
+
+- **WHEN** this normative reference is added
+- **THEN** no field SHALL be added, removed, or renamed in `CoreRunState` or
+  `LocalRunState` as a consequence
+- **AND** all existing consumers importing `RunState`, `CoreRunState`, or
+  `LocalRunState` SHALL continue to compile without code change
+
+#### Scenario: Discrepancy is surfaced, not silently reconciled
+
+- **WHEN** a field in `CoreRunState` or `LocalRunState` cannot be cleanly
+  classified under the canonical semantics (e.g., a canonical role has no
+  corresponding field, or a field resists classification)
+- **THEN** the discrepancy SHALL be recorded
+- **AND** reconciliation SHALL be handled by a separate change, not by
+  silently editing the partition in this specification
+


### PR DESCRIPTION
## Summary

- Introduce `canonical-workflow-state` capability: nine semantic roles of a workflow instance (run identity, change identity, current phase, lifecycle status, allowed events, actor identity, source metadata, history, previous run linkage), runtime-agnostic.
- Define adapter execution state by exclusion from the canonical surface — no normative exhaustive list of adapter-private fields.
- Declare the canonical spec as source of truth, with type-level partitions (`CoreRunState` / `LocalRunState`) as conforming representations.
- Add an additive normative reference to `workflow-run-state` declaring conformance; no field is added, removed, or renamed.
- Explicitly defer interchange format, stability policy, DB schema, server/transport/streaming implementations.

## Issue

Closes https://github.com/skr19930617/specflow/issues/164