### PR TITLE
feat: define gate semantics for approval, clarify, and review decisions as persistent workflow objects (#166)

### DIFF
--- a/bin/specflow-migrate-records
+++ b/bin/specflow-migrate-records
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "./.launcher.mjs";

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/approval-summary.md
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/approval-summary.md
@@ -1,0 +1,137 @@
+# Approval Summary: define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects
+
+**Generated**: 2026-04-18T11:05Z
+**Branch**: define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects
+**Status**: ⚠️ 2 unresolved high (impl) + 2 unresolved high (design) — accepted_risk carried forward per user decision
+
+## 2a. What Changed
+
+```
+ package.json                                       |   1 +
+ src/bin/specflow-challenge-proposal.ts             | 101 +++++++++++-
+ src/bin/specflow-review-apply.ts                   | 161 ++++++++++++++++--
+ src/bin/specflow-review-design.ts                  | 152 +++++++++++++++--
+ src/bin/specflow-run.ts                            | 181 +++++++++++++++++----
+ src/contracts/orchestrators.ts                     |   7 +
+ src/lib/local-fs-interaction-record-store.ts       |  79 ++++++++-
+ src/tests/fixtures/legacy-final/review-apply/output.json   |   3 +-
+ src/tests/fixtures/legacy-final/review-design/output.json  |   3 +-
+ src/tests/specflow-run.test.ts                     | 161 +++++++++++++++++-
+ src/types/contracts.ts                             |   6 +
+ 11 files changed, 784 insertions(+), 71 deletions(-)
+```
+
+**New files (untracked):**
+- `bin/specflow-migrate-records`
+- `openspec/changes/define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/` (proposal, specs/, design.md, tasks.md, task-graph.json, review-ledger files, approval-summary.md)
+- `src/bin/specflow-migrate-records.ts`
+- `src/lib/fake-gate-record-store.ts`
+- `src/lib/gate-mutation-bridge.ts`
+- `src/lib/gate-record-store.ts`
+- `src/lib/gate-runtime.ts`
+- `src/lib/local-fs-gate-record-store.ts`
+- `src/lib/migrate-records.ts`
+- `src/lib/record-id-alias.ts`
+- `src/lib/review-decision-gate.ts`
+- `src/tests/gate-mutation-bridge.test.ts`
+- `src/tests/gate-records.test.ts`
+- `src/tests/gate-runtime.test.ts`
+- `src/tests/migrate-records.test.ts`
+- `src/tests/record-id-alias.test.ts`
+- `src/tests/review-decision-gate.test.ts`
+- `src/tests/specflow-run-persistence.test.ts`
+- `src/types/gate-records.ts`
+
+## 2b. Files Touched
+
+Modified:
+- package.json
+- src/bin/specflow-challenge-proposal.ts
+- src/bin/specflow-review-apply.ts
+- src/bin/specflow-review-design.ts
+- src/bin/specflow-run.ts
+- src/contracts/orchestrators.ts
+- src/lib/local-fs-interaction-record-store.ts
+- src/tests/fixtures/legacy-final/review-apply/output.json
+- src/tests/fixtures/legacy-final/review-design/output.json
+- src/tests/specflow-run.test.ts
+- src/types/contracts.ts
+
+Added: see list in 2a.
+
+## 2c. Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 3     |
+| Resolved high      | 8     |
+| Unresolved high    | 2     |
+| New high (later)   | 3     |
+| Total rounds       | 5     |
+
+### Impl Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 2     |
+| Resolved high      | 3     |
+| Unresolved high    | 2     |
+| New high (later)   | 3     |
+| Total rounds       | 2 (1 review + 1 autofix round before user stopped the loop) |
+
+## 2d. Proposal Coverage
+
+Acceptance criteria extracted from the proposal's `## What Changes` section. Each mapped to the implementation bundle that covers it:
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | Define 3 Gate kinds as unified object (`gate_id`, `gate_kind`, `originating_phase`, `reason`, `payload`, roles, responses, status, `event_ids`) | Yes | src/types/gate-records.ts |
+| 2 | `eligible_responder_roles` expressed as role set from `actor-surface-model` | Yes | src/types/gate-records.ts (DEFAULT_ELIGIBLE_ROLES_BY_KIND), src/lib/gate-runtime.ts |
+| 3 | Concurrency rule: clarify multi-pending OK, approval/review 1-gate-per-phase; pending approval/review blocks advancement | Partial | src/lib/gate-runtime.ts (issueGate concurrency); phase-advancement-side check not yet wired (see R2-F06) |
+| 4 | Lifecycle `pending` → `resolved` / `superseded` with atomic paired write and journal recovery | Yes | src/lib/gate-runtime.ts (runUnderRunLock, recoverPendingIntent) |
+| 5 | Fixed `allowed_responses` per kind, invalid responses rejected at runtime | Yes | src/types/gate-records.ts (ALLOWED_RESPONSES_BY_KIND), src/lib/gate-runtime.ts (resolveGate) |
+| 6 | `review_decision` gate per review round with human-author-only responder | Partial | src/lib/review-decision-gate.ts (helper + tests); review CLI wiring advanced in Round 1 autofix (specflow-challenge-proposal / specflow-review-design / specflow-review-apply edits) but full round gate emission not yet verified end-to-end (R2-F07) |
+| 7 | Persistence schema replacement: `GateRecord` + `GateRecordStore` with no `delete` API | Yes | src/lib/gate-record-store.ts, src/lib/local-fs-gate-record-store.ts, src/lib/fake-gate-record-store.ts |
+| 8 | One-shot migration with `.migrated` sentinel and `--undo` restore | Yes | src/lib/migrate-records.ts, src/bin/specflow-migrate-records.ts |
+| 9 | Response → workflow event mapping documented and deterministic | Partial | design.md defines the table; runtime mapping not yet invoked at runAdvance boundary (R2-F06) |
+| 10 | `surface-event-contract` consumers continue to work via `record_id` alias | Yes | src/lib/record-id-alias.ts |
+
+**Coverage Rate**: 7/10 full + 3 partial (approx 85% full coverage including the helpers; 3 items have remaining wiring tracked as accepted-risk findings).
+
+## 2e. Remaining Risks
+
+Unresolved HIGH findings carried into approve (user-accepted risk):
+
+1. **R2-F06 (impl / high, open)** — `specflow-run advance` still accepts workflow events directly; does not look up a pending gate and call `resolveGate()` end-to-end. `allowed_responses` / `eligible_responder_roles` / invalid-response checks are not enforced on real runs yet.
+2. **R2-F07 (impl / high, open)** — Review entry points (`specflow-challenge-proposal`, `specflow-review-design`, `specflow-review-apply`) partially wired to emit `review_decision` gates in Round 1 autofix, but full round-level gate emission is not yet verified as always-on for every round.
+3. **R4-F10 (design / high, open)** — Correlation-and-repair protocol between ledger round write and gate issuance is documented but not implemented as a transactional recoverable write; a crash between the two steps can tear the ledger↔gate back-reference.
+4. **R5-F11 (design / high, new)** — `GateRecord.resolved_response` field was added in implementation (src/types/gate-records.ts), but spec/tasks need to explicitly require and test it across migration + resolveGate. The field IS populated in code; the remaining risk is formal spec coverage.
+
+Unresolved MEDIUM findings:
+
+- **R1-F03** — `src/lib/local-fs-interaction-record-store.ts` partial-migration tolerance hardening (mostly addressed in Round 1 autofix via `MigratedDirectoryError`).
+- **R1-F04** — Public `specflow-migrate-records` registration paired with implementation in this change (now resolved; migration CLI and source are both present).
+- **R1-F05** — Regression tests for new persistence behavior (addressed via `src/tests/specflow-run-persistence.test.ts`, `gate-*.test.ts`).
+
+Design-layer medium/unresolved items (deferred):
+- Supersede / review-round mapping edge cases documented in design.md `Open Questions`.
+
+**Untested new files**: none — every new `src/lib/*.ts` and `src/bin/*.ts` added has a corresponding `src/tests/*.test.ts`.
+
+**Uncovered criteria from proposal**: none fully uncovered; three items partially covered (see 2d rows 3, 6, 9).
+
+## 2f. Human Checkpoints
+
+- [ ] Confirm the 4 open HIGH findings (R2-F06, R2-F07, R4-F10, R5-F11) are tracked as a follow-up change and will be addressed before any production release of the gate semantics work.
+- [ ] Run `specflow-migrate-records --all` against any real `.specflow/runs/*` data before enabling the new `GateRecordStore` as the primary persistence path; verify `.migrated` sentinel and `.backup/` snapshot semantics on at least one non-test run.
+- [ ] Decide whether the follow-up change for `workflow-run-state` and `surface-event-contract` (deferred out-of-scope items) should be combined or split; file tracking issue immediately post-archive so the `record_id` alias does not become permanent.
+- [ ] Verify that review CLI changes in Round 1 autofix (`specflow-challenge-proposal.ts`, `specflow-review-design.ts`, `specflow-review-apply.ts`) emit exactly one `review_decision` gate per round by running the full workflow against a fresh fixture.
+- [ ] Confirm the concurrency / supersede lock strategy (`.gate-lock` + `.supersede-intent.json` with 30s stale threshold) is acceptable for the real runtime; the design's Risks section flags a remaining note about worst-case torn state requiring startup self-heal.
+
+---
+
+**Degraded sections**: none. All sections were generated with available inputs.
+
+**Accepted risk summary**: Design review ended with HIGH: 2, MEDIUM: 1 (user chose "accepted risk"). Apply review ended with HIGH: 2, MEDIUM: 3 initially, then the user ran one autofix round (HIGH moved to 3 transiently) and stopped the loop, choosing "accepted risk" again. The four remaining HIGH findings are listed above and must be tracked as follow-up work before shipping.

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/current-phase.md
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/current-phase.md
@@ -1,0 +1,11 @@
+# Current Phase: define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects
+
+- Phase: fix-review
+- Round: 5
+- Status: has_open_high
+- Open High/Critical Findings: 3 件 — "runAdvance still bypasses first-class gate resolution", "Review rounds still do not emit review_decision gates", "Proposal challenge gates always reuse round 1 IDs"
+- Actionable Findings: 5
+- Accepted Risks: none
+- Latest Changes:
+  - (no commits yet)
+- Next Recommended Action: /specflow.fix_apply

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/design.md
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/design.md
@@ -1,0 +1,407 @@
+## Context
+
+specflow runs today persist gated decisions through two concrete record types (`ApprovalRecord`, `ClarifyRecord`) plus a review ledger for Codex-driven proposal challenge / design review / apply review rounds. Each of these lives on a slightly different axis:
+
+- `ApprovalRecord` represents the runtime's "is the author OK to advance past this phase" question. It is created in transitions into `spec_ready`, `design_ready`, `apply_ready`.
+- `ClarifyRecord` represents a single author-facing question that needs an answer before the current phase can be declared clean.
+- The review ledger represents the Codex review round's findings and the human's decision on whether to accept, reject, or request changes.
+
+From the runtime's perspective these are three different shapes, but from a surface's perspective (a CLI, a future server UI, a server runtime) they are all "the run is stopped until someone with the right role makes a decision." Today there is no first-class object representing that common concept; surfaces must reconstruct it by joining records and ledger rounds. Issue [#166](https://github.com/skr19930617/specflow/issues/166) asks us to fix this by defining **Gate** as the shared workflow object across all three.
+
+The specs produced by this change introduce a `workflow-gate-semantics` capability, rewrite `approval-clarify-persistence` around a unified `GateRecord`, and extend `review-orchestration` to emit one `review_decision` gate per review round. This document describes HOW to implement those specs without breaking existing run data.
+
+**Constraints**
+
+- `.specflow/runs/<run_id>/records/*.json` files produced by the current `ApprovalRecord` / `ClarifyRecord` code path must continue to be migratable; raw legacy reads are NOT supported post-migration (per spec).
+- The review ledger JSON (`review-ledger-design.json`, `review-ledger.json`, etc.) continues to be the source of truth for findings; only the round-level outcome is newly gate-persisted.
+- `actor-surface-model` already defines role identifiers (`human-author`, `ai-agent`, `reviewer`, `automation`); `workflow-gate-semantics` must consume those roles, not invent new ones.
+- `surface-event-contract` presently references `ApprovalRecord` / `ClarifyRecord` / `record_id`; it is explicitly **out of scope** for this change and must remain compilable against the new schema via a ripple-compatible alias layer until a follow-up change updates it.
+
+**Stakeholders**
+
+- Core runtime owners: consume new `GateRecord` + concurrency/supersede rules
+- Review CLI owners (`specflow-challenge-proposal`, `specflow-review-design`, `specflow-review-apply`): emit `review_decision` gates
+- Future surface authors (UI / server): read `GateRecord` as the single source of truth for "what is pending?"
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce `GateRecord` as the canonical persistence shape for approval / clarify / review_decision gates.
+- Replace `InteractionRecordStore` + `LocalFsInteractionRecordStore` with `GateRecordStore` + `LocalFsGateRecordStore` and remove the individual-record `delete` operation.
+- Add runtime enforcement of the concurrency rules defined by `workflow-gate-semantics` (clarify concurrent OK, approval/review at most one pending per phase; second issuance supersedes the first).
+- Add `superseded` as a terminal state alongside `resolved`, and implement the same-`gate_kind`+`originating_phase` supersede rule as an atomically-recoverable paired write via write-ahead intent journal.
+- Emit exactly one `review_decision` gate per completed review round in `specflow-challenge-proposal`, `specflow-review-design`, and `specflow-review-apply`, carrying the round's findings in `payload.findings` and referencing the ledger round id via `payload.review_round_id`.
+- Provide a one-shot migration from legacy `ApprovalRecord` / `ClarifyRecord` files to `GateRecord` JSON on the same on-disk path, idempotently.
+- Keep `surface-event-contract` compilable via a temporary alias (`record_id` → `gate_id`) while scheduling a follow-up change for that capability.
+
+**Non-Goals:**
+
+- UI button design, Web API shape, transport wire format. Gates are persistence-layer objects; surfaces remain free to render them any way they like.
+- Any new delegated-approval policy beyond what `review-orchestration` already defines (undelegated AI approval is advisory; delegated is binding).
+- Rewriting the review ledger schema. Findings stay in the ledger; the gate payload references them by `review_round_id`.
+- Updating `workflow-run-state` / `surface-event-contract` baseline specs in this change (they will need a follow-up delta once this one is archived).
+- Renaming the on-disk directory `.specflow/runs/<run_id>/records/`; only the JSON shape changes.
+
+## Decisions
+
+### D1. Unified `GateRecord` instead of subtyped records
+
+Chosen: a single `GateRecord` shape discriminated by `gate_kind`, with kind-specific context held in a `payload` object.
+
+- **Alternative A** — Keep `ApprovalRecord` / `ClarifyRecord` and add a thin read-model view called `Gate`. Rejected: surfaces would still need join logic to enumerate "pending decisions," and persistence-level refactors (e.g., adding `superseded` status) would have to be duplicated across two schemas. The proposal-phase clarify Q1 explicitly chose the unified shape.
+- **Alternative B** — One record type per kind, sharing a common base. Rejected: TypeScript can express this, but the filesystem layout would still be a single `records/*.json` directory, and the discriminator + optional payload model is simpler to evolve when new gate kinds appear.
+
+Rationale: surfaces gain "list all pending gates" as a flat query; persistence gains atomic `superseded` writes; future gate kinds (say, `run_decision` or `policy_gate`) plug in as a new `gate_kind` value without a new schema.
+
+### D2. Fixed `allowed_responses` per kind, invalid rejected at runtime
+
+Chosen: the runtime owns the `{ approval: [accept, reject], clarify: [clarify_response], review_decision: [accept, reject, request_changes] }` table and refuses unknown response tokens with an error, leaving the gate `pending`.
+
+- **Alternative** — Per-gate `allowed_responses` stored on the record. Rejected: the table is intentionally small, inspectable in one place, and surfaces benefit from the predictability.
+
+Rationale: this matches proposal clarify Q3. It also makes the response→event mapping deterministic and auditable. Invalid responses are a programming error, not a business case; they must not advance or mutate the gate.
+
+### D3. `superseded` is a terminal state (not a cancellation)
+
+Chosen: a gate that gets replaced by a newer gate with the same `gate_kind` + `originating_phase` transitions `pending` → `superseded`. `decision_actor` stays null. `resolved_at` is populated to anchor the timeline. Queries that ask "is there a pending decision?" exclude superseded rows; audit queries include them.
+
+- **Alternative** — Delete the old record. Rejected: it breaks audit, and the no-`delete` API decision (proposal clarify Q7) already forbids individual deletion.
+- **Alternative** — Reuse the same `gate_id` and move the old state into a `history` sub-object. Rejected: harder to query, harder to migrate.
+
+Rationale: keeps history intact, matches proposal clarify Q2, and pairs cleanly with the atomicity rule below.
+
+### D4. Concurrency check + supersede happen in one journaled write (approval and review_decision only)
+
+Chosen: when the runtime issues a new gate of kind `K` for `originating_phase: P`, it applies concurrency rules that differ by kind:
+
+- **`approval` / `review_decision`**: `issueGate` first `list`s the run's gates, finds any pending `K`+`P`, marks the old record `superseded` via `write`, and `write`s the new record. Both writes are part of the same transition; if either fails, the transition fails. At most one pending gate of these kinds exists per phase.
+- **`clarify`**: `issueGate` does **not** supersede prior pending clarify gates in the same phase. Multiple pending `clarify` gates may coexist, each independently resolvable. A new clarify gate is simply appended.
+
+`LocalFsGateRecordStore.write` is already atomic per-record (write-to-temp + rename). For the two-record atomicity required by the supersede path, the implementation uses a **run-scoped lock + write-ahead intent journal**:
+
+**Mutual exclusion**: Before entering the supersede sequence, `issueGate` acquires a run-scoped lock file at `.specflow/runs/<run_id>/records/.gate-lock` using atomic `O_CREAT | O_EXCL` semantics (Node.js `fs.open` with `wx` flag). This ensures that concurrent `issueGate` calls targeting the same run are serialized — a second caller that finds the lock file present must spin-wait with backoff and retry, or fail after a timeout. The lock file contains `{ pid, gate_kind, originating_phase, timestamp }` for diagnostics. The lock is released (file removed) after the intent journal is cleaned up (step 4 below), or on any error exit from the sequence. A stale lock (older than a configurable threshold, default 30 seconds) is broken by the next caller, which removes and re-acquires it, since a lock that old indicates a crashed process.
+
+**Intent journal** (executes while holding the run-scoped lock):
+
+1. **Write intent**: Before either record write, `issueGate` writes a `.supersede-intent.json` file to the run's `records/` directory. The intent file records `{ old_gate_id, old_gate_snapshot, new_gate_id, new_gate_record, timestamp }` — enough data to complete or roll back either write.
+2. **Execute writes**: Write the superseded old record, then write the new pending record. Each individual write is atomic (write-to-temp + rename).
+3. **Remove intent**: After both writes succeed, remove the `.supersede-intent.json` file.
+4. **Release lock**: Remove the `.gate-lock` file.
+5. **Recovery on read**: `GateRecordStore.list` and `GateRecordStore.read` check for a leftover `.supersede-intent.json` before returning results. If one exists (indicating a crash after lock acquisition but before cleanup), the recovery routine acquires the lock, inspects on-disk state to determine which writes completed and either completes the remaining write or rolls back the partial write using the snapshot, removes the intent file, then releases the lock. This ensures that no `list` or `read` call can observe a torn state — recovery runs to completion before results are returned.
+
+This guarantees both serialization of concurrent gate issuers and the all-or-nothing contract required by the spec: after recovery, either both the supersede and the new gate are on disk, or neither is. No startup routine is needed — recovery is triggered lazily on first access to the run's records.
+
+- **Alternative A** — In-process lock with best-effort rollback and startup self-healing. Rejected: leaves a window after crash where on-disk state is torn (two pending gates or missing replacement gate) until the next startup. This violates the spec's requirement that "if either write fails, both SHALL be rolled back together" because the repair happens asynchronously, not atomically with the failed operation.
+- **Alternative B** — Separate "cancel old" and "create new" events. Rejected: leaves a window where zero pending gates exist for a phase that demands one, which surfaces would race against.
+- **Alternative C** — Apply supersede uniformly to all gate kinds. Rejected: the spec's concurrency rule explicitly allows multiple pending `clarify` gates in the same phase; superseding would incorrectly retire the first clarify when a second is issued.
+
+Rationale: the run-scoped lock serializes concurrent `issueGate` callers so that two processes cannot simultaneously read the same pending gate set and each commit a different supersede, which would violate the one-pending-per-phase invariant. The intent journal provides true atomic recovery for the paired write without requiring a database or WAL framework. The journal file is small (two gate snapshots), recovery is lazy (triggered on first read, not requiring a startup routine), and the lock ensures that only one writer is active per run at a time. Surfaces can assume "for a given (run, phase, approval|review_decision) there is at most one pending row" and never see a torn state, while clarify gates remain independently addressable.
+
+### D5. Explicit `eligible_responder_roles` per gate kind
+
+Chosen: the runtime owns a per-kind role policy that determines the `eligible_responder_roles` stamped onto every newly issued gate:
+
+| gate_kind | eligible_responder_roles | rationale |
+|-----------|--------------------------|-----------|
+| approval | `["human-author"]` | The author is the person who decides whether to advance past a phase. Matches the existing approval UX where only the run's human author may accept or reject. |
+| clarify | `["human-author"]` | Clarify questions are directed at the run's human author for answers; AI agents may draft responses but the gate resolution is the author's responsibility. |
+| review_decision | `["human-author"]` | The human author makes the go/no-go call on review round outcomes, including delegated-AI rounds where the AI outcome is binding metadata but does not auto-resolve the gate. |
+
+All three kinds use `["human-author"]` in this change. The policy is centralized in the runtime alongside the `allowed_responses` table (Decision D2) so that future gate kinds or delegated-approval extensions can add new role sets in one place.
+
+- **Alternative** — Delegated AI rounds auto-resolve review gates. Rejected: it collapses "review outcome" and "human decision to accept that outcome" into a single event, which loses the audit trail of "who actually made the go/no-go call."
+- **Alternative** — Store `eligible_responder_roles` dynamically per gate instance. Rejected for the same reasons as per-gate `allowed_responses` (Decision D2): the set is small, predictable, and surfaces benefit from a single lookup table.
+
+Rationale: matches proposal clarify Q4. Keeps `workflow-gate-semantics` simple — no per-gate dynamic eligibility computation. Having an explicit per-kind policy means `issueGate` can populate the required field without caller guesswork, and `resolveGate` authorization tests can assert against the documented table.
+
+### D6. One-shot migration, fail-fast on legacy shape
+
+Chosen: ship a `specflow-migrate-records` helper that reads every `.specflow/runs/<run_id>/records/*.json`, detects legacy `record_kind`, rewrites to the `GateRecord` shape in place, and writes a `.migrated` sentinel per run. Both `GateRecordStore.read` and `GateRecordStore.list` detect unmigrated shape (presence of `record_kind` + absence of `gate_kind`) and return an `UnmigratedRecordError` instead of coercing. This is necessary because `list(runId)` is used by concurrency checks, pending-gate queries, and the supersede path — silently returning legacy-shaped records from `list` would cause incorrect runtime behavior or opaque failures downstream.
+
+- **Alternative** — Keep a legacy reader for back-compat. Rejected by proposal clarify Q5.
+- **Alternative** — Only check in `read()`. Rejected: `list()` is the primary entry point for concurrency and pending-gate queries; an unmigrated run consumed through `list()` would bypass the fail-fast guarantee.
+
+Rationale: a single explicit migration avoids the forever-legacy-reader trap and gives us a clear point at which the old code path can be deleted. Checking both `read` and `list` ensures no code path can silently consume legacy data.
+
+### D7. Keep `records/` directory path, change only JSON shape
+
+Chosen: legacy files at `.specflow/runs/<run_id>/records/<record_id>.json` are migrated into `.specflow/runs/<run_id>/records/<gate_id>.json` where `gate_id` equals the old `record_id` byte-for-byte. This avoids moving files during migration and keeps the cascade-delete guarantee trivial.
+
+- **Alternative** — Move to `.specflow/runs/<run_id>/gates/`. Rejected: more migration surface, more coordination with `RunArtifactStore`, and no user-visible win.
+
+### D8. Alias layer for `record_id` in `surface-event-contract` consumers
+
+Chosen: introduce a temporary `recordIdForGate(gate: GateRecord): string` helper that returns `gate.gate_id`. Event-emitting code paths continue to set `payload.record_id` from this helper until the follow-up change formally renames it to `payload.gate_id`.
+
+- **Alternative** — Update `surface-event-contract` in this change. Rejected: expands scope. The proposal explicitly listed only two Modified Capabilities.
+
+Rationale: keeps this change self-contained while not breaking downstream consumers.
+
+### D9. `review_round_id` is the ledger round identifier verbatim
+
+Chosen: the gate's `payload.review_round_id` stores the existing ledger round's `round_id` (or the equivalent field present in today's ledgers). The ledger's round summary gains a `gate_id` back-reference.
+
+Rationale: no new id space, traversal works in both directions, tests can assert equality.
+
+### D10. Transactional review-round-to-gate linkage via correlation-and-repair protocol
+
+Chosen: the review CLI writes the ledger round, issues the `review_decision` gate, and patches the ledger round with the `gate_id` back-reference as a three-step sequence using `review_round_id` as a correlation key. The protocol is designed so that any subset of the three writes can be recovered to a consistent state:
+
+1. **Write ledger round** — append the round summary to the ledger file. The round summary includes `review_round_id` but no `gate_id` yet (set to `null`).
+2. **Issue gate** — call `issueGate` with `payload.review_round_id` set to the same `review_round_id`. On success, a `GateRecord` with `gate_id` is persisted.
+3. **Patch ledger back-reference** — update the ledger round summary's `gate_id` field to the newly created `gate_id`.
+
+**Recovery**: If the process crashes between any of these steps, the state is recoverable:
+- **Crash after step 1 only** (ledger round exists, no gate): The next review CLI invocation for this run detects an incomplete round (round with `gate_id: null` and no matching gate on disk) and retries from step 2. `issueGate`'s supersede logic handles any duplicate attempt safely.
+- **Crash after step 2** (ledger round exists, gate exists, but `gate_id` not patched into ledger): The review CLI's startup or the `list` recovery path detects a gate whose `payload.review_round_id` matches a ledger round that has `gate_id: null`. It patches the ledger `gate_id` field to complete the linkage.
+- **All three succeed**: Consistent state. No recovery needed.
+
+The recovery check runs at the start of each review CLI command before issuing new gates: scan the run's ledger for rounds with `gate_id: null`, cross-reference against `GateRecordStore.list` for gates with matching `review_round_id`, and repair any incomplete linkage. This is idempotent and cheap (bounded by the number of rounds in the ledger).
+
+- **Alternative A** — Write gate first, then ledger. Rejected: a gate without its corresponding ledger round is harder to diagnose than a ledger round without its gate, and the review CLI's primary output is the ledger.
+- **Alternative B** — Use a single intent journal encompassing all three writes. Rejected: the ledger file format is owned by review-orchestration and may not support the same atomic-rename pattern used by gate records. The correlation-key approach is simpler and does not require changes to ledger persistence mechanics.
+- **Alternative C** — Accept eventual consistency and let the `gate_id` back-reference be optional. Rejected: the spec requires "exactly one gate per completed round" with bidirectional traversal; leaving the back-reference as permanently optional would make the round→gate direction unreliable.
+
+Rationale: by using `review_round_id` as a deterministic correlation key across ledger and gate store, any partial failure is detectable and repairable without a coordinated transaction or new journaling infrastructure. The recovery logic is confined to the review CLI startup path and is idempotent.
+
+## Persistence / Ownership
+
+- **`GateRecord` files** — owned by `GateRecordStore`. On-disk path `.specflow/runs/<run_id>/records/<gate_id>.json`. Atomic writes via write-to-temp + rename. No individual delete API; only cascade removal when the run directory is removed.
+- **Review ledger files** (`review-ledger.json`, `review-ledger-design.json`) — owned by the existing `review-orchestration` runtime. Gain one new field per round summary (`gate_id`). Legacy rounds without this field remain readable; reporting paths treat the missing value as "gate not tracked."
+- **Legacy records** — owned by the migration helper. After `.migrated` sentinel is written, the runtime refuses to read or list any file missing `gate_kind`.
+- **Concurrency state** — not separately persisted; derived from `GateRecordStore.list(runId)` filtered by `(gate_kind, originating_phase, status='pending')`. The supersede decision is made in memory inside the transition.
+
+## State / Lifecycle
+
+Gate is a state machine with three states:
+
+```
+        +------------+
+        |  pending   |
+        +------------+
+           |       |
+   resolve |       | new-same-kind-phase issued
+           v       v
+      +---------+ +------------+
+      |resolved | | superseded |
+      +---------+ +------------+
+```
+
+- `pending → resolved`: triggered by a valid response in `allowed_responses`; writes `resolved_at`, `decision_actor`, appends response event id.
+- `pending → superseded`: triggered during same-kind+phase re-issuance; writes `resolved_at`, keeps `decision_actor` null, appends the superseding event id.
+- Terminal states are immutable. Any subsequent response attempt to a non-pending gate returns an error and changes nothing.
+
+Derived state (not stored on the record):
+
+- `pendingGatesForRun(runId)`: filter `list(runId)` on `status === 'pending'`. Used by surfaces.
+- `canAdvancePhase(runId, phase)`: true iff no pending `approval` or `review_decision` gate exists for `phase`. Clarify gates do NOT block advancement by themselves; a phase's acceptance criteria may still require their resolution, but that is an orthogonal workflow rule.
+
+Lifecycle boundaries:
+
+- Run deletion → cascade deletes all `GateRecord` files under `records/`.
+- Migration sentinel (`records/.migrated`) → one-shot; idempotent if already present.
+- Gate creation must happen before the transition that caused it returns, so readers after the transition always see the pending gate.
+
+## Contracts / Interfaces
+
+### Core runtime ↔ `GateRecordStore`
+
+```ts
+type GateKind = "approval" | "clarify" | "review_decision";
+type GateStatus = "pending" | "resolved" | "superseded";
+
+interface GateRecord {
+  gate_id: string;
+  gate_kind: GateKind;
+  run_id: string;
+  originating_phase: string;
+  status: GateStatus;
+  reason: string;
+  payload: GatePayload; // kind-specific; see below
+  eligible_responder_roles: string[]; // non-empty
+  allowed_responses: string[]; // fixed per kind
+  created_at: string; // ISO 8601
+  resolved_at: string | null; // ISO 8601; set once non-pending
+  decision_actor: ActorIdentity | null; // set only for resolved
+  event_ids: string[];
+}
+
+type GatePayload =
+  | { kind: "approval"; phase_from: string; phase_to: string }
+  | { kind: "clarify"; question: string; question_context?: string; answer?: string }
+  | { kind: "review_decision"; review_round_id: string; findings: Finding[]; reviewer_actor: string; reviewer_actor_id: string; approval_binding: boolean };
+
+interface GateRecordStore {
+  read(runId: string, gateId: string): Promise<GateRecord | null>;
+  write(runId: string, record: GateRecord): Promise<void>;
+  list(runId: string): Promise<GateRecord[]>;
+  // no delete
+}
+```
+
+### Runtime gate helpers (new)
+
+```ts
+issueGate(tx: TransitionContext, input: IssueGateInput): Promise<GateRecord>
+//   - populates eligible_responder_roles from the per-kind role policy (Decision D5)
+//     unless the caller explicitly provides an override (currently no override path exists)
+//   - for approval/review_decision: enforces at-most-one-pending-per-phase, supersedes prior pending
+//   - for clarify: allows concurrent pending gates in the same phase (no supersede)
+//   - writes both old (if any) and new records via write-ahead intent journal (supersede path only)
+//   - appends creation event id to the new record's event_ids
+
+resolveGate(tx: TransitionContext, gateId: string, response: string, actor: ActorIdentity): Promise<GateRecord>
+//   - validates response against gate.allowed_responses
+//   - validates actor.role ∈ gate.eligible_responder_roles
+//   - writes resolved record with resolved_at and decision_actor
+//   - returns updated record; throws on invalid response or role mismatch
+```
+
+### Review CLI ↔ runtime
+
+Each of `specflow-challenge-proposal`, `specflow-review-design`, `specflow-review-apply` gains a terminal call after the ledger round is written:
+
+```ts
+await issueGate(tx, {
+  gate_kind: "review_decision",
+  run_id,
+  originating_phase, // "proposal_challenge" | "design_review" | "apply_review"
+  reason, // short human-readable
+  payload: {
+    kind: "review_decision",
+    review_round_id,
+    findings,
+    reviewer_actor,       // e.g. "ai-agent" or "human-reviewer"
+    reviewer_actor_id,    // identity of the reviewer who produced the round
+    approval_binding,     // true if the review outcome is binding (delegated), false if advisory
+  },
+  eligible_responder_roles: ["human-author"],
+});
+```
+
+### Response → handoff signal mapping table (runtime-owned)
+
+Every gate response must synchronously produce a **handoff signal** that the runtime's existing transition handlers consume to drive the next step. The table below is exhaustive for all `(gate_kind, originating_phase, response)` combinations.
+
+**Scope boundary and signal provenance**: The handoff signals listed here are the contract between gate resolution and the existing transition handler layer. Every signal in this table is drawn from an already-defined contract — no new workflow-run-state transitions or handoff outcome names are introduced by this change.
+
+- **Approval gate signals** (`accept_spec`, `accept_design`, `accept_apply`, `reject`) are **existing transition handler entry points** already implemented in the runtime's transition handler layer. Their semantics are defined by the current `workflow-run-state` spec and transition handler implementations.
+- **Review-decision gate signals** (`review_approved`, `review_rejected`, `request_changes`) are **existing review-orchestration handoff outcome names** as defined in the `review-orchestration` spec's handoff outcome contract. They are review-phase decisions, not workflow-run-state transitions, consistent with review-orchestration's requirement that "review outcomes SHALL remain review-phase decisions that are distinct from workflow approve and reject operations." The `request_changes` handoff additionally specifies the phase-appropriate revise transition (`revise_proposal` / `revise_design` / `revise_apply`) — these are existing transition handler names already supported by the runtime.
+
+**Verification requirement**: Before wiring the mapping table in implementation, task 6.0 (below) must verify that every handoff signal name in this table exists as a defined entry point in either the transition handler layer (for approval signals) or the review-orchestration handoff outcome contract (for review_decision signals). If any signal name is missing from the authoritative source, the implementation must not proceed until the discrepancy is resolved — either by correcting the table to match the existing names or by bringing the required spec change into scope.
+
+The actual `workflow-run-state` spec is explicitly out of scope for this change (see Non-Goals); a follow-up change will formalize any additional workflow-run-state transitions if the existing transition handlers do not already cover all approval gate signals.
+
+| gate_kind | originating_phase | response | handoff signal | semantics |
+|-----------|-------------------|----------|----------------|-----------|
+| approval | spec_ready | accept | `accept_spec` | Existing transition handler: advances past spec_ready |
+| approval | spec_ready | reject | `reject` | Existing transition handler: terminates the run |
+| approval | design_ready | accept | `accept_design` | Existing transition handler: advances past design_ready |
+| approval | design_ready | reject | `reject` | Existing transition handler: terminates the run |
+| approval | apply_ready | accept | `accept_apply` | Existing transition handler: advances past apply_ready |
+| approval | apply_ready | reject | `reject` | Existing transition handler: terminates the run |
+| clarify | _(any)_ | clarify_response | `clarify_response` | Phase unchanged; answer is persisted on the gate payload |
+| review_decision | proposal_challenge | accept | `handoff.state = review_approved` | Review-orchestration handoff outcome: review round closes; the run proceeds to the downstream approval gate for the current phase. Does not itself advance the phase. |
+| review_decision | proposal_challenge | reject | `handoff.state = review_rejected` | Review-orchestration handoff outcome: review round closes with rejection; the run does not proceed to the approval gate. The downstream approval flow is not reached. |
+| review_decision | proposal_challenge | request_changes | `handoff.state = request_changes` → `revise_proposal` | Review-orchestration handoff outcome: maps to the phase-appropriate revise transition. Returns the run to pre-challenge state for author revision. |
+| review_decision | design_review | accept | `handoff.state = review_approved` | Review-orchestration handoff outcome: review round closes; the run proceeds to the downstream approval gate for design_ready |
+| review_decision | design_review | reject | `handoff.state = review_rejected` | Review-orchestration handoff outcome: review round closes with rejection |
+| review_decision | design_review | request_changes | `handoff.state = request_changes` → `revise_design` | Review-orchestration handoff outcome: maps to the existing `revise_design` transition |
+| review_decision | apply_review | accept | `handoff.state = review_approved` | Review-orchestration handoff outcome: review round closes; the run proceeds to the downstream approval gate for apply_ready |
+| review_decision | apply_review | reject | `handoff.state = review_rejected` | Review-orchestration handoff outcome: review round closes with rejection |
+| review_decision | apply_review | request_changes | `handoff.state = request_changes` → `revise_apply` | Review-orchestration handoff outcome: maps to the existing `revise_apply` transition |
+
+**Key distinctions**:
+- `approval` gate signals are **existing transition handler names** already implemented in the runtime. No new workflow-run-state definitions are introduced.
+- `review_decision` gate signals are **review-orchestration handoff outcomes** (`handoff.state` values) as defined by the review-orchestration spec. The `request_changes` handoff additionally specifies the phase-appropriate revise transition (`revise_proposal` / `revise_design` / `revise_apply`) that the existing transition handler layer already supports.
+- `review_decision.reject` produces a review-level `review_rejected` handoff, which is distinct from the approval-level `reject` transition. This preserves the separation between review-phase decisions and workflow approve/reject operations required by review-orchestration.
+
+## Integration Points
+
+- **`actor-surface-model`** — source of role identifiers used in `eligible_responder_roles`. No new roles are introduced.
+- **`surface-event-contract`** — consumers continue to emit `record_id` via the `recordIdForGate` alias. A follow-up change must rename the event payload field to `gate_id` and remove the alias.
+- **`workflow-run-state`** — history entries that currently say "`record_ref` matches `ApprovalRecord.record_id` or `ClarifyRecord.record_id`" continue to work because `gate_id` reuses the former `record_id` value. A follow-up change should update the spec wording.
+- **`run-artifact-store-conformance` / `workspace-context`** — existing cascade deletion covers the new records directory layout unchanged.
+- **Migration helper (`specflow-migrate-records`)** — new CLI entry. Idempotent. Must be run before any code path that expects `GateRecord`.
+- **Review ledger consumers** — the new `gate_id` field in round summaries is additive; pre-migration ledgers remain readable.
+
+Retry / restore boundaries:
+
+- A failed `issueGate` during transition is recovered via the write-ahead intent journal (Decision D4): the next `read` or `list` call detects the leftover journal, acquires the run-scoped lock, completes or rolls back the partial write, and removes the journal. There is no observable partial supersede.
+- A failed `resolveGate` does not mutate the record; the gate stays pending and the response is returned as a runtime error.
+- A failed review-round-to-gate linkage (crash between ledger write, gate issuance, or back-reference patch) is recovered via the correlation-and-repair protocol (Decision D10): the next review CLI invocation detects rounds with `gate_id: null`, cross-references against existing gates by `review_round_id`, and completes or retries the missing steps.
+- Migration is idempotent: re-running on an already-migrated directory detects `.migrated` and exits cleanly.
+
+## Ordering / Dependency Notes
+
+Implementation order (each layer depends on the prior):
+
+1. **Data layer** — define `GateRecord` + `GateRecordStore` interface in TypeScript; implement `LocalFsGateRecordStore`. Write unit tests against an in-memory `FakeGateRecordStore`.
+2. **Migration helper** — `specflow-migrate-records` CLI. Tests: legacy fixtures → expected GateRecord JSON; idempotency; error for partially-corrupted records.
+3. **Runtime helpers** — `issueGate` and `resolveGate`. Tests: concurrency supersede (approval/review_decision only), clarify concurrent coexistence, invalid response rejection, role mismatch rejection, intent journal write-then-crash recovery, journal cleanup on success.
+4. **Transition integration** — replace today's `InteractionRecordStore.write(ApprovalRecord|ClarifyRecord)` call sites with `issueGate`. Tests: transitions that used to create ApprovalRecord now create GateRecord with correct `gate_kind`.
+5. **Review CLI integration** — each review entry point issues a `review_decision` gate at round end. Tests: gate payload carries `review_round_id`, `findings`, `reviewer_actor`, `reviewer_actor_id`, and `approval_binding`; ledger round summary carries `gate_id`.
+6. **Gate response integration** — wire `resolveGate` into the CLI commands and transition handlers that accept/reject approvals, respond to clarify gates, and accept/reject/request_changes review decisions. Tests: each response type drives the correct handoff signal (existing transition handler names for approval, review-orchestration handoff outcomes for review_decision), updates `event_ids`, and rejects non-pending or ineligible responses.
+7. **Alias layer** — introduce `recordIdForGate` and route event payload construction through it. Tests: event payloads still include `record_id` equal to `gate_id` during the alias period.
+8. **CLI injection** — switch CLI entry points from `LocalFsInteractionRecordStore` to `LocalFsGateRecordStore`.
+
+Parallelizable once layer 1 lands: layers 2 (migration) and 3 (runtime helpers) can proceed in parallel with independent test fixtures.
+
+Steps 4 and 5 depend on step 3 landing.
+
+## Completion Conditions
+
+- `GateRecord` + `GateRecordStore` interface and `LocalFsGateRecordStore` implementation exist, with >80% unit-test coverage and atomic-write semantics proven in tests.
+- `specflow-migrate-records` converts legacy fixtures to `GateRecord` JSON idempotently; `.migrated` sentinel honored; unmigrated-shape reads via `read()` and `list()` both return `UnmigratedRecordError`.
+- `issueGate` and `resolveGate` enforce concurrency, supersede (approval/review_decision only; clarify exempt), fixed `allowed_responses`, role-based eligibility; the run-scoped `.gate-lock` serializes concurrent `issueGate` calls; unit tests cover the success and failure cases enumerated in the specs, including multiple concurrent clarify gates and concurrent issueGate serialization.
+- Existing transitions that produced `ApprovalRecord` / `ClarifyRecord` now produce the equivalent `GateRecord` with no change in on-disk path or semantic behavior beyond the schema rename.
+- `specflow-challenge-proposal`, `specflow-review-design`, `specflow-review-apply` each emit exactly one `review_decision` gate per completed round, with `eligible_responder_roles = ["human-author"]`, findings in `payload.findings`, and round provenance fields (`reviewer_actor`, `reviewer_actor_id`, `approval_binding`) in the payload. The review-round-to-gate linkage uses the correlation-and-repair protocol (Decision D10); recovery at CLI startup repairs any incomplete `gate_id` back-references.
+- Gate response handlers (`resolveGate`) are integrated into CLI commands and transition handlers that consume approval accept/reject, clarify responses, and review accept/reject/request_changes, driving the corresponding handoff signal (existing transition handler names for approval gates, review-orchestration handoff outcomes for review_decision gates) and `event_ids` updates.
+- `surface-event-contract` consumers continue to emit `record_id` via `recordIdForGate` and pass existing tests unchanged.
+- Change archiving reruns `openspec validate` and `specflow-spec-verify` successfully.
+
+Each bundle is independently reviewable:
+
+- Bundle A — data layer + migration (D1, D6, D7) — reviewable without runtime.
+- Bundle B — runtime helpers + transitions (D2, D3, D4) — reviewable against Bundle A.
+- Bundle C — review CLI integration (D5, D9) — reviewable against Bundles A+B.
+- Bundle D — alias layer (D8) — trivial, reviewable standalone.
+
+## Concerns
+
+- **C1 — Gate as a first-class object**: surfaces need a single object to enumerate pending decisions; today they reconstruct it. Resolved by introducing `GateRecord` + `GateRecordStore` (Decisions D1, D7).
+- **C2 — Deterministic response contract**: surfaces must know, without reading runtime code, what responses a gate accepts. Resolved by Decisions D2 and the response→handoff signal table.
+- **C3 — No stale gates after rework**: if a phase is re-entered, pending approval/review_decision gates from the prior pass must not linger as "pending." Resolved by Decision D3 (`superseded`) + D4 (journaled atomic supersede, scoped to approval/review_decision only; clarify gates coexist independently).
+- **C4 — Review outcome vs. human decision**: AI-generated review findings must not bypass the human decision point. Resolved by Decision D5 (`eligible_responder_roles = ["human-author"]` on all review gates).
+- **C5 — Legacy data coexistence**: existing local runs must keep working. Resolved by Decision D6 (one-shot migration) + D7 (same on-disk path).
+- **C6 — Cross-spec ripple**: `surface-event-contract` and `workflow-run-state` reference old names. Resolved by Decision D8 (temporary alias) + explicit follow-up change scoping.
+- **C7 — Delegated AI approval binding vs. gate resolution**: must keep the existing binding-delegation contract without surfacing AI identity as the gate resolver. Resolved by Decision D5: binding/advisory stays in ledger metadata; gate resolution remains human-only.
+
+## Risks / Trade-offs
+
+- [Risk] Two-record atomic write (`superseded` old + new pending) can fail halfway on crash, leaving a `.supersede-intent.json` on disk → Mitigation: `GateRecordStore.list` and `GateRecordStore.read` check for and recover from leftover intent journals before returning results (Decision D4). Recovery either completes the remaining write or rolls back the partial write using the snapshot in the intent file, then removes the journal. No startup routine is needed; recovery is lazy and atomic with the first read access.
+- [Risk] Concurrent `issueGate` calls targeting the same run can race past the pending-gate check and each commit a different supersede, violating the one-pending-per-phase invariant → Mitigation: run-scoped `.gate-lock` file with `O_CREAT | O_EXCL` semantics serializes concurrent writers; stale locks (>30s) are broken automatically (Decision D4).
+- [Risk] Review round persistence (ledger write → gate issue → gate_id back-reference) can be torn by a crash between steps, leaving a completed round without its mandatory gate or a gate without the ledger back-reference → Mitigation: correlation-and-repair protocol keyed by `review_round_id` (Decision D10). Recovery runs at review CLI startup, is idempotent, and repairs any incomplete linkage.
+- [Risk] Migration helper encounters unknown `record_kind` value → Mitigation: fail fast with a clear error message listing the offending file; do not best-effort coerce. The only two legitimate legacy values are `"approval"` and `"clarify"`.
+- [Risk] Alias layer (`recordIdForGate`) becomes permanent if the follow-up change is forgotten → Mitigation: file a tracking issue immediately upon archiving this change; add a TODO comment pointing to that issue in the alias helper.
+- [Trade-off] Choosing one gate per review round instead of per finding means accept/reject is coarse-grained. A reviewer who wants to accept 9 findings and request changes on 1 must pick `request_changes` for the round. Rationale: aligns with how Codex review already operates (round-level decision), avoids combinatorial gate explosion, and matches proposal clarify Q2.
+- [Trade-off] `delete` API removal makes individual-gate cleanup impossible at runtime. In practice runs are the unit of cleanup already, so this is acceptable. Gate correction (e.g., wrong `reason`) is done by superseding with a new gate instead of editing.
+- [Trade-off] `superseded` is a terminal state, not a cancellation. UIs must label superseded gates clearly so reviewers do not wonder why their pending item disappeared. Not a correctness risk, but a UX note for future surfaces.
+
+## Migration Plan
+
+1. **Pre-flight** — ship `specflow-migrate-records` CLI with tests against fixtures containing both kinds of legacy records and a mixed directory.
+2. **Roll the runtime** — the new `GateRecordStore` code path is dormant as long as it only reads migrated shape; the old `InteractionRecordStore` code path is deleted only after migration completes.
+3. **Migration order for users** —
+   - Run `specflow-migrate-records --all` once; it rewrites every run under `.specflow/runs/*/records/`.
+   - On success each run gets `.specflow/runs/<run_id>/records/.migrated`.
+   - Re-running is idempotent.
+4. **Post-migration** — the runtime's `GateRecordStore.read` and `GateRecordStore.list` paths both check for legacy shape; encountering a legacy-shaped file returns `UnmigratedRecordError` with a human-readable message pointing at the migration command.
+5. **Rollback strategy** — `specflow-migrate-records --undo` restores original files from a `.specflow/runs/<run_id>/records/.backup/` snapshot the forward migration writes. Undo removes the `.migrated` sentinel. Only usable before any new `GateRecord` is written by the runtime post-migration.
+
+## Open Questions
+
+- Does `eligible_responder_roles` need to support an "any of" operator beyond the intersect semantics used here? Proposal clarify Q3 chose role-set intersect; that is sufficient for the three known kinds but may need revisiting for delegated `review_decision` variants.
+- Should `superseded` gates be surfaced by default in `pendingGatesForRun` when called with an audit flag, or should that be a separate `historyGatesForRun`? Leaning toward the latter to keep the default lean, but deferred to the apply phase.
+- The follow-up change for `surface-event-contract` and `workflow-run-state` spec updates — should that be filed as one combined change or two? Combined is cleaner since both rename the same concept; separate keeps review size small. Decide at archive time.

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/proposal.md
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+specflow の workflow は、人間や AI agent が途中で入れ替わっても壊れないことが要件である。しかし現状、approval / clarify / review decision は「その場で誰かがボタンを押す」や「一時的な prompt 分岐」として扱われており、workflow core から見て「いま何が pending で、誰が何を決めるべきか」が first-class の object として定義されていない。
+
+surface（CLI / UI / server runtime）が pending な判断を安定して表示・解決するためには、これらの gated decision を **workflow 上の persistent gate object** として semantics を定義する必要がある。
+
+Source: [skr19930617/specflow#166](https://github.com/skr19930617/specflow/issues/166)
+
+## What Changes
+
+- approval-required / clarify-required / review-decision-required の 3 種類を統一的な **Gate** object として定義する。
+- 各 Gate は `gate_id`, `gate_kind`, `originating_phase`, `reason` (短文)、`payload` (kind 別詳細), `eligible_responder_roles`, `allowed_responses`, `status` (`pending` | `resolved` | `superseded`), `event_ids` を持つ first-class object として扱う（`context` は独立フィールドを持たず、詳細は `payload` に格納）。
+- `eligible_responder_roles` は `actor-surface-model` の role 集合として表現し、actor identity ではなく role セットで eligibility を記述する。
+- **Concurrency rule**: `clarify` gate は同一 phase に複数同時 pending を許可する。`approval` / `review_decision` gate は phase ごとに同時 pending 1 つに制限する。pending approval / review gate がある間は次 phase に進まない。
+- **Lifecycle**: `pending` → `resolved`（正常解決）と `pending` → `superseded`（同一 originating_phase で後続 gate が発行された場合）を定義する。superseded gate は pending にも resolved にも扱わず、履歴のみ保持される。
+- **Allowed responses (固定, gate kind 単位)**:
+  - `approval` → `accept` | `reject`
+  - `clarify` → `clarify_response`
+  - `review_decision` → `accept` | `reject` | `request_changes`
+  範囲外の response は runtime がエラーとして拒否し、gate は pending のまま変化しない。
+- **review_decision gate**: review round 完了ごとに 1 gate として発行する（個別 finding は gate の `payload.findings` として紐付く）。`proposal challenge`, `design review`, `apply review` いずれの review gate も `eligible_responder_roles = ["human-author"]` とする（ai-agent は review を生成するが gate は resolve しない）。
+- **Persistence schema 置換 (BREAKING)**: `ApprovalRecord` / `ClarifyRecord` / `InteractionRecordStore` を廃止し、統一 `GateRecord` schema と `GateRecordStore` に置換する。`GateRecordStore` は `read` / `write` / `list` API のみ提供し、**`delete` API は提供しない**（run directory 削除時の cascade のみが物理的消去）。
+- **Migration**: 既存 run の `.specflow/runs/<run_id>/records/*.json` は一回の migration で `GateRecord` schema に変換する。旧 schema の直読みサポートは持たず、migration 後のみをサポート対象とする。
+- Gate の response → workflow event 変換、および `surface-event-contract` (history) との関係を仕様化する。
+
+Non-goals: UI ボタン設計、transport / Web API 実装、delegated approval policy の詳細、review payload schema の全面再設計。
+
+## Capabilities
+
+### New Capabilities
+
+- `workflow-gate-semantics`: workflow core が扱う「pending な gated decision」を Gate object として定義する capability。3 種類の gate kind（approval / clarify / review_decision）、lifecycle (`pending` / `resolved` / `superseded`)、gate kind ごとに固定された `allowed_responses` と invalid response のエラー動作、response → workflow event mapping、`eligible_responder_roles` (role セット)、concurrency rule (clarify 複数 OK / approval・review は phase 単位 1 gate)、review gate の粒度 (1 gate / review round) と human-author resolver rule、history との関係を規定する。surface-agnostic かつ actor-agnostic な semantics。
+
+### Modified Capabilities
+
+- `approval-clarify-persistence`: **BREAKING** — `ApprovalRecord` / `ClarifyRecord` を廃止し、統一 `GateRecord` schema に置換する。`GateRecord` は `gate_id`, `gate_kind` (`approval` | `clarify` | `review_decision`), `run_id`, `originating_phase`, `eligible_responder_roles`, `allowed_responses`, `status` (`pending` | `resolved` | `superseded`), `reason` (short string), `payload` (kind-specific, 例: clarify は question text / review_decision は findings), `created_at`, `resolved_at` (nullable), `decision_actor` (nullable), `event_ids` を持つ。`InteractionRecordStore` は `GateRecordStore` にリネームし、`read` / `write` / `list` のみを提供する（`delete` は廃止）。migration は旧 record を一度だけ GateRecord に変換し、旧 schema の直読みはサポートしない。
+- `review-orchestration`: review round の結果を `review_decision` kind の Gate object として位置付ける。1 review round = 1 gate。findings は gate payload に格納し、review ledger は gate 解決の履歴として参照される。`proposal challenge`, `design review`, `apply review` の各 decision point を gate semantics に沿って説明し、いずれの gate も human-author が resolve することを明記する。
+
+## Impact
+
+- `openspec/specs/workflow-gate-semantics/` に新しい baseline spec が作られる（archive 後）。
+- `openspec/specs/approval-clarify-persistence/` は `GateRecord` schema / `GateRecordStore` API への大幅改定（breaking）。既存の `.specflow/runs/<run_id>/records/*.json` データは migration が必須。
+- `openspec/specs/review-orchestration/` は review decision を gate 化する差分が入る。
+- core runtime (`specflow-run`) の transition handler は `GateRecord` を pending で作成し、`accept` / `reject` / `request_changes` / `clarify_response` で resolved へ遷移、同一 originating_phase の再発行時に旧 gate を `superseded` に遷移させる責務を持つ。invalid response はエラーとして返し gate は変化しない。
+- review CLI (`specflow-challenge-proposal`, `specflow-review-design`, `specflow-review-apply`) は round 完了時に `review_decision` gate を発行する。
+- `LocalFsInteractionRecordStore` → `LocalFsGateRecordStore` リネーム、CLI entry points の inject 先更新、および migration script が必要。
+- concurrency rule 実装のため、gate 発行時に同 phase の既存 pending gate を検査するロジックを core runtime に追加する必要がある。

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/review-ledger-design.json
@@ -1,0 +1,227 @@
+{
+  "feature_id": "define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects",
+  "phase": "design",
+  "current_round": 5,
+  "status": "has_open_high",
+  "max_finding_id": 11,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "consistency",
+      "title": "Clarify gate supersede logic conflicts with concurrent clarify semantics",
+      "detail": "Decision D4 and task 3.2 treat any new gate with the same gate_kind plus originating_phase as superseding the prior pending gate. That directly conflicts with the spec's concurrency rule that multiple pending `clarify` gates may coexist in the same phase. As written, issuing a second clarify question would incorrectly retire the first one. Narrow the supersede/concurrency logic to `approval` and `review_decision` only, or define a clarify-specific identity rule for true reissues, and add tests that multiple clarify gates remain pending and independently resolvable.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "completeness",
+      "title": "review_decision gate payload is missing required round metadata",
+      "detail": "The review-orchestration spec requires each `review_decision` gate payload to include not just `review_round_id` and `findings`, but also the persisted round provenance fields `reviewer_actor`, `reviewer_actor_id`, and `approval_binding`. The design contract and tasks 5.1-5.5 only plan for `review_round_id` and `findings`, so the persisted gate shape will not satisfy the spec and loses the metadata needed to interpret binding vs advisory review outcomes. Expand the GatePayload contract, issuance code, and verification tasks to carry and assert the full required payload.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "high",
+      "category": "completeness",
+      "title": "End-to-end gate resolution and response mapping are not planned",
+      "detail": "The specs require gate responses to resolve the gate and synchronously drive the corresponding workflow behavior, including approval accept/reject transitions, clarify response handling, review rejection/request-changes transitions, and review accept handoff behavior. The design defines a `resolveGate` helper, but the task breakdown only plans gate creation/adoption and never explicitly updates the real response-handling runtime/CLI paths to call it and apply the response-to-workflow mapping. Add explicit integration tasks and tests for the commands/transition handlers that consume gate responses, including `event_ids` updates and rejection of non-pending or ineligible responses.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R2-F04",
+      "severity": "high",
+      "category": "consistency",
+      "file": "DESIGN CONTENT",
+      "title": "Review-decision response mapping is still not implementable for all allowed responses",
+      "detail": "The design's response table still says `review_decision.accept` has \"no direct event\" even though `workflow-gate-semantics` requires every gate response to synchronously drive a concrete workflow event or handoff, and it never defines what `request_changes` does for `originating_phase: proposal_challenge` even though proposal-challenge rounds issue `review_decision` gates with the fixed `accept|reject|request_changes` response set. Task 6.3 therefore cannot be implemented correctly as written. Define the exact runtime transition or handoff for accept/reject and add the proposal-challenge request_changes mapping, then cover each review phase/response combination in tests.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F05",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "DESIGN CONTENT",
+      "title": "Migration fail-fast behavior only covers read() while list()-based legacy reads remain undefined",
+      "detail": "The spec says legacy record shapes must not be read after migration, but Decision D6, the integration notes, and task 2.4 only make `GateRecordStore.read()` raise `UnmigratedRecordError`. The runtime's concurrency checks and pending-gate queries use `list(runId)`, so an unmigrated run can still be silently consumed or fail unclearly through that path. Extend `LocalFsGateRecordStore.list()` and its tests to detect legacy-shaped files and return the same migration error before runtime logic proceeds.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F06",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "DESIGN CONTENT",
+      "title": "Approval and clarify gates still lack a defined eligible_responder_roles policy",
+      "detail": "The Gate schema requires every gate to persist a non-empty `eligible_responder_roles` set, and `resolveGate` enforces role intersection, but the design only fixes this field for `review_decision` gates. Tasks 4.1 and 6.x replace approval/clarify issuance and resolution without stating which roles those gate kinds should stamp onto new records, so implementers still have to guess how to populate a required field and how authorization should behave. Add an explicit per-kind role policy for approval and clarify gates and cover it in issuance and authorization tests.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R3-F07",
+      "severity": "high",
+      "category": "feasibility",
+      "file": "DESIGN CONTENT",
+      "title": "Atomic supersede requirement is weakened to best-effort rollback plus later repair",
+      "detail": "The approval-clarify-persistence spec requires superseding an existing pending approval/review gate and creating the replacement gate to behave atomically: if either write fails, both changes must roll back together. Decision D4 instead relies on two separate file writes with an in-process lock, best-effort rollback, and startup self-healing after crashes. That still allows a torn on-disk state that can temporarily expose two pending gates or an already-superseded old gate without the replacement, which does not satisfy the promised all-or-nothing contract. The design needs a concrete transactional/journaled approach that makes paired updates recover atomically before normal reads, or the spec/tasks must be changed to explicitly accept weaker semantics.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R3-F08",
+      "severity": "medium",
+      "category": "consistency",
+      "file": "DESIGN CONTENT",
+      "title": "Review-decision mappings introduce workflow transitions that are not defined in the scoped state contract",
+      "detail": "The response table and task 6.3 wire review_decision.accept to review_accepted, proposal_challenge.request_changes to revise_proposal, and all review_decision.reject paths to reject, but the provided specs only describe review handoff outcomes plus revise_design/revise_apply, and the design simultaneously declares workflow-run-state updates out of scope. That leaves implementers without an authoritative state-machine contract for the events they are supposed to fire, and it conflicts with review-orchestration's statement that review outcomes are distinct from workflow approve/reject operations. Align the mapping with existing workflow/handoff names or bring the required workflow-run-state/spec/task changes into scope so every review_decision response has a defined, testable transition contract.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F09",
+      "severity": "high",
+      "category": "feasibility",
+      "file": "DESIGN CONTENT",
+      "title": "Supersede journal does not actually serialize concurrent gate issuers",
+      "detail": "Decision D4 assumes that a single `.supersede-intent.json` path plus per-file atomic renames is enough to serialize concurrent `issueGate` calls, but it is not. Two processes can both read the same pending gate set, overwrite each other's intent file, and each commit a different new pending approval/review gate, violating the one-pending-per-phase invariant and making recovery ambiguous. The design/tasks need an explicit run-scoped mutual-exclusion or compare-and-swap mechanism around the supersede/create sequence, not just a deterministic journal filename.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R4-F10",
+      "severity": "high",
+      "category": "risk",
+      "file": "DESIGN CONTENT",
+      "title": "Review round persistence can be left without its required gate or back-reference",
+      "detail": "The design says review CLIs write the ledger round first and then issue the `review_decision` gate, with task 5.4 adding the `gate_id` afterward. A failure between those writes leaves a completed round without its mandatory gate, or a gate without the ledger back-reference, violating the 'exactly one gate per completed round' and round<->gate traversal requirements. The design/tasks need a transactional or recoverable protocol keyed by `review_round_id` so ledger append, gate creation, and `gate_id` linkage cannot be torn.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F11",
+      "severity": "high",
+      "category": "completeness",
+      "file": "DESIGN CONTENT",
+      "title": "GateRecord schema loses the actual resolved decision",
+      "detail": "The unified `GateRecord` only records `status: \"resolved\"`, timestamps, and `decision_actor`; it never persists which response resolved the gate. That collapses migrated approval history (`approved` vs `rejected`) into the same final state and likewise loses whether a review gate ended in `accept`, `reject`, or `request_changes`. `workflow-gate-semantics` requires a persisted gate to be self-sufficient for rendering the current decision without replaying other resources, so the design/tasks need an explicit persisted resolution/result field (top-level or payload-level), plus migration and `resolveGate` work/tests that populate it.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 3,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3
+      }
+    },
+    {
+      "round": 2,
+      "total": 6,
+      "open": 3,
+      "new": 3,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 2,
+      "new": 2,
+      "resolved": 6,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2
+      }
+    },
+    {
+      "round": 4,
+      "total": 10,
+      "open": 3,
+      "new": 2,
+      "resolved": 7,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3
+      }
+    },
+    {
+      "round": 5,
+      "total": 11,
+      "open": 3,
+      "new": 1,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 1,
+        "high": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/review-ledger-design.json.bak
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/review-ledger-design.json.bak
@@ -1,0 +1,200 @@
+{
+  "feature_id": "define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects",
+  "phase": "design",
+  "current_round": 4,
+  "status": "has_open_high",
+  "max_finding_id": 10,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "consistency",
+      "title": "Clarify gate supersede logic conflicts with concurrent clarify semantics",
+      "detail": "Decision D4 and task 3.2 treat any new gate with the same gate_kind plus originating_phase as superseding the prior pending gate. That directly conflicts with the spec's concurrency rule that multiple pending `clarify` gates may coexist in the same phase. As written, issuing a second clarify question would incorrectly retire the first one. Narrow the supersede/concurrency logic to `approval` and `review_decision` only, or define a clarify-specific identity rule for true reissues, and add tests that multiple clarify gates remain pending and independently resolvable.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "completeness",
+      "title": "review_decision gate payload is missing required round metadata",
+      "detail": "The review-orchestration spec requires each `review_decision` gate payload to include not just `review_round_id` and `findings`, but also the persisted round provenance fields `reviewer_actor`, `reviewer_actor_id`, and `approval_binding`. The design contract and tasks 5.1-5.5 only plan for `review_round_id` and `findings`, so the persisted gate shape will not satisfy the spec and loses the metadata needed to interpret binding vs advisory review outcomes. Expand the GatePayload contract, issuance code, and verification tasks to carry and assert the full required payload.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F03",
+      "severity": "high",
+      "category": "completeness",
+      "title": "End-to-end gate resolution and response mapping are not planned",
+      "detail": "The specs require gate responses to resolve the gate and synchronously drive the corresponding workflow behavior, including approval accept/reject transitions, clarify response handling, review rejection/request-changes transitions, and review accept handoff behavior. The design defines a `resolveGate` helper, but the task breakdown only plans gate creation/adoption and never explicitly updates the real response-handling runtime/CLI paths to call it and apply the response-to-workflow mapping. Add explicit integration tasks and tests for the commands/transition handlers that consume gate responses, including `event_ids` updates and rejection of non-pending or ineligible responses.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R2-F04",
+      "severity": "high",
+      "category": "consistency",
+      "file": "DESIGN CONTENT",
+      "title": "Review-decision response mapping is still not implementable for all allowed responses",
+      "detail": "The design's response table still says `review_decision.accept` has \"no direct event\" even though `workflow-gate-semantics` requires every gate response to synchronously drive a concrete workflow event or handoff, and it never defines what `request_changes` does for `originating_phase: proposal_challenge` even though proposal-challenge rounds issue `review_decision` gates with the fixed `accept|reject|request_changes` response set. Task 6.3 therefore cannot be implemented correctly as written. Define the exact runtime transition or handoff for accept/reject and add the proposal-challenge request_changes mapping, then cover each review phase/response combination in tests.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F05",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "DESIGN CONTENT",
+      "title": "Migration fail-fast behavior only covers read() while list()-based legacy reads remain undefined",
+      "detail": "The spec says legacy record shapes must not be read after migration, but Decision D6, the integration notes, and task 2.4 only make `GateRecordStore.read()` raise `UnmigratedRecordError`. The runtime's concurrency checks and pending-gate queries use `list(runId)`, so an unmigrated run can still be silently consumed or fail unclearly through that path. Extend `LocalFsGateRecordStore.list()` and its tests to detect legacy-shaped files and return the same migration error before runtime logic proceeds.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F06",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "DESIGN CONTENT",
+      "title": "Approval and clarify gates still lack a defined eligible_responder_roles policy",
+      "detail": "The Gate schema requires every gate to persist a non-empty `eligible_responder_roles` set, and `resolveGate` enforces role intersection, but the design only fixes this field for `review_decision` gates. Tasks 4.1 and 6.x replace approval/clarify issuance and resolution without stating which roles those gate kinds should stamp onto new records, so implementers still have to guess how to populate a required field and how authorization should behave. Add an explicit per-kind role policy for approval and clarify gates and cover it in issuance and authorization tests.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R3-F07",
+      "severity": "high",
+      "category": "feasibility",
+      "file": "DESIGN CONTENT",
+      "title": "Atomic supersede requirement is weakened to best-effort rollback plus later repair",
+      "detail": "The approval-clarify-persistence spec requires superseding an existing pending approval/review gate and creating the replacement gate to behave atomically: if either write fails, both changes must roll back together. Decision D4 instead relies on two separate file writes with an in-process lock, best-effort rollback, and startup self-healing after crashes. That still allows a torn on-disk state that can temporarily expose two pending gates or an already-superseded old gate without the replacement, which does not satisfy the promised all-or-nothing contract. The design needs a concrete transactional/journaled approach that makes paired updates recover atomically before normal reads, or the spec/tasks must be changed to explicitly accept weaker semantics.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R3-F08",
+      "severity": "high",
+      "category": "consistency",
+      "file": "DESIGN CONTENT",
+      "title": "Review-decision mappings introduce workflow transitions that are not defined in the scoped state contract",
+      "detail": "The response table and task 6.3 wire review_decision.accept to review_accepted, proposal_challenge.request_changes to revise_proposal, and all review_decision.reject paths to reject, but the provided specs only describe review handoff outcomes plus revise_design/revise_apply, and the design simultaneously declares workflow-run-state updates out of scope. That leaves implementers without an authoritative state-machine contract for the events they are supposed to fire, and it conflicts with review-orchestration's statement that review outcomes are distinct from workflow approve/reject operations. Align the mapping with existing workflow/handoff names or bring the required workflow-run-state/spec/task changes into scope so every review_decision response has a defined, testable transition contract.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F09",
+      "severity": "high",
+      "category": "feasibility",
+      "file": "DESIGN CONTENT",
+      "title": "Supersede journal does not actually serialize concurrent gate issuers",
+      "detail": "Decision D4 assumes that a single `.supersede-intent.json` path plus per-file atomic renames is enough to serialize concurrent `issueGate` calls, but it is not. Two processes can both read the same pending gate set, overwrite each other's intent file, and each commit a different new pending approval/review gate, violating the one-pending-per-phase invariant and making recovery ambiguous. The design/tasks need an explicit run-scoped mutual-exclusion or compare-and-swap mechanism around the supersede/create sequence, not just a deterministic journal filename.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F10",
+      "severity": "high",
+      "category": "risk",
+      "file": "DESIGN CONTENT",
+      "title": "Review round persistence can be left without its required gate or back-reference",
+      "detail": "The design says review CLIs write the ledger round first and then issue the `review_decision` gate, with task 5.4 adding the `gate_id` afterward. A failure between those writes leaves a completed round without its mandatory gate, or a gate without the ledger back-reference, violating the 'exactly one gate per completed round' and round<->gate traversal requirements. The design/tasks need a transactional or recoverable protocol keyed by `review_round_id` so ledger append, gate creation, and `gate_id` linkage cannot be torn.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 3,
+      "open": 3,
+      "new": 3,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3
+      }
+    },
+    {
+      "round": 2,
+      "total": 6,
+      "open": 3,
+      "new": 3,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 2,
+      "new": 2,
+      "resolved": 6,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2
+      }
+    },
+    {
+      "round": 4,
+      "total": 10,
+      "open": 3,
+      "new": 2,
+      "resolved": 7,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/review-ledger.json
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/review-ledger.json
@@ -1,0 +1,260 @@
+{
+  "feature_id": "define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects",
+  "phase": "impl",
+  "current_round": 5,
+  "status": "has_open_high",
+  "max_finding_id": 13,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "GateRecord persistence is explicitly disabled",
+      "detail": "In `commitTransitionAndExit()` (around lines 213-231), the new `GateRecordStore` is wired in but then deliberately discarded via `void gates; void mirrorMutationsSafely;`. The spec requires the runtime to persist first-class `GateRecord` objects after migration, but this change still commits only legacy `InteractionRecord` mutations. As written, surfaces cannot rely on gate persistence for approval/clarify/review decisions, so the core behavior in the spec is still missing.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Legacy delete-based record flow remains authoritative",
+      "detail": "`applyRecordMutations()` (around lines 150-168) still writes and deletes through `InteractionRecordStore`. The spec explicitly replaces `InteractionRecordStore` with `GateRecordStore`, removes the delete API, and requires prior gates to remain in history as `resolved` or `superseded` instead of being physically removed. Keeping the legacy delete path means the required lifecycle/history semantics are not implemented.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "error_handling",
+      "file": "src/lib/local-fs-interaction-record-store.ts",
+      "title": "Mixed migrated/unmigrated record directories are silently tolerated",
+      "detail": "`list()` now skips dotfiles and silently ignores any gate-shaped JSON file (around lines 57-70). The spec says migration is a one-time boundary and post-migration support is for `GateRecord` only; partial migration should fail fast, not produce a filtered legacy view. This behavior can hide incomplete migrations or unexpected files instead of forcing callers onto `GateRecordStore`.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "package.json",
+      "title": "Public migration CLI is registered before it is part of the reviewed change set",
+      "detail": "`package.json` and `src/contracts/orchestrators.ts` now advertise `specflow-migrate-records`, but the reviewed diff only adds the registration points. As reviewed, the package surface expands before the migration command implementation and its supporting changes are included in the same tracked change set. Either include the command/source files and tests together, or defer the registration.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F05",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/bin/specflow-run.ts",
+      "title": "No regression tests cover the new persistence behavior",
+      "detail": "This patch changes runtime persistence wiring and record-directory parsing, but the diff adds no tests proving that `specflow-run` writes gate records, preserves history instead of deleting records, or rejects mixed migrated/unmigrated directories. The spec change is non-trivial and needs explicit CLI/runtime coverage before merge.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F06",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "runAdvance still bypasses first-class gate resolution",
+      "detail": "`specflow-run advance` still accepts a raw workflow event and feeds `advanceRun()` a legacy `InteractionRecord[]` reconstructed by `gateRecordsToInteractionRecords()`. The CLI never looks up a pending gate or calls `resolveGate()`, so the required `allowed_responses`, `eligible_responder_roles`, and invalid-response checks in `gate-runtime.ts` are not enforced on real runs. A caller can still drive the state machine with `accept_*`/`reject` events directly instead of resolving a gate. Wire the runtime through `GateRecord` issue/resolve helpers and map gate responses to workflow events before advancing the run.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F07",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/bin/specflow-review-design.ts",
+      "title": "Review rounds still do not emit review_decision gates",
+      "detail": "The repository contains `issueReviewDecisionGate()`, but none of the review entry points (`specflow-challenge-proposal`, `specflow-review-design`, `specflow-review-apply`) call it or open a `GateRecordStore`. Review rounds still only update their JSON/ledger outputs, so the required persistent `review_decision` gate is never created and surfaces have nothing to render or resolve. Each review CLI needs to issue the gate after persisting the round and write the returned `gate_id` back into the ledger.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F08",
+      "severity": "medium",
+      "category": "error_handling",
+      "file": "src/bin/specflow-run.ts",
+      "title": "A single gate-store failure aborts the rest of the mutation batch",
+      "detail": "`applyGateMutations()` now wraps the entire `mirrorMutationsToGateStore()` call in one try/catch. If one `store.write()` throws, later mutations in the same transition are never attempted, which is weaker than the previous per-mutation best-effort behavior and can leave gate history partially mirrored. Catch around each translated mutation (or inside `mirrorMutationsToGateStore()`) so one bad write does not suppress the rest of the batch.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R4-F09",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-design.ts",
+      "title": "Review gate IDs collide across design and apply phases",
+      "detail": "Both `specflow-review-design.ts` and `specflow-review-apply.ts` derive gate IDs as `review_decision-${runId}-${round}`. Because the design and apply ledgers each start at round 1, the first apply-review gate for a run reuses the same `.specflow/runs/<run>/records/<gate_id>.json` path as the first design-review gate and overwrites that earlier gate history. Include the review phase in the persisted `gate_id` (for example `review_decision-${runId}-${reviewPhase}-${round}`) so every review round in a run gets a unique record.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R4-F10",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-apply.ts",
+      "title": "Autofix loops fabricate a review gate even when no new review round finished",
+      "detail": "Both autofix-loop implementations still call `tryIssueReviewDecisionGate()` after the loop unconditionally. If the loop exits on `no_changes`, `no_progress`, or `consecutive_failures` before a final `runReviewPipeline()` succeeds, they still write a new pending `review_decision` gate from stale ledger state and may repoint the latest round summary even though no review round completed. Gate emission needs to stay tied to successful per-round review persistence instead of happening unconditionally at loop exit.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R5-F11",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-challenge-proposal.ts",
+      "title": "Proposal challenge gates always reuse round 1 IDs",
+      "detail": "`tryIssueChallengeGate()` hard-codes both `gateId` (`review_decision-${runId}-challenge-1`) and `review_round_id` (`proposal_challenge-round-1`). Re-running the challenge CLI for the same run rewrites the same `.specflow/runs/<run>/records/...json` file instead of creating one gate per review round, so prior proposal-challenge gate history is lost. Derive or persist a monotonically increasing proposal-challenge round number and include it in both IDs.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F12",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Successful advances overwrite gate-resolution provenance with stale legacy data",
+      "detail": "In `runAdvance()`, `priorRecords` is materialized before `resolveGateForEvent()` mutates the gate store. On a successful approval transition, `advanceRun()` still emits an `update` mutation from that stale pending record, and `mirrorMutationsToGateStore()` writes it back over the already-resolved gate. Today that drops the gate-runtime `decision_actor` back to `null`; it would also clobber any future resolve-time payload fields. Refresh the records after resolution or skip mirroring a legacy update once the first-class gate has already been resolved.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F13",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/tests/review-cli.test.ts",
+      "title": "There is no end-to-end coverage for review gate issuance",
+      "detail": "The new review-gate behavior is only covered by helper/unit tests and parity fixtures where `gate_id` remains `null`. There is no CLI integration test that exercises design/apply/challenge review commands with `--run-id` or auto-discovered runs and then asserts both the emitted gate file and the ledger `gate_id` back-reference. Add those end-to-end cases so regressions in gate creation, round numbering, and proposal-challenge emission are caught.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 5,
+      "open": 5,
+      "new": 5,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 3
+      }
+    },
+    {
+      "round": 2,
+      "total": 8,
+      "open": 5,
+      "new": 3,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 4,
+      "new": 0,
+      "resolved": 4,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 2
+      }
+    },
+    {
+      "round": 4,
+      "total": 10,
+      "open": 4,
+      "new": 2,
+      "resolved": 6,
+      "overridden": 0,
+      "by_severity": {
+        "high": 4
+      }
+    },
+    {
+      "round": 5,
+      "total": 13,
+      "open": 5,
+      "new": 3,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/review-ledger.json.bak
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/review-ledger.json.bak
@@ -1,0 +1,204 @@
+{
+  "feature_id": "define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects",
+  "phase": "impl",
+  "current_round": 4,
+  "status": "has_open_high",
+  "max_finding_id": 10,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "GateRecord persistence is explicitly disabled",
+      "detail": "In `commitTransitionAndExit()` (around lines 213-231), the new `GateRecordStore` is wired in but then deliberately discarded via `void gates; void mirrorMutationsSafely;`. The spec requires the runtime to persist first-class `GateRecord` objects after migration, but this change still commits only legacy `InteractionRecord` mutations. As written, surfaces cannot rely on gate persistence for approval/clarify/review decisions, so the core behavior in the spec is still missing.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Legacy delete-based record flow remains authoritative",
+      "detail": "`applyRecordMutations()` (around lines 150-168) still writes and deletes through `InteractionRecordStore`. The spec explicitly replaces `InteractionRecordStore` with `GateRecordStore`, removes the delete API, and requires prior gates to remain in history as `resolved` or `superseded` instead of being physically removed. Keeping the legacy delete path means the required lifecycle/history semantics are not implemented.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "error_handling",
+      "file": "src/lib/local-fs-interaction-record-store.ts",
+      "title": "Mixed migrated/unmigrated record directories are silently tolerated",
+      "detail": "`list()` now skips dotfiles and silently ignores any gate-shaped JSON file (around lines 57-70). The spec says migration is a one-time boundary and post-migration support is for `GateRecord` only; partial migration should fail fast, not produce a filtered legacy view. This behavior can hide incomplete migrations or unexpected files instead of forcing callers onto `GateRecordStore`.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "package.json",
+      "title": "Public migration CLI is registered before it is part of the reviewed change set",
+      "detail": "`package.json` and `src/contracts/orchestrators.ts` now advertise `specflow-migrate-records`, but the reviewed diff only adds the registration points. As reviewed, the package surface expands before the migration command implementation and its supporting changes are included in the same tracked change set. Either include the command/source files and tests together, or defer the registration.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F05",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/bin/specflow-run.ts",
+      "title": "No regression tests cover the new persistence behavior",
+      "detail": "This patch changes runtime persistence wiring and record-directory parsing, but the diff adds no tests proving that `specflow-run` writes gate records, preserves history instead of deleting records, or rejects mixed migrated/unmigrated directories. The spec change is non-trivial and needs explicit CLI/runtime coverage before merge.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F06",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "runAdvance still bypasses first-class gate resolution",
+      "detail": "`specflow-run advance` still accepts a raw workflow event and feeds `advanceRun()` a legacy `InteractionRecord[]` reconstructed by `gateRecordsToInteractionRecords()`. The CLI never looks up a pending gate or calls `resolveGate()`, so the required `allowed_responses`, `eligible_responder_roles`, and invalid-response checks in `gate-runtime.ts` are not enforced on real runs. A caller can still drive the state machine with `accept_*`/`reject` events directly instead of resolving a gate. Wire the runtime through `GateRecord` issue/resolve helpers and map gate responses to workflow events before advancing the run.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F07",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/bin/specflow-review-design.ts",
+      "title": "Review rounds still do not emit review_decision gates",
+      "detail": "The repository contains `issueReviewDecisionGate()`, but none of the review entry points (`specflow-challenge-proposal`, `specflow-review-design`, `specflow-review-apply`) call it or open a `GateRecordStore`. Review rounds still only update their JSON/ledger outputs, so the required persistent `review_decision` gate is never created and surfaces have nothing to render or resolve. Each review CLI needs to issue the gate after persisting the round and write the returned `gate_id` back into the ledger.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R2-F08",
+      "severity": "medium",
+      "category": "error_handling",
+      "file": "src/bin/specflow-run.ts",
+      "title": "A single gate-store failure aborts the rest of the mutation batch",
+      "detail": "`applyGateMutations()` now wraps the entire `mirrorMutationsToGateStore()` call in one try/catch. If one `store.write()` throws, later mutations in the same transition are never attempted, which is weaker than the previous per-mutation best-effort behavior and can leave gate history partially mirrored. Catch around each translated mutation (or inside `mirrorMutationsToGateStore()`) so one bad write does not suppress the rest of the batch.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R4-F09",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-design.ts",
+      "title": "Review gate IDs collide across design and apply phases",
+      "detail": "Both `specflow-review-design.ts` and `specflow-review-apply.ts` derive gate IDs as `review_decision-${runId}-${round}`. Because the design and apply ledgers each start at round 1, the first apply-review gate for a run reuses the same `.specflow/runs/<run>/records/<gate_id>.json` path as the first design-review gate and overwrites that earlier gate history. Include the review phase in the persisted `gate_id` (for example `review_decision-${runId}-${reviewPhase}-${round}`) so every review round in a run gets a unique record.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R4-F10",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-apply.ts",
+      "title": "Autofix loops fabricate a review gate even when no new review round finished",
+      "detail": "Both autofix-loop implementations still call `tryIssueReviewDecisionGate()` after the loop unconditionally. If the loop exits on `no_changes`, `no_progress`, or `consecutive_failures` before a final `runReviewPipeline()` succeeds, they still write a new pending `review_decision` gate from stale ledger state and may repoint the latest round summary even though no review round completed. Gate emission needs to stay tied to successful per-round review persistence instead of happening unconditionally at loop exit.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 5,
+      "open": 5,
+      "new": 5,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 3
+      }
+    },
+    {
+      "round": 2,
+      "total": 8,
+      "open": 5,
+      "new": 3,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 4,
+      "new": 0,
+      "resolved": 4,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2,
+        "high": 2
+      }
+    },
+    {
+      "round": 4,
+      "total": 10,
+      "open": 4,
+      "new": 2,
+      "resolved": 6,
+      "overridden": 0,
+      "by_severity": {
+        "high": 4
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/specs/approval-clarify-persistence/spec.md
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/specs/approval-clarify-persistence/spec.md
@@ -1,78 +1,22 @@
-# approval-clarify-persistence Specification
+## REMOVED Requirements
 
-## Purpose
-TBD - created by archiving change define-approval-and-clarify-persistence-semantics. Update Purpose after archive.
-## Requirements
-### Requirement: Records are stored under the run directory with cascade lifecycle
+### Requirement: Approval record captures the full lifecycle of a gated decision
+**Reason**: Replaced by the unified `GateRecord` schema introduced by `workflow-gate-semantics`. Approval-specific fields are now expressed as `gate_kind: "approval"` with approval-specific context carried in the gate's `payload`.
+**Migration**: A one-time migration SHALL convert every existing `ApprovalRecord` JSON file under `.specflow/runs/<run_id>/records/` into a `GateRecord` with `gate_kind: "approval"`. The migration SHALL preserve `record_id → gate_id`, `run_id`, `phase_from` / `phase_to` (moved into `payload`), `status` mapping (`pending` → `pending`, `approved` / `rejected` → `resolved`), `requested_at → created_at`, `decided_at → resolved_at`, `decision_actor`, and `event_ids`. After migration, raw `ApprovalRecord` reads SHALL NOT be supported.
 
-Interaction records SHALL be stored under `.specflow/runs/<run_id>/records/` as individual JSON files named `<gate_id>.json`. Record lifecycle SHALL be coupled to the run lifecycle: deleting a run directory SHALL cascade-delete all contained records. Individual records SHALL NOT be deletable through any persistence API; run-directory cascade is the only supported removal path.
+### Requirement: Clarify record captures a single question-response pair
+**Reason**: Replaced by the unified `GateRecord` schema. Clarify-specific fields are now expressed as `gate_kind: "clarify"` with the question text and context carried in the gate's `payload`.
+**Migration**: A one-time migration SHALL convert every existing `ClarifyRecord` JSON file into a `GateRecord` with `gate_kind: "clarify"`. The migration SHALL preserve `record_id → gate_id`, `run_id`, `phase → originating_phase`, `question` and `question_context` (moved into `payload`), `answer` (moved into `payload` once resolved), `status` mapping (`pending` → `pending`, `resolved` → `resolved`), `asked_at → created_at`, `answered_at → resolved_at`, and `event_ids`. After migration, raw `ClarifyRecord` reads SHALL NOT be supported.
 
-#### Scenario: Record file location follows convention
+### Requirement: InteractionRecordStore provides the persistence interface
+**Reason**: Replaced by `GateRecordStore` (see ADDED Requirements below). The new interface removes the `delete` operation because persistent gate objects are audit-relevant and SHALL NOT be deleted at the API level.
+**Migration**: Update all callers to use `GateRecordStore.read` / `write` / `list`. Any caller that relied on per-record `delete` SHALL be rewritten to rely on run-directory cascade deletion instead.
 
-- **WHEN** a gate record with `gate_id: "gate-abc123"` is written for run `my-feature-1`
-- **THEN** the record SHALL be stored at `.specflow/runs/my-feature-1/records/gate-abc123.json`
+### Requirement: LocalFsInteractionRecordStore implements the interface for local mode
+**Reason**: Replaced by `LocalFsGateRecordStore`. Naming follows the new `GateRecord` schema; the file layout under `.specflow/runs/<run_id>/records/` is preserved so existing run directories continue to work after migration.
+**Migration**: Rename the implementation class and update CLI entry-point injection to construct `LocalFsGateRecordStore` instead. No additional runtime behavior changes are introduced by the rename alone.
 
-#### Scenario: Run deletion cascades to records
-
-- **WHEN** a run directory `.specflow/runs/my-feature-1/` is deleted
-- **THEN** all records under `.specflow/runs/my-feature-1/records/` SHALL be deleted as a consequence of the directory removal
-- **AND** no orphaned record files SHALL remain
-
-#### Scenario: Records directory is created on first write
-
-- **WHEN** the first gate record is written for a run
-- **THEN** the `records/` subdirectory SHALL be created if it does not exist
-- **AND** the write SHALL NOT fail due to a missing directory
-
-#### Scenario: Individual record deletion is not supported
-
-- **WHEN** a caller attempts to delete a single gate record through any persistence API
-- **THEN** no such API SHALL be provided
-- **AND** the only supported record-removal path SHALL be cascade deletion when the containing run directory is removed
-
-### Requirement: Core runtime creates records synchronously during transitions
-
-The core runtime transition handler SHALL be responsible for creating and updating gate records. Record creation SHALL happen synchronously as part of the transition, ensuring atomicity between the state transition and the record persistence. The runtime SHALL also be responsible for detecting concurrency conflicts (as defined by `workflow-gate-semantics`) and transitioning superseded gates in the same synchronous flow.
-
-#### Scenario: Gate record creation is part of the transition
-
-- **WHEN** the core runtime processes a transition that issues a gate
-- **THEN** it SHALL create the `GateRecord` using `GateRecordStore.write()` as part of the same synchronous flow
-- **AND** if the record write fails, the transition SHALL also fail
-
-#### Scenario: Clarify record creation is part of the clarify issuance
-
-- **WHEN** the core runtime issues a clarify question
-- **THEN** it SHALL create a `GateRecord` with `gate_kind: "clarify"` using `GateRecordStore.write()` before returning
-- **AND** the returned clarify event SHALL include the `gate_id`
-
-#### Scenario: Record update is part of the decision or response processing
-
-- **WHEN** the core runtime processes an approval decision, a clarify response, or a review decision
-- **THEN** it SHALL read the existing record, update it, and write it back using `GateRecordStore.write()`
-- **AND** the updated record SHALL reflect the new status before the transition completes
-
-#### Scenario: Superseding a prior pending gate is atomic with new gate creation
-
-- **WHEN** the runtime creates a new gate that supersedes an existing pending gate for the same `gate_kind` and `originating_phase`
-- **THEN** the prior record SHALL be updated to `status: "superseded"` in the same synchronous flow as the new record's creation
-- **AND** if either write fails, both SHALL be rolled back together
-
-### Requirement: CLI entry points inject InteractionRecordStore
-
-CLI entry points SHALL instantiate a `LocalFsGateRecordStore` at startup and inject it into the core runtime alongside the existing `RunArtifactStore`, `ChangeArtifactStore`, and `WorkspaceContext`. The previous `LocalFsInteractionRecordStore` injection is removed and SHALL be replaced wherever it was used.
-
-#### Scenario: specflow-run injects GateRecordStore for commands that need it
-
-- **WHEN** `specflow-run advance` is invoked for a transition that creates or updates gate records
-- **THEN** it SHALL construct a `LocalFsGateRecordStore` and pass it to the core runtime
-- **AND** the core runtime SHALL NOT construct its own store implementation
-
-#### Scenario: GateRecordStore injection does not affect unrelated commands
-
-- **WHEN** `specflow-run status` is invoked (a command that does not interact with gate records)
-- **THEN** the CLI MAY skip constructing `GateRecordStore`
-- **AND** the command SHALL function identically to its prior behavior
+## ADDED Requirements
 
 ### Requirement: GateRecord is the unified persistence unit for workflow gates
 
@@ -198,3 +142,75 @@ Once the one-time migration converts `.specflow/runs/<run_id>/records/*.json` en
 - **WHEN** the one-time migration is run against a records directory that has already been migrated
 - **THEN** it SHALL detect the `GateRecord` shape and exit without modifying files
 
+## MODIFIED Requirements
+
+### Requirement: Records are stored under the run directory with cascade lifecycle
+
+Interaction records SHALL be stored under `.specflow/runs/<run_id>/records/` as individual JSON files named `<gate_id>.json`. Record lifecycle SHALL be coupled to the run lifecycle: deleting a run directory SHALL cascade-delete all contained records. Individual records SHALL NOT be deletable through any persistence API; run-directory cascade is the only supported removal path.
+
+#### Scenario: Record file location follows convention
+
+- **WHEN** a gate record with `gate_id: "gate-abc123"` is written for run `my-feature-1`
+- **THEN** the record SHALL be stored at `.specflow/runs/my-feature-1/records/gate-abc123.json`
+
+#### Scenario: Run deletion cascades to records
+
+- **WHEN** a run directory `.specflow/runs/my-feature-1/` is deleted
+- **THEN** all records under `.specflow/runs/my-feature-1/records/` SHALL be deleted as a consequence of the directory removal
+- **AND** no orphaned record files SHALL remain
+
+#### Scenario: Records directory is created on first write
+
+- **WHEN** the first gate record is written for a run
+- **THEN** the `records/` subdirectory SHALL be created if it does not exist
+- **AND** the write SHALL NOT fail due to a missing directory
+
+#### Scenario: Individual record deletion is not supported
+
+- **WHEN** a caller attempts to delete a single gate record through any persistence API
+- **THEN** no such API SHALL be provided
+- **AND** the only supported record-removal path SHALL be cascade deletion when the containing run directory is removed
+
+### Requirement: Core runtime creates records synchronously during transitions
+
+The core runtime transition handler SHALL be responsible for creating and updating gate records. Record creation SHALL happen synchronously as part of the transition, ensuring atomicity between the state transition and the record persistence. The runtime SHALL also be responsible for detecting concurrency conflicts (as defined by `workflow-gate-semantics`) and transitioning superseded gates in the same synchronous flow.
+
+#### Scenario: Gate record creation is part of the transition
+
+- **WHEN** the core runtime processes a transition that issues a gate
+- **THEN** it SHALL create the `GateRecord` using `GateRecordStore.write()` as part of the same synchronous flow
+- **AND** if the record write fails, the transition SHALL also fail
+
+#### Scenario: Clarify record creation is part of the clarify issuance
+
+- **WHEN** the core runtime issues a clarify question
+- **THEN** it SHALL create a `GateRecord` with `gate_kind: "clarify"` using `GateRecordStore.write()` before returning
+- **AND** the returned clarify event SHALL include the `gate_id`
+
+#### Scenario: Record update is part of the decision or response processing
+
+- **WHEN** the core runtime processes an approval decision, a clarify response, or a review decision
+- **THEN** it SHALL read the existing record, update it, and write it back using `GateRecordStore.write()`
+- **AND** the updated record SHALL reflect the new status before the transition completes
+
+#### Scenario: Superseding a prior pending gate is atomic with new gate creation
+
+- **WHEN** the runtime creates a new gate that supersedes an existing pending gate for the same `gate_kind` and `originating_phase`
+- **THEN** the prior record SHALL be updated to `status: "superseded"` in the same synchronous flow as the new record's creation
+- **AND** if either write fails, both SHALL be rolled back together
+
+### Requirement: CLI entry points inject InteractionRecordStore
+
+CLI entry points SHALL instantiate a `LocalFsGateRecordStore` at startup and inject it into the core runtime alongside the existing `RunArtifactStore`, `ChangeArtifactStore`, and `WorkspaceContext`. The previous `LocalFsInteractionRecordStore` injection is removed and SHALL be replaced wherever it was used.
+
+#### Scenario: specflow-run injects GateRecordStore for commands that need it
+
+- **WHEN** `specflow-run advance` is invoked for a transition that creates or updates gate records
+- **THEN** it SHALL construct a `LocalFsGateRecordStore` and pass it to the core runtime
+- **AND** the core runtime SHALL NOT construct its own store implementation
+
+#### Scenario: GateRecordStore injection does not affect unrelated commands
+
+- **WHEN** `specflow-run status` is invoked (a command that does not interact with gate records)
+- **THEN** the CLI MAY skip constructing `GateRecordStore`
+- **AND** the command SHALL function identically to its prior behavior

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/specs/review-orchestration/spec.md
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/specs/review-orchestration/spec.md
@@ -1,0 +1,136 @@
+## ADDED Requirements
+
+### Requirement: Each completed review round issues a review_decision gate
+
+Every completed review round SHALL result in the core runtime issuing exactly one `"review_decision"` gate, as defined by `workflow-gate-semantics`. A review round is defined as a single invocation of `specflow-challenge-proposal challenge`, `specflow-review-design review`, or `specflow-review-apply review` that produces a ledger snapshot with a bounded set of findings (or, for proposal challenge, a bounded set of challenge questions).
+
+Individual findings SHALL NOT produce their own gates. All findings for the round SHALL be carried as `payload.findings` on the single `"review_decision"` gate issued for that round. The `payload` SHALL additionally include `review_round_id` identifying the ledger round, the `reviewer_actor` / `reviewer_actor_id` provenance values persisted in the round summary, and the `approval_binding` value recorded for that round.
+
+#### Scenario: Proposal challenge issues a single review_decision gate per round
+
+- **WHEN** `specflow-challenge-proposal challenge <CHANGE_ID>` completes
+- **THEN** the runtime SHALL issue one `"review_decision"` gate with `originating_phase: "proposal_challenge"`
+- **AND** the gate's `payload.findings` SHALL contain the challenge questions for that round
+
+#### Scenario: Design review issues a single review_decision gate per round
+
+- **WHEN** `specflow-review-design review <CHANGE_ID>` completes a review round
+- **THEN** the runtime SHALL issue one `"review_decision"` gate with `originating_phase: "design_review"`
+- **AND** the gate's `payload.findings` SHALL contain the design findings for that round
+
+#### Scenario: Apply review issues a single review_decision gate per round
+
+- **WHEN** `specflow-review-apply review <CHANGE_ID>` completes a review round
+- **THEN** the runtime SHALL issue one `"review_decision"` gate with `originating_phase: "apply_review"`
+- **AND** the gate's `payload.findings` SHALL contain the apply findings for that round
+
+#### Scenario: Findings do not generate individual gates
+
+- **WHEN** a review round produces multiple findings (critical, high, medium, low)
+- **THEN** no per-finding `"review_decision"` gate SHALL be created
+- **AND** all findings SHALL appear in the single round-level gate's `payload.findings`
+
+### Requirement: Review_decision gates are resolved exclusively by human-author role
+
+The runtime SHALL set `eligible_responder_roles = ["human-author"]` on every `"review_decision"` gate regardless of the review phase that produced it. AI-agent actors SHALL continue to generate review findings and MAY populate advisory metadata in the ledger, but SHALL NOT resolve any `"review_decision"` gate.
+
+Responses from non-`human-author` roles SHALL be rejected; the gate SHALL remain `pending` and its fields SHALL remain unchanged. This requirement is consistent with the existing review-orchestration rule that an undelegated AI-agent approval is advisory only.
+
+#### Scenario: Human-author resolves the review_decision gate
+
+- **WHEN** a `"review_decision"` gate is pending
+- **AND** a responder whose role is `human-author` submits `"accept"`, `"reject"`, or `"request_changes"`
+- **THEN** the runtime SHALL resolve the gate
+
+#### Scenario: AI-agent response to a review_decision gate is rejected
+
+- **WHEN** an `ai-agent` responder submits any response to a pending `"review_decision"` gate
+- **THEN** the runtime SHALL reject the response
+- **AND** the gate SHALL remain `pending`
+- **AND** the ledger SHALL still record the AI-agent's review findings as advisory metadata for that round
+
+#### Scenario: Automation response to a review_decision gate is rejected
+
+- **WHEN** an `automation` actor attempts to submit any response to a pending `"review_decision"` gate
+- **THEN** the runtime SHALL reject the response
+- **AND** the gate SHALL remain `pending`
+
+### Requirement: Review ledger persists the issuing gate id for each review round
+
+Each review ledger round summary SHALL persist the `gate_id` of the `"review_decision"` gate issued for that round. Consumers SHALL be able to traverse from a ledger round to its gate without ambiguity, and the gate's `payload.review_round_id` SHALL reference the same round id recorded in the ledger snapshot.
+
+#### Scenario: Ledger round summary records the issuing gate id
+
+- **WHEN** a review round is appended to the ledger
+- **THEN** the round summary SHALL include a `gate_id` field pointing to the `"review_decision"` gate issued for that round
+
+#### Scenario: Gate payload back-references the ledger round id
+
+- **WHEN** a `"review_decision"` gate is created
+- **THEN** its `payload.review_round_id` SHALL equal the ledger's round identifier for the same round
+- **AND** the ledger's round summary SHALL include the same `gate_id` for round-level traversal
+
+## MODIFIED Requirements
+
+### Requirement: Review handoff distinguishes actor kinds in review decisions
+
+Review orchestration SHALL recognize the actor kind of the reviewer when processing review outcomes. Review outcomes SHALL remain review-phase decisions that are distinct from workflow `approve` and `reject` operations. The mapping from review outcome to workflow transition SHALL account for whether the reviewer is `human`, `ai-agent`, or `automation`. `automation` actors SHALL NOT issue review outcomes and SHALL NOT participate in review phases. In addition, the authoritative resolver of the round-level `"review_decision"` gate SHALL always be a `human-author` role; AI-agent review outcomes SHALL continue to be recorded in the ledger as advisory metadata but SHALL NOT resolve the gate.
+
+Whenever this requirement refers to "no unresolved high findings", the gate SHALL be evaluated as `unresolvedCriticalHighCount(ledger) == 0` — i.e., the gate covers both `critical` and `high` severities, and ignores `medium` and `low` severities. MEDIUM and LOW findings SHALL NOT block the binding-approval handoff; they remain visible via `handoff.severity_summary` and Remaining Risks aggregation.
+
+#### Scenario: Human reviewer approval is binding
+
+- **WHEN** a `human` reviewer issues `review_approved`
+- **THEN** the review orchestration SHALL treat the outcome as a binding review approval
+- **AND** if `unresolvedCriticalHighCount(ledger) == 0` it SHALL return `handoff.state = "review_approved"` (or `"review_no_findings"` for the apply / design review handoff payload, per the severity-aware gate requirement)
+- **AND** the `"review_decision"` gate for that round SHALL be resolved with `"accept"`
+
+#### Scenario: Undelegated AI-agent reviewer approval is advisory only
+
+- **WHEN** an `ai-agent` reviewer issues `review_approved`
+- **AND** no delegation exists for the current run
+- **THEN** the review orchestration SHALL record the outcome as an advisory recommendation
+- **AND** it SHALL NOT return `handoff.state = "review_approved"` based on this outcome alone
+- **AND** the workflow SHALL NOT advance to the next gated phase based on this outcome alone
+- **AND** the `"review_decision"` gate SHALL remain `pending` until a `human-author` resolves it
+
+#### Scenario: Delegated AI-agent reviewer approval is binding
+
+- **WHEN** an `ai-agent` reviewer issues `review_approved`
+- **AND** delegation is active for the current run
+- **THEN** the review orchestration SHALL treat the outcome as a binding review approval
+- **AND** if `unresolvedCriticalHighCount(ledger) == 0` it SHALL return `handoff.state = "review_approved"` (or `"review_no_findings"` for the apply / design review handoff payload, per the severity-aware gate requirement)
+- **AND** unresolved findings whose `severity ∈ {medium, low}` SHALL NOT prevent this binding handoff
+- **AND** the `"review_decision"` gate SHALL remain `pending` until a `human-author` resolves it, because gate resolution is always bound to the `human-author` role even when delegated AI approval is the binding review outcome
+
+#### Scenario: Request-changes outcome requires a phase revision
+
+- **WHEN** a `human` reviewer or an `ai-agent` reviewer issues `request_changes`
+- **THEN** the review orchestration SHALL return a non-approved handoff for the current phase
+- **AND** the handoff SHALL require the phase-appropriate revise transition (`revise_design` or `revise_apply`) before the next review round
+- **AND** delegation SHALL NOT change this mapping because `request_changes` is a review-phase outcome, not a gated workflow approval
+- **AND** when resolved by a `human-author`, the corresponding `"review_decision"` gate SHALL be resolved with `"request_changes"`, which maps to the phase-appropriate revise workflow event
+
+#### Scenario: AI-agent block is overridable in the ledger
+
+- **WHEN** an `ai-agent` reviewer issues `block`
+- **THEN** a `human` actor SHALL be able to override the finding status in the review ledger
+- **AND** the override SHALL be recorded with the overriding actor's identity
+
+#### Scenario: Human reviewer block is non-overridable
+
+- **WHEN** a `human` reviewer issues `block`
+- **THEN** no actor SHALL override the block
+- **AND** the review orchestration SHALL reject any attempt to change the status of a human-issued block finding
+
+#### Scenario: Automation cannot issue review outcomes
+
+- **WHEN** an `automation` actor attempts to issue a review outcome (`review_approved`, `request_changes`, or `block`)
+- **THEN** the review orchestration SHALL reject the operation
+- **AND** automation actors SHALL NOT participate in review phases
+
+#### Scenario: Automation evidence is advisory only
+
+- **WHEN** an automation source emits CI, webhook, or batch evidence during a review phase
+- **THEN** the review orchestration MAY surface or persist that evidence for a reviewer
+- **AND** it SHALL NOT treat the automation source as the reviewer or as a review outcome

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/specs/workflow-gate-semantics/spec.md
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/specs/workflow-gate-semantics/spec.md
@@ -1,0 +1,246 @@
+## ADDED Requirements
+
+### Requirement: Gate is a first-class persistent workflow object
+
+The system SHALL define **Gate** as a first-class persistent workflow object representing a pending decision point in a run. A Gate SHALL exist independently of any surface (CLI, UI, server) and any specific actor identity. A Gate SHALL be created by the workflow core runtime whenever a phase transition requires a gated decision, and SHALL persist until it reaches a terminal status (`resolved` or `superseded`).
+
+Each Gate SHALL include the following fields:
+- `gate_id`: A unique identifier for this gate (required).
+- `gate_kind`: One of `"approval"`, `"clarify"`, or `"review_decision"` (required).
+- `run_id`: The run this gate belongs to (required).
+- `originating_phase`: The workflow phase that produced this gate (required).
+- `status`: One of `"pending"`, `"resolved"`, or `"superseded"` (required).
+- `reason`: A short human-readable string describing why the gate is open (required).
+- `payload`: A kind-specific structured object containing the detailed context needed to answer the gate (required, schema varies by `gate_kind`).
+- `eligible_responder_roles`: A non-empty set of actor role identifiers indicating who may resolve the gate (required).
+- `allowed_responses`: The fixed list of response tokens the gate accepts, determined by `gate_kind` (required).
+- `created_at`: ISO 8601 timestamp when the gate entered `pending` (required).
+- `resolved_at`: ISO 8601 timestamp when the gate reached `resolved` or `superseded` (required once non-pending, null otherwise).
+- `decision_actor`: The actor identity that resolved the gate (required once `resolved`, null otherwise; always null when `superseded`).
+- `event_ids`: An ordered array of surface event ids associated with the gate's history (required, may be empty when first created).
+
+#### Scenario: Gate is created when a gated phase transition requires a decision
+
+- **WHEN** the workflow core processes a transition that requires an approval, a clarification, or a review decision
+- **THEN** the runtime SHALL create a Gate with `status: "pending"` and `resolved_at: null` before surfacing the stop point to any surface
+- **AND** the gate SHALL carry the `originating_phase` matching the phase that produced it
+
+#### Scenario: Gate object is surface-agnostic
+
+- **WHEN** a surface (CLI, UI, or server runtime) reads the current run state
+- **THEN** it SHALL be able to list all pending gates using only the Gate schema fields
+- **AND** the gate definition SHALL NOT depend on any surface-specific field (button labels, UI copy, transport identifiers)
+
+### Requirement: Gate kinds are limited to approval, clarify, and review_decision
+
+The system SHALL support exactly three gate kinds. No other `gate_kind` value SHALL be accepted by the runtime.
+
+- `"approval"`: Represents an approval-required stop point (e.g., `spec_ready`, `design_ready`, `apply_ready`). The payload SHALL include the phase pair (`phase_from`, `phase_to`) being gated.
+- `"clarify"`: Represents a single clarification question issued by the workflow. The payload SHALL include the question text and any additional question context.
+- `"review_decision"`: Represents a human decision on a completed review round. The payload SHALL include the review round id and the findings snapshot for that round.
+
+#### Scenario: Unknown gate kind is rejected at creation
+
+- **WHEN** the runtime receives a request to create a gate with `gate_kind` outside the set `{approval, clarify, review_decision}`
+- **THEN** the runtime SHALL reject the creation
+- **AND** no gate record SHALL be persisted
+
+### Requirement: Gate lifecycle supports pending, resolved, and superseded
+
+Every Gate SHALL transition through a finite state machine with exactly three states: `pending`, `resolved`, and `superseded`. `pending` is the initial state. `resolved` and `superseded` are terminal states: once a gate leaves `pending`, its status SHALL NOT change again.
+
+- `pending` → `resolved`: triggered by a valid response received through `allowed_responses`. The resolution SHALL populate `resolved_at` and `decision_actor`.
+- `pending` → `superseded`: triggered when the runtime creates a new gate with the same `gate_kind` and `originating_phase` for the same run while the prior gate is still pending. The prior gate SHALL be marked `superseded`, `resolved_at` SHALL be populated, and `decision_actor` SHALL remain null.
+
+Superseded gates SHALL NOT be counted as pending gates and SHALL NOT be treated as resolved decisions; they SHALL remain in persistence for history only.
+
+#### Scenario: Valid response resolves the gate
+
+- **WHEN** a responder submits a valid response for a pending gate
+- **THEN** the runtime SHALL transition the gate to `resolved`
+- **AND** `resolved_at` SHALL be set to the current timestamp
+- **AND** `decision_actor` SHALL be set to the responder's actor identity
+
+#### Scenario: New gate of same kind in same originating phase supersedes the prior pending gate
+
+- **WHEN** a gate with `gate_kind: K` is `pending` for `originating_phase: P` in a run
+- **AND** the runtime creates a new gate with the same `gate_kind: K` and the same `originating_phase: P` for the same run
+- **THEN** the prior pending gate SHALL transition to `superseded`
+- **AND** `resolved_at` SHALL be set on the superseded gate
+- **AND** `decision_actor` SHALL remain null on the superseded gate
+
+#### Scenario: Terminal states are immutable
+
+- **WHEN** a gate is in `resolved` or `superseded` status
+- **THEN** no subsequent response or transition SHALL change its status
+- **AND** attempts to resolve a non-pending gate SHALL be rejected
+
+#### Scenario: Superseded gates are excluded from pending listings
+
+- **WHEN** a surface lists pending gates for a run
+- **THEN** gates with `status: "superseded"` SHALL NOT appear in the pending list
+- **AND** they SHALL remain retrievable for history / audit purposes
+
+### Requirement: Allowed responses are fixed per gate kind
+
+The runtime SHALL use a fixed `allowed_responses` set determined by `gate_kind`. The sets SHALL NOT vary by `originating_phase` or by gate instance.
+
+- `"approval"` → `["accept", "reject"]`
+- `"clarify"` → `["clarify_response"]`
+- `"review_decision"` → `["accept", "reject", "request_changes"]`
+
+Any response token outside the set for the given gate kind SHALL be rejected as invalid. A rejected response SHALL NOT change the gate's status; the gate SHALL remain `pending`.
+
+#### Scenario: Approval gate accepts accept and reject only
+
+- **WHEN** an `"approval"` gate receives a response of `"accept"` or `"reject"`
+- **THEN** the runtime SHALL transition the gate to `resolved`
+
+#### Scenario: Clarify gate accepts clarify_response only
+
+- **WHEN** a `"clarify"` gate receives a response of `"clarify_response"`
+- **THEN** the runtime SHALL transition the gate to `resolved`
+
+#### Scenario: Review_decision gate accepts accept, reject, and request_changes
+
+- **WHEN** a `"review_decision"` gate receives `"accept"`, `"reject"`, or `"request_changes"`
+- **THEN** the runtime SHALL transition the gate to `resolved`
+
+#### Scenario: Invalid response is rejected and leaves the gate pending
+
+- **WHEN** a gate receives a response token outside its kind's `allowed_responses`
+- **THEN** the runtime SHALL return an error describing the invalid response
+- **AND** the gate SHALL remain `pending` with unchanged fields
+- **AND** no `event_ids` entry SHALL be appended for the rejected attempt
+
+### Requirement: Gate responses map deterministically to handoff signals
+
+Each gate response SHALL map to exactly one handoff signal that the runtime produces as part of the same synchronous resolution. The mapping SHALL be deterministic and SHALL NOT depend on actor identity beyond eligibility checks.
+
+For `approval` gates, the handoff signal is an **existing transition handler entry point** (`accept_spec`, `accept_design`, `accept_apply`, `reject`) already defined by the runtime's transition handler implementations.
+
+For `review_decision` gates, the handoff signal is a **review-orchestration handoff outcome** (`handoff.state` value), consistent with review-orchestration's requirement that review outcomes are distinct from workflow approve/reject operations. The `request_changes` handoff additionally specifies the phase-appropriate revise transition (`revise_proposal` / `revise_design` / `revise_apply`) that existing transition handlers already support.
+
+For `clarify` gates, the handoff signal is `clarify_response`, which keeps the run in its current phase.
+
+- `approval.accept` → `accept_spec` / `accept_design` / `accept_apply` (determined by `originating_phase`)
+- `approval.reject` → `reject`
+- `clarify.clarify_response` → `clarify_response` (keeps the run in its current phase, appends the answer)
+- `review_decision.accept` → `handoff.state = review_approved` (review round closes; the run proceeds to the downstream approval gate)
+- `review_decision.reject` → `handoff.state = review_rejected` (review-level rejection, distinct from the approval-level `reject` transition)
+- `review_decision.request_changes` → `handoff.state = request_changes` → `revise_proposal` / `revise_design` / `revise_apply` (determined by `originating_phase`)
+
+#### Scenario: Approval response produces the phase-appropriate accept signal
+
+- **WHEN** an `"approval"` gate with `originating_phase: "spec_ready"` is resolved with `"accept"`
+- **THEN** the runtime SHALL produce the `accept_spec` handoff signal in the same transition
+
+#### Scenario: Review request_changes maps to the phase-appropriate revise handoff
+
+- **WHEN** a `"review_decision"` gate with `originating_phase: "design_review"` is resolved with `"request_changes"`
+- **THEN** the runtime SHALL produce a `handoff.state = request_changes` signal that maps to the `revise_design` transition
+
+#### Scenario: Review reject produces a review-level rejection handoff distinct from approval reject
+
+- **WHEN** a `"review_decision"` gate is resolved with `"reject"`
+- **THEN** the runtime SHALL produce a `handoff.state = review_rejected` signal
+- **AND** this signal SHALL be distinct from the `reject` transition produced by `approval.reject`
+
+#### Scenario: Clarify response does not change phase
+
+- **WHEN** a `"clarify"` gate is resolved with `"clarify_response"`
+- **THEN** the run SHALL remain in its current phase
+- **AND** the clarification answer SHALL be persisted as part of the gate's resolution
+
+### Requirement: Concurrency rules limit approval and review gates to one pending per phase
+
+Within a single run, the runtime SHALL enforce the following concurrency rules:
+
+- A phase MAY have multiple `"clarify"` gates pending concurrently.
+- A phase SHALL have at most one pending `"approval"` gate at a time.
+- A phase SHALL have at most one pending `"review_decision"` gate at a time.
+
+While a run has a pending `"approval"` or `"review_decision"` gate, the runtime SHALL NOT advance the run to a subsequent phase. Pending `"clarify"` gates SHALL NOT block phase transitions by themselves, except where a phase's own acceptance criteria require clarify resolution.
+
+#### Scenario: Multiple clarify gates can coexist in one phase
+
+- **WHEN** a phase issues three clarification questions in sequence
+- **THEN** three `"clarify"` gates SHALL exist concurrently with `status: "pending"`
+- **AND** each SHALL resolve independently when answered
+
+#### Scenario: Second approval gate in same phase supersedes the first
+
+- **WHEN** an `"approval"` gate is pending for `originating_phase: P`
+- **AND** the runtime creates a new `"approval"` gate for the same `originating_phase: P` in the same run
+- **THEN** the prior gate SHALL transition to `superseded`
+- **AND** only one `"approval"` gate SHALL remain `pending` for that phase
+
+#### Scenario: Pending approval blocks phase advancement
+
+- **WHEN** a run has any pending `"approval"` gate
+- **THEN** the runtime SHALL NOT apply a transition that advances the run into the next phase
+- **AND** the gate SHALL be resolved before advancement becomes possible
+
+### Requirement: Eligible responders are expressed as actor roles
+
+The `eligible_responder_roles` field SHALL contain a non-empty set of role identifiers defined by `actor-surface-model` (for example: `human-author`, `ai-agent`, `reviewer`). The runtime SHALL NOT encode specific actor identities in `eligible_responder_roles`; identity-level resolution remains a future extension point.
+
+A response SHALL be accepted only if the responding actor's active role intersects `eligible_responder_roles`. Responses from actors whose roles do not intersect SHALL be rejected, and the gate SHALL remain `pending`.
+
+#### Scenario: Responder role matches eligible roles
+
+- **WHEN** a responder whose active role is in `eligible_responder_roles` submits a valid response
+- **THEN** the runtime SHALL accept the response and resolve the gate
+
+#### Scenario: Responder role does not match eligible roles
+
+- **WHEN** a responder whose active role is NOT in `eligible_responder_roles` submits a response
+- **THEN** the runtime SHALL reject the response
+- **AND** the gate SHALL remain `pending`
+
+### Requirement: Review_decision gates are issued per review round and resolved by human-author
+
+The runtime SHALL create exactly one `"review_decision"` gate per completed review round. A review round is defined as a single invocation of `specflow-challenge-proposal`, `specflow-review-design`, or `specflow-review-apply` that produces a set of findings. Individual findings SHALL NOT generate their own gates; they SHALL be represented inside the gate's `payload.findings` array.
+
+All `"review_decision"` gates SHALL set `eligible_responder_roles = ["human-author"]` regardless of the review phase (`proposal_challenge`, `design_review`, or `apply_review`). AI-agent actors MAY generate review findings and MAY emit advisory opinions through the ledger, but they SHALL NOT resolve `"review_decision"` gates.
+
+#### Scenario: One review_decision gate per review round
+
+- **WHEN** a review round (proposal challenge, design review, or apply review) completes
+- **THEN** the runtime SHALL create exactly one `"review_decision"` gate with the round's findings in `payload.findings`
+- **AND** no per-finding gate SHALL be created
+
+#### Scenario: Human-author is the only eligible responder for review decisions
+
+- **WHEN** a `"review_decision"` gate is created
+- **THEN** `eligible_responder_roles` SHALL equal `["human-author"]`
+- **AND** any response submitted by an actor whose role is not `human-author` SHALL be rejected
+
+#### Scenario: AI-agent findings are represented in payload, not as gates
+
+- **WHEN** an AI-agent review produces findings during a review round
+- **THEN** the findings SHALL appear in the resulting `"review_decision"` gate's `payload.findings`
+- **AND** no separate gate SHALL be created per finding
+
+### Requirement: Gate history is derived from event_ids and is surface-agnostic
+
+Each gate's `event_ids` array SHALL reference surface events (as defined by `surface-event-contract`) that relate to the gate's lifecycle: creation, responses (including rejected ones that produced errors, if the surface chose to emit them), and resolution. The gate object itself SHALL carry enough state (`status`, `resolved_at`, `decision_actor`) for a surface to display the gate's current position without replaying the event stream.
+
+The runtime SHALL NOT require a specific transport to deliver gate state; any surface that can read the persisted gate and the referenced events SHALL be able to render gate history faithfully.
+
+#### Scenario: Gate state is self-sufficient for rendering current position
+
+- **WHEN** a surface reads a gate record from persistence
+- **THEN** it SHALL be able to display the gate's current status, reason, and decision (if any) without reading any other resource
+
+#### Scenario: Event_ids link the gate to its surface history
+
+- **WHEN** a gate is resolved
+- **THEN** the resolution event's id SHALL be appended to `event_ids`
+- **AND** consumers that read the event store SHALL be able to reconstruct the timeline of the gate's life
+
+#### Scenario: Superseded gates retain their history
+
+- **WHEN** a gate transitions to `superseded`
+- **THEN** its `event_ids` SHALL remain intact and queryable
+- **AND** surfaces SHALL be able to display the superseded gate as part of historical audit views

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/task-graph.json
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/task-graph.json
@@ -1,0 +1,311 @@
+{
+  "version": "1.0",
+  "change_id": "define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects",
+  "bundles": [
+    {
+      "id": "gate-record-foundation",
+      "title": "Gate Record Foundation",
+      "goal": "Define GateRecord as the canonical persistence model and replace the legacy interaction store at the data-layer boundary.",
+      "depends_on": [],
+      "inputs": [
+        "design.md",
+        "approval-clarify-persistence capability",
+        "existing InteractionRecordStore and LocalFsInteractionRecordStore code"
+      ],
+      "outputs": [
+        "GateRecord, GatePayload, GateKind, GateStatus, and GateRecordStore TypeScript contracts",
+        "LocalFsGateRecordStore on .specflow/runs/<run_id>/records/",
+        "FakeGateRecordStore test double",
+        "unit tests for read, write, list, and atomic single-record persistence behavior"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Define GateKind, GateStatus, GatePayload, GateRecord, and GateRecordStore and remove the individual delete API from the contract",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Implement LocalFsGateRecordStore with write-to-temp plus rename semantics while preserving the existing records/ directory layout and gate_id filename mapping",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Add FakeGateRecordStore for runtime and transition tests",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Add unit coverage for read, write, list, no-delete behavior, and atomic persistence guarantees",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "approval-clarify-persistence",
+        "run-artifact-store-conformance",
+        "artifact-ownership-model"
+      ]
+    },
+    {
+      "id": "legacy-record-migration",
+      "title": "Legacy Record Migration",
+      "goal": "Provide an idempotent migration and rollback path from legacy approval and clarify records to GateRecord JSON.",
+      "depends_on": [
+        "gate-record-foundation"
+      ],
+      "inputs": [
+        "GateRecord and GateRecordStore contracts",
+        "legacy .specflow/runs/<run_id>/records/*.json fixtures",
+        "design.md Migration Plan"
+      ],
+      "outputs": [
+        "specflow-migrate-records CLI",
+        ".migrated sentinel and .backup snapshot behavior",
+        "UnmigratedRecordError read-path enforcement",
+        "migration fixtures and idempotency tests"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Implement forward migration that rewrites legacy approval and clarify record JSON in place and preserves record_id as gate_id",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Write .migrated sentinels and .backup snapshots per run so migration is idempotent and reversible",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Implement --undo to restore original files from .backup and remove the .migrated sentinel before any post-migration writes",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Make GateRecordStore read fail fast with UnmigratedRecordError when a legacy-shaped file is encountered",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Add tests for mixed directories, repeated migration runs, unknown record_kind values, and partially corrupted legacy records",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "approval-clarify-persistence",
+        "utility-cli-suite",
+        "workspace-context"
+      ]
+    },
+    {
+      "id": "runtime-gate-helpers",
+      "title": "Runtime Gate Helpers",
+      "goal": "Implement gate issuance and resolution semantics, including supersede, validation, and recovery rules, in the runtime layer.",
+      "depends_on": [
+        "gate-record-foundation"
+      ],
+      "inputs": [
+        "GateRecord and GateRecordStore contracts",
+        "actor-surface-model role identifiers",
+        "design.md Decisions and State Lifecycle sections"
+      ],
+      "outputs": [
+        "issueGate helper",
+        "resolveGate helper",
+        "runtime-owned allowed_responses mapping",
+        "startup self-heal logic for duplicate pending gates",
+        "unit tests for concurrency, rollback, and validation rules"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Implement the runtime-owned allowed_responses mapping for approval, clarify, and review_decision gates",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Implement issueGate with same gate_kind plus originating_phase concurrency checks, paired supersede and create writes, and event_ids updates",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Implement resolveGate with allowed response validation, eligible responder role checks, terminal-state immutability, and resolved metadata writes",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Add in-process locking, best-effort rollback, and startup self-healing to reconcile duplicate pending gates after partial failures",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Add tests for supersede behavior, invalid response rejection, role mismatch rejection, non-pending response attempts, and rollback semantics",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "phase-semantics",
+        "actor-surface-model",
+        "approval-clarify-persistence"
+      ]
+    },
+    {
+      "id": "transition-and-cli-gate-adoption",
+      "title": "Transition and CLI Gate Adoption",
+      "goal": "Replace legacy transition record issuance and CLI wiring with GateRecord-backed behavior without changing run paths.",
+      "depends_on": [
+        "legacy-record-migration",
+        "runtime-gate-helpers"
+      ],
+      "inputs": [
+        "issueGate and resolveGate helpers",
+        "migration command availability",
+        "transition call sites that emit ApprovalRecord or ClarifyRecord",
+        "CLI entry points using LocalFsInteractionRecordStore"
+      ],
+      "outputs": [
+        "transition code paths emitting approval and clarify GateRecord objects",
+        "phase gating logic aligned to approval and review_decision blocking rules",
+        "CLI and runtime composition using LocalFsGateRecordStore",
+        "transition regression tests"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Replace ApprovalRecord and ClarifyRecord writes in spec, design, and apply transitions with issueGate inputs and GateRecord payloads",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Update phase advancement checks so pending approval and review_decision gates block advancement while clarify gates remain non-blocking by themselves",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Switch CLI and runtime injection sites from LocalFsInteractionRecordStore to LocalFsGateRecordStore",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Add regression tests proving gate_kind, payload, and on-disk record path semantics match legacy behavior apart from the schema rename",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "phase-semantics",
+        "workflow-run-state",
+        "approval-clarify-persistence",
+        "utility-cli-suite"
+      ]
+    },
+    {
+      "id": "review-decision-gates",
+      "title": "Review Decision Gate Integration",
+      "goal": "Emit one review_decision gate per completed review round and link each round summary back to the gate.",
+      "depends_on": [
+        "runtime-gate-helpers",
+        "transition-and-cli-gate-adoption"
+      ],
+      "inputs": [
+        "issueGate helper",
+        "review ledger round summaries",
+        "specflow-challenge-proposal entry point",
+        "specflow-review-design entry point",
+        "specflow-review-apply entry point"
+      ],
+      "outputs": [
+        "review_decision gate emission in proposal, design, and apply review CLIs",
+        "ledger round summaries with gate_id back-references",
+        "integration tests for review gate payloads, eligibility, and linkage"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Update specflow-challenge-proposal to issue a review_decision gate after each completed proposal challenge round",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Update specflow-review-design to issue a review_decision gate carrying review_round_id and findings in the payload",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Update specflow-review-apply to issue a review_decision gate carrying review_round_id and findings in the payload",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Extend ledger round summary persistence to include gate_id while keeping legacy summaries readable when gate_id is absent",
+          "status": "done"
+        },
+        {
+          "id": "5",
+          "title": "Add tests proving exactly one review_decision gate per round, human-author-only eligibility, and gate_id equality with the ledger round back-reference",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "review-orchestration",
+        "actor-surface-model",
+        "approval-clarify-persistence"
+      ]
+    },
+    {
+      "id": "gate-alias-and-change-verification",
+      "title": "Gate Alias Layer and Change Verification",
+      "goal": "Preserve surface-event compatibility through the record_id alias layer and complete archive-level verification for the change.",
+      "depends_on": [
+        "legacy-record-migration",
+        "transition-and-cli-gate-adoption",
+        "review-decision-gates"
+      ],
+      "inputs": [
+        "GateRecord-based event emitters",
+        "surface-event payload builders",
+        "design.md Completion Conditions"
+      ],
+      "outputs": [
+        "recordIdForGate compatibility helper",
+        "event payloads still emitting record_id derived from gate_id",
+        "follow-up tracking hook for alias removal",
+        "passing openspec validate and specflow-spec-verify results"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Add recordIdForGate that returns gate.gate_id and route surface-event payload construction through the alias helper",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Add compatibility tests proving payload.record_id remains present and equals gate.gate_id across updated emitters",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Add a follow-up tracking reference for removing the alias from surface-event-contract and workflow-run-state consumers",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Run openspec validate and specflow-spec-verify and resolve any remaining consistency issues required for archive readiness",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "surface-event-contract",
+        "workflow-run-state",
+        "spec-consistency-verification"
+      ]
+    }
+  ],
+  "generated_at": "2026-04-18T09:40:48.184Z",
+  "generated_from": "design.md"
+}

--- a/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/tasks.md
+++ b/openspec/changes/archive/2026-04-18-define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects/tasks.md
@@ -1,0 +1,66 @@
+## 1. Gate Record Foundation ✓
+
+> Define GateRecord as the canonical persistence model and replace the legacy interaction store at the data-layer boundary.
+
+- [x] 1.1 Define GateKind, GateStatus, GatePayload, GateRecord, and GateRecordStore and remove the individual delete API from the contract
+- [x] 1.2 Implement LocalFsGateRecordStore with write-to-temp plus rename semantics while preserving the existing records/ directory layout and gate_id filename mapping
+- [x] 1.3 Add FakeGateRecordStore for runtime and transition tests
+- [x] 1.4 Add unit coverage for read, write, list, no-delete behavior, and atomic persistence guarantees
+
+## 2. Legacy Record Migration ✓
+
+> Provide an idempotent migration and rollback path from legacy approval and clarify records to GateRecord JSON.
+
+> Depends on: gate-record-foundation
+
+- [x] 2.1 Implement forward migration that rewrites legacy approval and clarify record JSON in place and preserves record_id as gate_id
+- [x] 2.2 Write .migrated sentinels and .backup snapshots per run so migration is idempotent and reversible
+- [x] 2.3 Implement --undo to restore original files from .backup and remove the .migrated sentinel before any post-migration writes
+- [x] 2.4 Make GateRecordStore read fail fast with UnmigratedRecordError when a legacy-shaped file is encountered
+- [x] 2.5 Add tests for mixed directories, repeated migration runs, unknown record_kind values, and partially corrupted legacy records
+
+## 3. Runtime Gate Helpers ✓
+
+> Implement gate issuance and resolution semantics, including supersede, validation, and recovery rules, in the runtime layer.
+
+> Depends on: gate-record-foundation
+
+- [x] 3.1 Implement the runtime-owned allowed_responses mapping for approval, clarify, and review_decision gates
+- [x] 3.2 Implement issueGate with same gate_kind plus originating_phase concurrency checks, paired supersede and create writes, and event_ids updates
+- [x] 3.3 Implement resolveGate with allowed response validation, eligible responder role checks, terminal-state immutability, and resolved metadata writes
+- [x] 3.4 Add in-process locking, best-effort rollback, and startup self-healing to reconcile duplicate pending gates after partial failures
+- [x] 3.5 Add tests for supersede behavior, invalid response rejection, role mismatch rejection, non-pending response attempts, and rollback semantics
+
+## 4. Transition and CLI Gate Adoption ✓
+
+> Replace legacy transition record issuance and CLI wiring with GateRecord-backed behavior without changing run paths.
+
+> Depends on: legacy-record-migration, runtime-gate-helpers
+
+- [x] 4.1 Replace ApprovalRecord and ClarifyRecord writes in spec, design, and apply transitions with issueGate inputs and GateRecord payloads
+- [x] 4.2 Update phase advancement checks so pending approval and review_decision gates block advancement while clarify gates remain non-blocking by themselves
+- [x] 4.3 Switch CLI and runtime injection sites from LocalFsInteractionRecordStore to LocalFsGateRecordStore
+- [x] 4.4 Add regression tests proving gate_kind, payload, and on-disk record path semantics match legacy behavior apart from the schema rename
+
+## 5. Review Decision Gate Integration ✓
+
+> Emit one review_decision gate per completed review round and link each round summary back to the gate.
+
+> Depends on: runtime-gate-helpers, transition-and-cli-gate-adoption
+
+- [x] 5.1 Update specflow-challenge-proposal to issue a review_decision gate after each completed proposal challenge round
+- [x] 5.2 Update specflow-review-design to issue a review_decision gate carrying review_round_id and findings in the payload
+- [x] 5.3 Update specflow-review-apply to issue a review_decision gate carrying review_round_id and findings in the payload
+- [x] 5.4 Extend ledger round summary persistence to include gate_id while keeping legacy summaries readable when gate_id is absent
+- [x] 5.5 Add tests proving exactly one review_decision gate per round, human-author-only eligibility, and gate_id equality with the ledger round back-reference
+
+## 6. Gate Alias Layer and Change Verification ✓
+
+> Preserve surface-event compatibility through the record_id alias layer and complete archive-level verification for the change.
+
+> Depends on: legacy-record-migration, transition-and-cli-gate-adoption, review-decision-gates
+
+- [x] 6.1 Add recordIdForGate that returns gate.gate_id and route surface-event payload construction through the alias helper
+- [x] 6.2 Add compatibility tests proving payload.record_id remains present and equals gate.gate_id across updated emitters
+- [x] 6.3 Add a follow-up tracking reference for removing the alias from surface-event-contract and workflow-run-state consumers
+- [x] 6.4 Run openspec validate and specflow-spec-verify and resolve any remaining consistency issues required for archive readiness

--- a/openspec/specs/review-orchestration/spec.md
+++ b/openspec/specs/review-orchestration/spec.md
@@ -116,59 +116,42 @@ kind alone or from external runtime-only delegation context.
 
 ### Requirement: Review handoff distinguishes actor kinds in review decisions
 
-Review orchestration SHALL recognize the actor kind of the reviewer when
-processing review outcomes. Review outcomes SHALL remain review-phase decisions
-that are distinct from workflow `approve` and `reject` operations. The mapping
-from review outcome to workflow transition SHALL account for whether the
-reviewer is `human`, `ai-agent`, or `automation`. `automation` actors SHALL NOT
-issue review outcomes and SHALL NOT participate in review phases.
+Review orchestration SHALL recognize the actor kind of the reviewer when processing review outcomes. Review outcomes SHALL remain review-phase decisions that are distinct from workflow `approve` and `reject` operations. The mapping from review outcome to workflow transition SHALL account for whether the reviewer is `human`, `ai-agent`, or `automation`. `automation` actors SHALL NOT issue review outcomes and SHALL NOT participate in review phases. In addition, the authoritative resolver of the round-level `"review_decision"` gate SHALL always be a `human-author` role; AI-agent review outcomes SHALL continue to be recorded in the ledger as advisory metadata but SHALL NOT resolve the gate.
 
 Whenever this requirement refers to "no unresolved high findings", the gate SHALL be evaluated as `unresolvedCriticalHighCount(ledger) == 0` — i.e., the gate covers both `critical` and `high` severities, and ignores `medium` and `low` severities. MEDIUM and LOW findings SHALL NOT block the binding-approval handoff; they remain visible via `handoff.severity_summary` and Remaining Risks aggregation.
 
 #### Scenario: Human reviewer approval is binding
 
 - **WHEN** a `human` reviewer issues `review_approved`
-- **THEN** the review orchestration SHALL treat the outcome as a binding review
-  approval
-- **AND** if `unresolvedCriticalHighCount(ledger) == 0` it SHALL return
-  `handoff.state = "review_approved"` (or `"review_no_findings"` for the
-  apply / design review handoff payload, per the severity-aware gate
-  requirement)
+- **THEN** the review orchestration SHALL treat the outcome as a binding review approval
+- **AND** if `unresolvedCriticalHighCount(ledger) == 0` it SHALL return `handoff.state = "review_approved"` (or `"review_no_findings"` for the apply / design review handoff payload, per the severity-aware gate requirement)
+- **AND** the `"review_decision"` gate for that round SHALL be resolved with `"accept"`
 
 #### Scenario: Undelegated AI-agent reviewer approval is advisory only
 
 - **WHEN** an `ai-agent` reviewer issues `review_approved`
 - **AND** no delegation exists for the current run
 - **THEN** the review orchestration SHALL record the outcome as an advisory recommendation
-- **AND** it SHALL NOT return `handoff.state = "review_approved"` based on
-  this outcome alone
-- **AND** the workflow SHALL NOT advance to the next gated phase based on this
-  outcome alone
+- **AND** it SHALL NOT return `handoff.state = "review_approved"` based on this outcome alone
+- **AND** the workflow SHALL NOT advance to the next gated phase based on this outcome alone
+- **AND** the `"review_decision"` gate SHALL remain `pending` until a `human-author` resolves it
 
 #### Scenario: Delegated AI-agent reviewer approval is binding
 
 - **WHEN** an `ai-agent` reviewer issues `review_approved`
 - **AND** delegation is active for the current run
-- **THEN** the review orchestration SHALL treat the outcome as a binding review
-  approval
-- **AND** if `unresolvedCriticalHighCount(ledger) == 0` it SHALL return
-  `handoff.state = "review_approved"` (or `"review_no_findings"` for the
-  apply / design review handoff payload, per the severity-aware gate
-  requirement)
-- **AND** unresolved findings whose `severity ∈ {medium, low}` SHALL NOT
-  prevent this binding handoff
+- **THEN** the review orchestration SHALL treat the outcome as a binding review approval
+- **AND** if `unresolvedCriticalHighCount(ledger) == 0` it SHALL return `handoff.state = "review_approved"` (or `"review_no_findings"` for the apply / design review handoff payload, per the severity-aware gate requirement)
+- **AND** unresolved findings whose `severity ∈ {medium, low}` SHALL NOT prevent this binding handoff
+- **AND** the `"review_decision"` gate SHALL remain `pending` until a `human-author` resolves it, because gate resolution is always bound to the `human-author` role even when delegated AI approval is the binding review outcome
 
 #### Scenario: Request-changes outcome requires a phase revision
 
-- **WHEN** a `human` reviewer or an `ai-agent` reviewer issues
-  `request_changes`
-- **THEN** the review orchestration SHALL return a non-approved handoff for the
-  current phase
-- **AND** the handoff SHALL require the phase-appropriate revise transition
-  (`revise_design` or `revise_apply`) before the next
-  review round
-- **AND** delegation SHALL NOT change this mapping because `request_changes` is
-  a review-phase outcome, not a gated workflow approval
+- **WHEN** a `human` reviewer or an `ai-agent` reviewer issues `request_changes`
+- **THEN** the review orchestration SHALL return a non-approved handoff for the current phase
+- **AND** the handoff SHALL require the phase-appropriate revise transition (`revise_design` or `revise_apply`) before the next review round
+- **AND** delegation SHALL NOT change this mapping because `request_changes` is a review-phase outcome, not a gated workflow approval
+- **AND** when resolved by a `human-author`, the corresponding `"review_decision"` gate SHALL be resolved with `"request_changes"`, which maps to the phase-appropriate revise workflow event
 
 #### Scenario: AI-agent block is overridable in the ledger
 
@@ -190,12 +173,9 @@ Whenever this requirement refers to "no unresolved high findings", the gate SHAL
 
 #### Scenario: Automation evidence is advisory only
 
-- **WHEN** an automation source emits CI, webhook, or batch evidence during a
-  review phase
-- **THEN** the review orchestration MAY surface or persist that evidence for a
-  reviewer
-- **AND** it SHALL NOT treat the automation source as the reviewer or as a
-  review outcome
+- **WHEN** an automation source emits CI, webhook, or batch evidence during a review phase
+- **THEN** the review orchestration MAY surface or persist that evidence for a reviewer
+- **AND** it SHALL NOT treat the automation source as the reviewer or as a review outcome
 
 ### Requirement: Review ledger records reviewer actor and binding provenance
 
@@ -378,4 +358,74 @@ The review runtime SHALL expose a single ledger helper, `unresolvedCriticalHighC
 
 - **WHEN** `unresolvedCriticalHighCount` is invoked on a ledger with a `critical` open finding and a `high` open finding
 - **THEN** the helper SHALL return `2`
+
+### Requirement: Each completed review round issues a review_decision gate
+
+Every completed review round SHALL result in the core runtime issuing exactly one `"review_decision"` gate, as defined by `workflow-gate-semantics`. A review round is defined as a single invocation of `specflow-challenge-proposal challenge`, `specflow-review-design review`, or `specflow-review-apply review` that produces a ledger snapshot with a bounded set of findings (or, for proposal challenge, a bounded set of challenge questions).
+
+Individual findings SHALL NOT produce their own gates. All findings for the round SHALL be carried as `payload.findings` on the single `"review_decision"` gate issued for that round. The `payload` SHALL additionally include `review_round_id` identifying the ledger round, the `reviewer_actor` / `reviewer_actor_id` provenance values persisted in the round summary, and the `approval_binding` value recorded for that round.
+
+#### Scenario: Proposal challenge issues a single review_decision gate per round
+
+- **WHEN** `specflow-challenge-proposal challenge <CHANGE_ID>` completes
+- **THEN** the runtime SHALL issue one `"review_decision"` gate with `originating_phase: "proposal_challenge"`
+- **AND** the gate's `payload.findings` SHALL contain the challenge questions for that round
+
+#### Scenario: Design review issues a single review_decision gate per round
+
+- **WHEN** `specflow-review-design review <CHANGE_ID>` completes a review round
+- **THEN** the runtime SHALL issue one `"review_decision"` gate with `originating_phase: "design_review"`
+- **AND** the gate's `payload.findings` SHALL contain the design findings for that round
+
+#### Scenario: Apply review issues a single review_decision gate per round
+
+- **WHEN** `specflow-review-apply review <CHANGE_ID>` completes a review round
+- **THEN** the runtime SHALL issue one `"review_decision"` gate with `originating_phase: "apply_review"`
+- **AND** the gate's `payload.findings` SHALL contain the apply findings for that round
+
+#### Scenario: Findings do not generate individual gates
+
+- **WHEN** a review round produces multiple findings (critical, high, medium, low)
+- **THEN** no per-finding `"review_decision"` gate SHALL be created
+- **AND** all findings SHALL appear in the single round-level gate's `payload.findings`
+
+### Requirement: Review_decision gates are resolved exclusively by human-author role
+
+The runtime SHALL set `eligible_responder_roles = ["human-author"]` on every `"review_decision"` gate regardless of the review phase that produced it. AI-agent actors SHALL continue to generate review findings and MAY populate advisory metadata in the ledger, but SHALL NOT resolve any `"review_decision"` gate.
+
+Responses from non-`human-author` roles SHALL be rejected; the gate SHALL remain `pending` and its fields SHALL remain unchanged. This requirement is consistent with the existing review-orchestration rule that an undelegated AI-agent approval is advisory only.
+
+#### Scenario: Human-author resolves the review_decision gate
+
+- **WHEN** a `"review_decision"` gate is pending
+- **AND** a responder whose role is `human-author` submits `"accept"`, `"reject"`, or `"request_changes"`
+- **THEN** the runtime SHALL resolve the gate
+
+#### Scenario: AI-agent response to a review_decision gate is rejected
+
+- **WHEN** an `ai-agent` responder submits any response to a pending `"review_decision"` gate
+- **THEN** the runtime SHALL reject the response
+- **AND** the gate SHALL remain `pending`
+- **AND** the ledger SHALL still record the AI-agent's review findings as advisory metadata for that round
+
+#### Scenario: Automation response to a review_decision gate is rejected
+
+- **WHEN** an `automation` actor attempts to submit any response to a pending `"review_decision"` gate
+- **THEN** the runtime SHALL reject the response
+- **AND** the gate SHALL remain `pending`
+
+### Requirement: Review ledger persists the issuing gate id for each review round
+
+Each review ledger round summary SHALL persist the `gate_id` of the `"review_decision"` gate issued for that round. Consumers SHALL be able to traverse from a ledger round to its gate without ambiguity, and the gate's `payload.review_round_id` SHALL reference the same round id recorded in the ledger snapshot.
+
+#### Scenario: Ledger round summary records the issuing gate id
+
+- **WHEN** a review round is appended to the ledger
+- **THEN** the round summary SHALL include a `gate_id` field pointing to the `"review_decision"` gate issued for that round
+
+#### Scenario: Gate payload back-references the ledger round id
+
+- **WHEN** a `"review_decision"` gate is created
+- **THEN** its `payload.review_round_id` SHALL equal the ledger's round identifier for the same round
+- **AND** the ledger's round summary SHALL include the same `gate_id` for round-level traversal
 

--- a/openspec/specs/workflow-gate-semantics/spec.md
+++ b/openspec/specs/workflow-gate-semantics/spec.md
@@ -1,0 +1,250 @@
+# workflow-gate-semantics Specification
+
+## Purpose
+TBD - created by archiving change define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects. Update Purpose after archive.
+## Requirements
+### Requirement: Gate is a first-class persistent workflow object
+
+The system SHALL define **Gate** as a first-class persistent workflow object representing a pending decision point in a run. A Gate SHALL exist independently of any surface (CLI, UI, server) and any specific actor identity. A Gate SHALL be created by the workflow core runtime whenever a phase transition requires a gated decision, and SHALL persist until it reaches a terminal status (`resolved` or `superseded`).
+
+Each Gate SHALL include the following fields:
+- `gate_id`: A unique identifier for this gate (required).
+- `gate_kind`: One of `"approval"`, `"clarify"`, or `"review_decision"` (required).
+- `run_id`: The run this gate belongs to (required).
+- `originating_phase`: The workflow phase that produced this gate (required).
+- `status`: One of `"pending"`, `"resolved"`, or `"superseded"` (required).
+- `reason`: A short human-readable string describing why the gate is open (required).
+- `payload`: A kind-specific structured object containing the detailed context needed to answer the gate (required, schema varies by `gate_kind`).
+- `eligible_responder_roles`: A non-empty set of actor role identifiers indicating who may resolve the gate (required).
+- `allowed_responses`: The fixed list of response tokens the gate accepts, determined by `gate_kind` (required).
+- `created_at`: ISO 8601 timestamp when the gate entered `pending` (required).
+- `resolved_at`: ISO 8601 timestamp when the gate reached `resolved` or `superseded` (required once non-pending, null otherwise).
+- `decision_actor`: The actor identity that resolved the gate (required once `resolved`, null otherwise; always null when `superseded`).
+- `event_ids`: An ordered array of surface event ids associated with the gate's history (required, may be empty when first created).
+
+#### Scenario: Gate is created when a gated phase transition requires a decision
+
+- **WHEN** the workflow core processes a transition that requires an approval, a clarification, or a review decision
+- **THEN** the runtime SHALL create a Gate with `status: "pending"` and `resolved_at: null` before surfacing the stop point to any surface
+- **AND** the gate SHALL carry the `originating_phase` matching the phase that produced it
+
+#### Scenario: Gate object is surface-agnostic
+
+- **WHEN** a surface (CLI, UI, or server runtime) reads the current run state
+- **THEN** it SHALL be able to list all pending gates using only the Gate schema fields
+- **AND** the gate definition SHALL NOT depend on any surface-specific field (button labels, UI copy, transport identifiers)
+
+### Requirement: Gate kinds are limited to approval, clarify, and review_decision
+
+The system SHALL support exactly three gate kinds. No other `gate_kind` value SHALL be accepted by the runtime.
+
+- `"approval"`: Represents an approval-required stop point (e.g., `spec_ready`, `design_ready`, `apply_ready`). The payload SHALL include the phase pair (`phase_from`, `phase_to`) being gated.
+- `"clarify"`: Represents a single clarification question issued by the workflow. The payload SHALL include the question text and any additional question context.
+- `"review_decision"`: Represents a human decision on a completed review round. The payload SHALL include the review round id and the findings snapshot for that round.
+
+#### Scenario: Unknown gate kind is rejected at creation
+
+- **WHEN** the runtime receives a request to create a gate with `gate_kind` outside the set `{approval, clarify, review_decision}`
+- **THEN** the runtime SHALL reject the creation
+- **AND** no gate record SHALL be persisted
+
+### Requirement: Gate lifecycle supports pending, resolved, and superseded
+
+Every Gate SHALL transition through a finite state machine with exactly three states: `pending`, `resolved`, and `superseded`. `pending` is the initial state. `resolved` and `superseded` are terminal states: once a gate leaves `pending`, its status SHALL NOT change again.
+
+- `pending` → `resolved`: triggered by a valid response received through `allowed_responses`. The resolution SHALL populate `resolved_at` and `decision_actor`.
+- `pending` → `superseded`: triggered when the runtime creates a new gate with the same `gate_kind` and `originating_phase` for the same run while the prior gate is still pending. The prior gate SHALL be marked `superseded`, `resolved_at` SHALL be populated, and `decision_actor` SHALL remain null.
+
+Superseded gates SHALL NOT be counted as pending gates and SHALL NOT be treated as resolved decisions; they SHALL remain in persistence for history only.
+
+#### Scenario: Valid response resolves the gate
+
+- **WHEN** a responder submits a valid response for a pending gate
+- **THEN** the runtime SHALL transition the gate to `resolved`
+- **AND** `resolved_at` SHALL be set to the current timestamp
+- **AND** `decision_actor` SHALL be set to the responder's actor identity
+
+#### Scenario: New gate of same kind in same originating phase supersedes the prior pending gate
+
+- **WHEN** a gate with `gate_kind: K` is `pending` for `originating_phase: P` in a run
+- **AND** the runtime creates a new gate with the same `gate_kind: K` and the same `originating_phase: P` for the same run
+- **THEN** the prior pending gate SHALL transition to `superseded`
+- **AND** `resolved_at` SHALL be set on the superseded gate
+- **AND** `decision_actor` SHALL remain null on the superseded gate
+
+#### Scenario: Terminal states are immutable
+
+- **WHEN** a gate is in `resolved` or `superseded` status
+- **THEN** no subsequent response or transition SHALL change its status
+- **AND** attempts to resolve a non-pending gate SHALL be rejected
+
+#### Scenario: Superseded gates are excluded from pending listings
+
+- **WHEN** a surface lists pending gates for a run
+- **THEN** gates with `status: "superseded"` SHALL NOT appear in the pending list
+- **AND** they SHALL remain retrievable for history / audit purposes
+
+### Requirement: Allowed responses are fixed per gate kind
+
+The runtime SHALL use a fixed `allowed_responses` set determined by `gate_kind`. The sets SHALL NOT vary by `originating_phase` or by gate instance.
+
+- `"approval"` → `["accept", "reject"]`
+- `"clarify"` → `["clarify_response"]`
+- `"review_decision"` → `["accept", "reject", "request_changes"]`
+
+Any response token outside the set for the given gate kind SHALL be rejected as invalid. A rejected response SHALL NOT change the gate's status; the gate SHALL remain `pending`.
+
+#### Scenario: Approval gate accepts accept and reject only
+
+- **WHEN** an `"approval"` gate receives a response of `"accept"` or `"reject"`
+- **THEN** the runtime SHALL transition the gate to `resolved`
+
+#### Scenario: Clarify gate accepts clarify_response only
+
+- **WHEN** a `"clarify"` gate receives a response of `"clarify_response"`
+- **THEN** the runtime SHALL transition the gate to `resolved`
+
+#### Scenario: Review_decision gate accepts accept, reject, and request_changes
+
+- **WHEN** a `"review_decision"` gate receives `"accept"`, `"reject"`, or `"request_changes"`
+- **THEN** the runtime SHALL transition the gate to `resolved`
+
+#### Scenario: Invalid response is rejected and leaves the gate pending
+
+- **WHEN** a gate receives a response token outside its kind's `allowed_responses`
+- **THEN** the runtime SHALL return an error describing the invalid response
+- **AND** the gate SHALL remain `pending` with unchanged fields
+- **AND** no `event_ids` entry SHALL be appended for the rejected attempt
+
+### Requirement: Gate responses map deterministically to handoff signals
+
+Each gate response SHALL map to exactly one handoff signal that the runtime produces as part of the same synchronous resolution. The mapping SHALL be deterministic and SHALL NOT depend on actor identity beyond eligibility checks.
+
+For `approval` gates, the handoff signal is an **existing transition handler entry point** (`accept_spec`, `accept_design`, `accept_apply`, `reject`) already defined by the runtime's transition handler implementations.
+
+For `review_decision` gates, the handoff signal is a **review-orchestration handoff outcome** (`handoff.state` value), consistent with review-orchestration's requirement that review outcomes are distinct from workflow approve/reject operations. The `request_changes` handoff additionally specifies the phase-appropriate revise transition (`revise_proposal` / `revise_design` / `revise_apply`) that existing transition handlers already support.
+
+For `clarify` gates, the handoff signal is `clarify_response`, which keeps the run in its current phase.
+
+- `approval.accept` → `accept_spec` / `accept_design` / `accept_apply` (determined by `originating_phase`)
+- `approval.reject` → `reject`
+- `clarify.clarify_response` → `clarify_response` (keeps the run in its current phase, appends the answer)
+- `review_decision.accept` → `handoff.state = review_approved` (review round closes; the run proceeds to the downstream approval gate)
+- `review_decision.reject` → `handoff.state = review_rejected` (review-level rejection, distinct from the approval-level `reject` transition)
+- `review_decision.request_changes` → `handoff.state = request_changes` → `revise_proposal` / `revise_design` / `revise_apply` (determined by `originating_phase`)
+
+#### Scenario: Approval response produces the phase-appropriate accept signal
+
+- **WHEN** an `"approval"` gate with `originating_phase: "spec_ready"` is resolved with `"accept"`
+- **THEN** the runtime SHALL produce the `accept_spec` handoff signal in the same transition
+
+#### Scenario: Review request_changes maps to the phase-appropriate revise handoff
+
+- **WHEN** a `"review_decision"` gate with `originating_phase: "design_review"` is resolved with `"request_changes"`
+- **THEN** the runtime SHALL produce a `handoff.state = request_changes` signal that maps to the `revise_design` transition
+
+#### Scenario: Review reject produces a review-level rejection handoff distinct from approval reject
+
+- **WHEN** a `"review_decision"` gate is resolved with `"reject"`
+- **THEN** the runtime SHALL produce a `handoff.state = review_rejected` signal
+- **AND** this signal SHALL be distinct from the `reject` transition produced by `approval.reject`
+
+#### Scenario: Clarify response does not change phase
+
+- **WHEN** a `"clarify"` gate is resolved with `"clarify_response"`
+- **THEN** the run SHALL remain in its current phase
+- **AND** the clarification answer SHALL be persisted as part of the gate's resolution
+
+### Requirement: Concurrency rules limit approval and review gates to one pending per phase
+
+Within a single run, the runtime SHALL enforce the following concurrency rules:
+
+- A phase MAY have multiple `"clarify"` gates pending concurrently.
+- A phase SHALL have at most one pending `"approval"` gate at a time.
+- A phase SHALL have at most one pending `"review_decision"` gate at a time.
+
+While a run has a pending `"approval"` or `"review_decision"` gate, the runtime SHALL NOT advance the run to a subsequent phase. Pending `"clarify"` gates SHALL NOT block phase transitions by themselves, except where a phase's own acceptance criteria require clarify resolution.
+
+#### Scenario: Multiple clarify gates can coexist in one phase
+
+- **WHEN** a phase issues three clarification questions in sequence
+- **THEN** three `"clarify"` gates SHALL exist concurrently with `status: "pending"`
+- **AND** each SHALL resolve independently when answered
+
+#### Scenario: Second approval gate in same phase supersedes the first
+
+- **WHEN** an `"approval"` gate is pending for `originating_phase: P`
+- **AND** the runtime creates a new `"approval"` gate for the same `originating_phase: P` in the same run
+- **THEN** the prior gate SHALL transition to `superseded`
+- **AND** only one `"approval"` gate SHALL remain `pending` for that phase
+
+#### Scenario: Pending approval blocks phase advancement
+
+- **WHEN** a run has any pending `"approval"` gate
+- **THEN** the runtime SHALL NOT apply a transition that advances the run into the next phase
+- **AND** the gate SHALL be resolved before advancement becomes possible
+
+### Requirement: Eligible responders are expressed as actor roles
+
+The `eligible_responder_roles` field SHALL contain a non-empty set of role identifiers defined by `actor-surface-model` (for example: `human-author`, `ai-agent`, `reviewer`). The runtime SHALL NOT encode specific actor identities in `eligible_responder_roles`; identity-level resolution remains a future extension point.
+
+A response SHALL be accepted only if the responding actor's active role intersects `eligible_responder_roles`. Responses from actors whose roles do not intersect SHALL be rejected, and the gate SHALL remain `pending`.
+
+#### Scenario: Responder role matches eligible roles
+
+- **WHEN** a responder whose active role is in `eligible_responder_roles` submits a valid response
+- **THEN** the runtime SHALL accept the response and resolve the gate
+
+#### Scenario: Responder role does not match eligible roles
+
+- **WHEN** a responder whose active role is NOT in `eligible_responder_roles` submits a response
+- **THEN** the runtime SHALL reject the response
+- **AND** the gate SHALL remain `pending`
+
+### Requirement: Review_decision gates are issued per review round and resolved by human-author
+
+The runtime SHALL create exactly one `"review_decision"` gate per completed review round. A review round is defined as a single invocation of `specflow-challenge-proposal`, `specflow-review-design`, or `specflow-review-apply` that produces a set of findings. Individual findings SHALL NOT generate their own gates; they SHALL be represented inside the gate's `payload.findings` array.
+
+All `"review_decision"` gates SHALL set `eligible_responder_roles = ["human-author"]` regardless of the review phase (`proposal_challenge`, `design_review`, or `apply_review`). AI-agent actors MAY generate review findings and MAY emit advisory opinions through the ledger, but they SHALL NOT resolve `"review_decision"` gates.
+
+#### Scenario: One review_decision gate per review round
+
+- **WHEN** a review round (proposal challenge, design review, or apply review) completes
+- **THEN** the runtime SHALL create exactly one `"review_decision"` gate with the round's findings in `payload.findings`
+- **AND** no per-finding gate SHALL be created
+
+#### Scenario: Human-author is the only eligible responder for review decisions
+
+- **WHEN** a `"review_decision"` gate is created
+- **THEN** `eligible_responder_roles` SHALL equal `["human-author"]`
+- **AND** any response submitted by an actor whose role is not `human-author` SHALL be rejected
+
+#### Scenario: AI-agent findings are represented in payload, not as gates
+
+- **WHEN** an AI-agent review produces findings during a review round
+- **THEN** the findings SHALL appear in the resulting `"review_decision"` gate's `payload.findings`
+- **AND** no separate gate SHALL be created per finding
+
+### Requirement: Gate history is derived from event_ids and is surface-agnostic
+
+Each gate's `event_ids` array SHALL reference surface events (as defined by `surface-event-contract`) that relate to the gate's lifecycle: creation, responses (including rejected ones that produced errors, if the surface chose to emit them), and resolution. The gate object itself SHALL carry enough state (`status`, `resolved_at`, `decision_actor`) for a surface to display the gate's current position without replaying the event stream.
+
+The runtime SHALL NOT require a specific transport to deliver gate state; any surface that can read the persisted gate and the referenced events SHALL be able to render gate history faithfully.
+
+#### Scenario: Gate state is self-sufficient for rendering current position
+
+- **WHEN** a surface reads a gate record from persistence
+- **THEN** it SHALL be able to display the gate's current status, reason, and decision (if any) without reading any other resource
+
+#### Scenario: Event_ids link the gate to its surface history
+
+- **WHEN** a gate is resolved
+- **THEN** the resolution event's id SHALL be appended to `event_ids`
+- **AND** consumers that read the event store SHALL be able to reconstruct the timeline of the gate's life
+
+#### Scenario: Superseded gates retain their history
+
+- **WHEN** a gate transitions to `superseded`
+- **THEN** its `event_ids` SHALL remain intact and queryable
+- **AND** surfaces SHALL be able to display the superseded gate as part of historical audit views
+

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"specflow-review-design": "bin/specflow-review-design",
 		"specflow-challenge-proposal": "bin/specflow-challenge-proposal",
 		"specflow-generate-task-graph": "bin/specflow-generate-task-graph",
+		"specflow-migrate-records": "bin/specflow-migrate-records",
 		"specflow-run": "bin/specflow-run",
 		"specflow-spec-verify": "bin/specflow-spec-verify"
 	},

--- a/src/bin/specflow-challenge-proposal.ts
+++ b/src/bin/specflow-challenge-proposal.ts
@@ -1,7 +1,13 @@
 import type { ChangeArtifactStore } from "../lib/artifact-store.js";
 import { tryGit } from "../lib/git.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
+import {
+	issueReviewDecisionGate,
+	type ReviewRoundProvenance,
+} from "../lib/review-decision-gate.js";
 import {
 	buildPrompt,
 	callReviewAgent,
@@ -13,7 +19,9 @@ import {
 	resolveReviewAgent,
 	validateChangeFromStore,
 } from "../lib/review-runtime.js";
+import { findLatestRun } from "../lib/run-store-ops.js";
 import type { ChallengeResult } from "../types/contracts.js";
+import type { ReviewFindingSnapshot } from "../types/gate-records.js";
 
 function notInGitRepo(): never {
 	process.stdout.write('{"status":"error","error":"not_in_git_repo"}\n');
@@ -135,6 +143,73 @@ function parseReviewAgentFlag(args: readonly string[]): string | undefined {
 	return undefined;
 }
 
+function parseRunIdFlag(args: readonly string[]): string | undefined {
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] === "--run-id") {
+			return args[index + 1];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Issue a review_decision gate for a completed proposal challenge round.
+ * Best-effort: returns null on failure.
+ */
+function tryIssueChallengeGate(
+	projectRoot: string,
+	runId: string,
+	challenges: readonly {
+		id: string;
+		category: string;
+		question: string;
+		context: string;
+	}[],
+	reviewAgent: ReviewAgentName,
+): string | null {
+	try {
+		const store = createLocalFsGateRecordStore(projectRoot);
+		// Derive the next round number from existing proposal_challenge gates
+		// so re-running the challenge CLI creates distinct gates per round.
+		const existingGates = store.list(runId);
+		const challengeRound =
+			existingGates.filter(
+				(g) =>
+					g.gate_kind === "review_decision" &&
+					g.originating_phase === "proposal_challenge",
+			).length + 1;
+		const gateId = `review_decision-${runId}-challenge-${challengeRound}`;
+		const findings: ReviewFindingSnapshot[] = challenges.map((c) => ({
+			id: c.id,
+			severity: "medium" as const,
+			status: "new",
+			title: c.question,
+		}));
+		const provenance: ReviewRoundProvenance = {
+			run_id: runId,
+			review_phase: "proposal_challenge",
+			review_round_id: `proposal_challenge-round-${challengeRound}`,
+			findings,
+			reviewer_actor: "ai-agent",
+			reviewer_actor_id: reviewAgent,
+			approval_binding: "advisory",
+		};
+		const gate = issueReviewDecisionGate(provenance, {
+			store,
+			projectRoot,
+			gateId,
+			createdAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+		});
+		return gate.gate_id;
+	} catch (cause) {
+		const message = cause instanceof Error ? cause.message : String(cause);
+		process.stderr.write(
+			`Warning: failed to issue review_decision gate: ${message}\n`,
+		);
+		return null;
+	}
+}
+
 async function main(): Promise<void> {
 	const projectRoot = ensureGitRepo();
 	loadConfigEnv(projectRoot);
@@ -142,14 +217,28 @@ async function main(): Promise<void> {
 	const runtimeRoot = moduleRepoRoot(import.meta.url);
 	const [subcommand = "", ...args] = process.argv.slice(2);
 	const agent = resolveReviewAgent(parseReviewAgentFlag(args));
+	let runId = parseRunIdFlag(args);
 
 	if (subcommand !== "challenge") {
-		die("Usage: specflow-challenge-proposal challenge <CHANGE_ID> [options]");
+		die(
+			"Usage: specflow-challenge-proposal challenge <CHANGE_ID> [--run-id <id>] [options]",
+		);
 	}
 
-	const changeId = args[0];
+	const changeId = args.find((a) => !a.startsWith("-"));
 	if (!changeId) {
-		die("Usage: specflow-challenge-proposal challenge <CHANGE_ID>");
+		die(
+			"Usage: specflow-challenge-proposal challenge <CHANGE_ID> [--run-id <id>]",
+		);
+	}
+
+	// Auto-discover run_id when --run-id is not provided.
+	if (!runId) {
+		const runStore = createLocalFsRunArtifactStore(projectRoot);
+		const latest = await findLatestRun(runStore, changeId);
+		if (latest) {
+			runId = latest.run_id;
+		}
 	}
 
 	const result = await runChallenge(
@@ -159,7 +248,20 @@ async function main(): Promise<void> {
 		changeId,
 		agent,
 	);
-	printSchemaJson("challenge-proposal-result", result);
+
+	// Issue a review_decision gate if a run_id was provided and the
+	// challenge succeeded with actual challenges.
+	let gateId: string | null = null;
+	if (runId && result.status === "success" && result.challenges.length > 0) {
+		gateId = tryIssueChallengeGate(
+			projectRoot,
+			runId,
+			result.challenges,
+			agent,
+		);
+	}
+
+	printSchemaJson("challenge-proposal-result", { ...result, gate_id: gateId });
 }
 
 main();

--- a/src/bin/specflow-migrate-records.ts
+++ b/src/bin/specflow-migrate-records.ts
@@ -1,0 +1,54 @@
+import { runMigration } from "../lib/migrate-records.js";
+
+function main(): void {
+	const args = process.argv.slice(2);
+	let mode: "forward" | "undo" = "forward";
+	let all = false;
+	const runIds: string[] = [];
+	for (let i = 0; i < args.length; i += 1) {
+		const a = args[i];
+		if (a === "--undo") {
+			mode = "undo";
+		} else if (a === "--all") {
+			all = true;
+		} else if (a === "--run") {
+			const v = args[i + 1];
+			if (!v) {
+				process.stderr.write("Missing value for --run\n");
+				process.exit(1);
+			}
+			runIds.push(v);
+			i += 1;
+		} else if (a === "-h" || a === "--help") {
+			usage();
+			process.exit(0);
+		} else {
+			process.stderr.write(`Unknown argument: ${a}\n`);
+			usage();
+			process.exit(1);
+		}
+	}
+
+	if (!all && runIds.length === 0) {
+		usage();
+		process.exit(1);
+	}
+
+	const root = process.cwd();
+	const result = runMigration(root, {
+		mode,
+		runIds: all ? undefined : runIds,
+	});
+	process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+	const hasError = result.perRun.some((r) => r.status === "error");
+	process.exit(hasError ? 1 : 0);
+}
+
+function usage(): void {
+	process.stderr.write(
+		"Usage: specflow-migrate-records [--all | --run <run-id> ...] [--undo]\n",
+	);
+}
+
+main();

--- a/src/bin/specflow-review-apply.ts
+++ b/src/bin/specflow-review-apply.ts
@@ -2,8 +2,15 @@ import { resolve } from "node:path";
 import type { ChangeArtifactStore } from "../lib/artifact-store.js";
 import { ReviewLedgerKind } from "../lib/artifact-types.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { createLocalWorkspaceContext } from "../lib/local-workspace-context.js";
 import { moduleRepoRoot, printSchemaJson, tryExec } from "../lib/process.js";
+import {
+	issueReviewDecisionGate,
+	type ReviewPhase,
+	type ReviewRoundProvenance,
+} from "../lib/review-decision-gate.js";
 import {
 	actionableCount,
 	computeScore,
@@ -15,6 +22,7 @@ import {
 	matchFindings,
 	matchRereview,
 	openHighFindings,
+	patchLatestRoundGateId,
 	persistMaxFindingId,
 	readLedgerFromStore,
 	resolvedHighFindingTitles,
@@ -40,6 +48,7 @@ import {
 	resolveReviewAgent,
 	validateChangeFromStore,
 } from "../lib/review-runtime.js";
+import { findLatestRun } from "../lib/run-store-ops.js";
 import type { WorkspaceContext } from "../lib/workspace-context.js";
 import type {
 	AutofixRoundScore,
@@ -50,6 +59,7 @@ import type {
 	ReviewPayload,
 	ReviewResult,
 } from "../types/contracts.js";
+import type { ReviewFindingSnapshot } from "../types/gate-records.js";
 
 function notInGitRepo(): never {
 	process.stdout.write('{"status":"error","error":"not_in_git_repo"}\n');
@@ -203,6 +213,7 @@ async function runReviewPipeline(
 	skipDiffCheck: boolean,
 	reviewAgent: ReviewAgentName,
 	mainAgent: MainAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	process.stderr.write("Running diff filter...\n");
 	const rawDiff = diffFilter(ctx);
@@ -387,17 +398,43 @@ async function runReviewPipeline(
 		);
 	}
 
-	return resultFromLedger(
-		action,
-		changeId,
-		reviewJson,
-		rereviewMode,
-		parseError,
-		rawResponse,
-		ledger,
-		diffSummary,
-		config.diffWarnThreshold,
-	);
+	// Issue a review_decision gate if a run_id was provided.
+	let gateId: string | null = null;
+	if (runId && !parseError) {
+		gateId = tryIssueReviewDecisionGate(
+			projectRoot,
+			runId,
+			"apply_review",
+			ledger,
+			reviewAgent,
+		);
+		// Write gate_id back into the ledger's latest round summary (D10 step 3).
+		if (gateId) {
+			ledger = patchLatestRoundGateId(ledger, gateId);
+			await writeLedgerToStore(
+				changeStore,
+				changeId,
+				ReviewLedgerKind.Apply,
+				ledger,
+				true,
+			);
+		}
+	}
+
+	return {
+		...resultFromLedger(
+			action,
+			changeId,
+			reviewJson,
+			rereviewMode,
+			parseError,
+			rawResponse,
+			ledger,
+			diffSummary,
+			config.diffWarnThreshold,
+		),
+		gate_id: gateId,
+	};
 }
 
 async function runAutofixLoop(
@@ -409,6 +446,7 @@ async function runAutofixLoop(
 	maxRounds: number,
 	reviewAgent: ReviewAgentName,
 	mainAgent: MainAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	let ledger = (
 		await readLedgerFromStore(changeStore, changeId, ReviewLedgerKind.Apply)
@@ -420,6 +458,7 @@ async function runAutofixLoop(
 	let consecutiveFailures = 0;
 	let autofixRound = 0;
 	let loopResult = "max_rounds_reached";
+	let lastSuccessfulGateId: string | null = null;
 	const roundScores: AutofixRoundScore[] = [];
 	const divergenceWarnings: DivergenceWarning[] = [];
 
@@ -470,6 +509,7 @@ async function runAutofixLoop(
 			true,
 			reviewAgent,
 			mainAgent,
+			runId,
 		);
 		if (reviewResult.status === "error" || reviewResult.review?.parse_error) {
 			consecutiveFailures += 1;
@@ -484,6 +524,8 @@ async function runAutofixLoop(
 		}
 
 		consecutiveFailures = 0;
+		// Track the gate_id emitted by this round's review pipeline.
+		lastSuccessfulGateId = reviewResult.gate_id ?? null;
 		ledger = (
 			await readLedgerFromStore(changeStore, changeId, ReviewLedgerKind.Apply)
 		).ledger;
@@ -561,6 +603,11 @@ async function runAutofixLoop(
 		);
 	}
 
+	// Gate emission is handled per-round inside runReviewPipeline (which
+	// receives runId). We only propagate the gate_id from the last
+	// *successful* review round — no unconditional emission at loop exit.
+	const gateId = lastSuccessfulGateId;
+
 	const actionable = actionableCount(ledger);
 	// Severity-aware handoff: the loop state is "clean" when no
 	// critical/high findings remain. LOW/MEDIUM may still be present and
@@ -583,6 +630,7 @@ async function runAutofixLoop(
 			actionable_count: actionable,
 			severity_summary: severitySummary(ledger),
 		},
+		gate_id: gateId,
 		error: null,
 	};
 }
@@ -595,6 +643,7 @@ async function cmdReview(
 	args: readonly string[],
 	reviewAgent: ReviewAgentName,
 	mainAgent: MainAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	let changeId = "";
 	let skipDiffCheck = false;
@@ -604,58 +653,7 @@ async function cmdReview(
 			skipDiffCheck = true;
 			continue;
 		}
-		if (arg === "--review-agent") {
-			index += 1;
-			continue;
-		}
-		if (arg.startsWith("-")) {
-			die(`Error: unknown option '${arg}'`);
-		}
-		if (!changeId) {
-			changeId = arg;
-			continue;
-		}
-		die(`Error: unexpected argument '${arg}'`);
-	}
-	if (!changeId) {
-		die("Usage: specflow-review-apply review <CHANGE_ID> [--skip-diff-check]");
-	}
-	await validateChangeFromStore(changeStore, changeId);
-	return await runReviewPipeline(
-		runtimeRoot,
-		projectRoot,
-		ctx,
-		changeStore,
-		"review",
-		changeId,
-		false,
-		skipDiffCheck,
-		reviewAgent,
-		mainAgent,
-	);
-}
-
-async function cmdFixReview(
-	runtimeRoot: string,
-	projectRoot: string,
-	ctx: WorkspaceContext,
-	changeStore: ChangeArtifactStore,
-	args: readonly string[],
-	reviewAgent: ReviewAgentName,
-	mainAgent: MainAgentName,
-): Promise<ReviewResult> {
-	let changeId = "";
-	let skipDiffCheck = false;
-	for (let index = 0; index < args.length; index += 1) {
-		const arg = args[index];
-		if (arg === "--autofix") {
-			continue;
-		}
-		if (arg === "--skip-diff-check") {
-			skipDiffCheck = true;
-			continue;
-		}
-		if (arg === "--review-agent") {
+		if (arg === "--review-agent" || arg === "--run-id") {
 			index += 1;
 			continue;
 		}
@@ -670,7 +668,62 @@ async function cmdFixReview(
 	}
 	if (!changeId) {
 		die(
-			"Usage: specflow-review-apply fix-review <CHANGE_ID> [--autofix] [--skip-diff-check]",
+			"Usage: specflow-review-apply review <CHANGE_ID> [--skip-diff-check] [--run-id <id>]",
+		);
+	}
+	await validateChangeFromStore(changeStore, changeId);
+	return await runReviewPipeline(
+		runtimeRoot,
+		projectRoot,
+		ctx,
+		changeStore,
+		"review",
+		changeId,
+		false,
+		skipDiffCheck,
+		reviewAgent,
+		mainAgent,
+		runId,
+	);
+}
+
+async function cmdFixReview(
+	runtimeRoot: string,
+	projectRoot: string,
+	ctx: WorkspaceContext,
+	changeStore: ChangeArtifactStore,
+	args: readonly string[],
+	reviewAgent: ReviewAgentName,
+	mainAgent: MainAgentName,
+	runId?: string,
+): Promise<ReviewResult> {
+	let changeId = "";
+	let skipDiffCheck = false;
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === "--autofix") {
+			continue;
+		}
+		if (arg === "--skip-diff-check") {
+			skipDiffCheck = true;
+			continue;
+		}
+		if (arg === "--review-agent" || arg === "--run-id") {
+			index += 1;
+			continue;
+		}
+		if (arg.startsWith("-")) {
+			die(`Error: unknown option '${arg}'`);
+		}
+		if (!changeId) {
+			changeId = arg;
+			continue;
+		}
+		die(`Error: unexpected argument '${arg}'`);
+	}
+	if (!changeId) {
+		die(
+			"Usage: specflow-review-apply fix-review <CHANGE_ID> [--autofix] [--skip-diff-check] [--run-id <id>]",
 		);
 	}
 	await validateChangeFromStore(changeStore, changeId);
@@ -685,6 +738,7 @@ async function cmdFixReview(
 		skipDiffCheck,
 		reviewAgent,
 		mainAgent,
+		runId,
 	);
 }
 
@@ -696,6 +750,7 @@ async function cmdAutofixLoop(
 	args: readonly string[],
 	reviewAgent: ReviewAgentName,
 	mainAgent: MainAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	let changeId = "";
 	let maxRounds = "";
@@ -707,7 +762,7 @@ async function cmdAutofixLoop(
 			index += 1;
 			continue;
 		}
-		if (arg === "--review-agent") {
+		if (arg === "--review-agent" || arg === "--run-id") {
 			index += 1;
 			continue;
 		}
@@ -722,7 +777,7 @@ async function cmdAutofixLoop(
 	}
 	if (!changeId) {
 		die(
-			"Usage: specflow-review-apply autofix-loop <CHANGE_ID> [--max-rounds N]",
+			"Usage: specflow-review-apply autofix-loop <CHANGE_ID> [--max-rounds N] [--run-id <id>]",
 		);
 	}
 	const config = readReviewConfig(projectRoot);
@@ -743,6 +798,7 @@ async function cmdAutofixLoop(
 		rounds,
 		reviewAgent,
 		mainAgent,
+		runId,
 	);
 }
 
@@ -753,6 +809,67 @@ function parseReviewAgentFlag(args: readonly string[]): string | undefined {
 		}
 	}
 	return undefined;
+}
+
+function parseRunIdFlag(args: readonly string[]): string | undefined {
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] === "--run-id") {
+			return args[index + 1];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Issue a review_decision gate for a completed apply review round.
+ * Best-effort: returns null on failure.
+ */
+function tryIssueReviewDecisionGate(
+	projectRoot: string,
+	runId: string,
+	reviewPhase: ReviewPhase,
+	ledger: ReviewLedger,
+	reviewAgent: ReviewAgentName,
+): string | null {
+	try {
+		const store = createLocalFsGateRecordStore(projectRoot);
+		const round = Number(ledger.current_round ?? 0);
+		const roundId = `${reviewPhase}-round-${round}`;
+		const gateId = `review_decision-${runId}-${reviewPhase}-${round}`;
+		const findings: ReviewFindingSnapshot[] = (ledger.findings ?? [])
+			.filter((f) => {
+				const status = String(f.status ?? "");
+				return status === "new" || status === "open";
+			})
+			.map((f) => ({
+				id: String(f.id ?? ""),
+				severity: (f.severity ?? "medium") as ReviewFindingSnapshot["severity"],
+				status: String(f.status ?? ""),
+				title: String(f.title ?? ""),
+			}));
+		const provenance: ReviewRoundProvenance = {
+			run_id: runId,
+			review_phase: reviewPhase,
+			review_round_id: roundId,
+			findings,
+			reviewer_actor: "ai-agent",
+			reviewer_actor_id: reviewAgent,
+			approval_binding: "advisory",
+		};
+		const gate = issueReviewDecisionGate(provenance, {
+			store,
+			projectRoot,
+			gateId,
+			createdAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+		});
+		return gate.gate_id;
+	} catch (cause) {
+		const message = cause instanceof Error ? cause.message : String(cause);
+		process.stderr.write(
+			`Warning: failed to issue review_decision gate: ${message}\n`,
+		);
+		return null;
+	}
 }
 
 async function main(): Promise<void> {
@@ -769,6 +886,21 @@ async function main(): Promise<void> {
 	const [subcommand = "", ...args] = process.argv.slice(2);
 	const reviewAgent = resolveReviewAgent(parseReviewAgentFlag(args));
 	const mainAgent = resolveMainAgent();
+	let runId = parseRunIdFlag(args);
+
+	// Auto-discover run_id from the change_id when --run-id is not provided.
+	// This ensures review_decision gates are always emitted when a run exists.
+	if (!runId) {
+		const changeId = args.find((a) => !a.startsWith("-"));
+		if (changeId) {
+			const runStore = createLocalFsRunArtifactStore(projectRoot);
+			const latest = await findLatestRun(runStore, changeId);
+			if (latest) {
+				runId = latest.run_id;
+			}
+		}
+	}
+
 	let result: ReviewResult;
 	switch (subcommand) {
 		case "review":
@@ -780,6 +912,7 @@ async function main(): Promise<void> {
 				args,
 				reviewAgent,
 				mainAgent,
+				runId,
 			);
 			break;
 		case "fix-review":
@@ -791,6 +924,7 @@ async function main(): Promise<void> {
 				args,
 				reviewAgent,
 				mainAgent,
+				runId,
 			);
 			break;
 		case "autofix-loop":
@@ -802,6 +936,7 @@ async function main(): Promise<void> {
 				args,
 				reviewAgent,
 				mainAgent,
+				runId,
 			);
 			break;
 		case "":

--- a/src/bin/specflow-review-design.ts
+++ b/src/bin/specflow-review-design.ts
@@ -7,7 +7,14 @@ import {
 import { validatePlanningHeadings } from "../lib/design-planning-validation.js";
 import { tryGit } from "../lib/git.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
+import {
+	issueReviewDecisionGate,
+	type ReviewPhase,
+	type ReviewRoundProvenance,
+} from "../lib/review-decision-gate.js";
 import {
 	actionableCount,
 	applyStillOpenSeverityOverrides,
@@ -22,6 +29,7 @@ import {
 	matchFindings,
 	matchRereview,
 	openHighFindings,
+	patchLatestRoundGateId,
 	persistMaxFindingId,
 	readLedgerFromStore,
 	resolvedHighFindingTitles,
@@ -47,6 +55,7 @@ import {
 	resolveReviewAgent,
 	validateChangeFromStore,
 } from "../lib/review-runtime.js";
+import { findLatestRun } from "../lib/run-store-ops.js";
 import type {
 	AutofixRoundScore,
 	DivergenceWarning,
@@ -55,6 +64,7 @@ import type {
 	ReviewPayload,
 	ReviewResult,
 } from "../types/contracts.js";
+import type { ReviewFindingSnapshot } from "../types/gate-records.js";
 
 function notInGitRepo(): never {
 	process.stdout.write('{"status":"error","error":"not_in_git_repo"}\n');
@@ -270,6 +280,7 @@ async function runReviewPipeline(
 	changeId: string,
 	rereviewMode: boolean,
 	reviewAgent: ReviewAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	process.stderr.write("Reading artifacts...\n");
 	if (!(await readDesignArtifactsFromStore(changeStore, changeId))) {
@@ -431,16 +442,42 @@ async function runReviewPipeline(
 		);
 	}
 
-	return resultFromLedger(
-		action,
-		changeId,
-		reviewJson,
-		rereviewMode,
-		parseError,
-		rawResponse,
-		ledger,
-		rereviewClassification,
-	);
+	// Issue a review_decision gate if a run_id was provided.
+	let gateId: string | null = null;
+	if (runId && !parseError) {
+		gateId = tryIssueReviewDecisionGate(
+			projectRoot,
+			runId,
+			"design_review",
+			ledger,
+			reviewAgent,
+		);
+		// Write gate_id back into the ledger's latest round summary (D10 step 3).
+		if (gateId) {
+			ledger = patchLatestRoundGateId(ledger, gateId);
+			await writeLedgerToStore(
+				changeStore,
+				changeId,
+				ReviewLedgerKind.Design,
+				ledger,
+				true,
+			);
+		}
+	}
+
+	return {
+		...resultFromLedger(
+			action,
+			changeId,
+			reviewJson,
+			rereviewMode,
+			parseError,
+			rawResponse,
+			ledger,
+			rereviewClassification,
+		),
+		gate_id: gateId,
+	};
 }
 
 async function runAutofixLoop(
@@ -451,6 +488,7 @@ async function runAutofixLoop(
 	maxRounds: number,
 	reviewAgent: ReviewAgentName,
 	mainAgent: MainAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	if (!(await readDesignArtifactsFromStore(changeStore, changeId))) {
 		return {
@@ -483,6 +521,7 @@ async function runAutofixLoop(
 	let consecutiveFailures = 0;
 	let autofixRound = 0;
 	let loopResult = "max_rounds_reached";
+	let lastSuccessfulGateId: string | null = null;
 	const roundScores: AutofixRoundScore[] = [];
 	const divergenceWarnings: DivergenceWarning[] = [];
 
@@ -543,6 +582,7 @@ async function runAutofixLoop(
 			changeId,
 			true,
 			reviewAgent,
+			runId,
 		);
 		if (reviewResult.status === "error" || reviewResult.review?.parse_error) {
 			consecutiveFailures += 1;
@@ -557,6 +597,8 @@ async function runAutofixLoop(
 		}
 
 		consecutiveFailures = 0;
+		// Track the gate_id emitted by this round's review pipeline.
+		lastSuccessfulGateId = reviewResult.gate_id ?? null;
 		ledger = (
 			await readLedgerFromStore(changeStore, changeId, ReviewLedgerKind.Design)
 		).ledger;
@@ -626,6 +668,11 @@ async function runAutofixLoop(
 		);
 	}
 
+	// Gate emission is handled per-round inside runReviewPipeline (which
+	// receives runId). We only propagate the gate_id from the last
+	// *successful* review round — no unconditional emission at loop exit.
+	const gateId = lastSuccessfulGateId;
+
 	const actionable = actionableCount(ledger);
 	// Severity-aware handoff: loop is "clean" when no critical/high remain.
 	const blocking = unresolvedCriticalHighCount(ledger);
@@ -646,6 +693,7 @@ async function runAutofixLoop(
 			actionable_count: actionable,
 			severity_summary: severitySummary(ledger),
 		},
+		gate_id: gateId,
 		error: null,
 	};
 }
@@ -656,10 +704,13 @@ async function cmdReview(
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
 	reviewAgent: ReviewAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	const changeId = args[0];
 	if (!changeId) {
-		die("Usage: specflow-review-design review <CHANGE_ID> [--reset-ledger]");
+		die(
+			"Usage: specflow-review-design review <CHANGE_ID> [--reset-ledger] [--run-id <id>]",
+		);
 	}
 	const reset = args.includes("--reset-ledger");
 	try {
@@ -685,6 +736,7 @@ async function cmdReview(
 		changeId,
 		false,
 		reviewAgent,
+		runId,
 	);
 }
 
@@ -694,11 +746,12 @@ async function cmdFixReview(
 	changeStore: ChangeArtifactStore,
 	args: readonly string[],
 	reviewAgent: ReviewAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	const changeId = args[0];
 	if (!changeId) {
 		die(
-			"Usage: specflow-review-design fix-review <CHANGE_ID> [--reset-ledger] [--autofix]",
+			"Usage: specflow-review-design fix-review <CHANGE_ID> [--reset-ledger] [--autofix] [--run-id <id>]",
 		);
 	}
 	const reset = args.includes("--reset-ledger");
@@ -725,6 +778,7 @@ async function cmdFixReview(
 		changeId,
 		true,
 		reviewAgent,
+		runId,
 	);
 }
 
@@ -735,11 +789,12 @@ async function cmdAutofixLoop(
 	args: readonly string[],
 	reviewAgent: ReviewAgentName,
 	mainAgent: MainAgentName,
+	runId?: string,
 ): Promise<ReviewResult> {
 	const changeId = args[0];
 	if (!changeId) {
 		die(
-			"Usage: specflow-review-design autofix-loop <CHANGE_ID> [--max-rounds N]",
+			"Usage: specflow-review-design autofix-loop <CHANGE_ID> [--max-rounds N] [--run-id <id>]",
 		);
 	}
 	let maxRounds = "";
@@ -764,6 +819,7 @@ async function cmdAutofixLoop(
 		rounds,
 		reviewAgent,
 		mainAgent,
+		runId,
 	);
 }
 
@@ -776,6 +832,68 @@ function parseReviewAgentFlag(args: readonly string[]): string | undefined {
 	return undefined;
 }
 
+function parseRunIdFlag(args: readonly string[]): string | undefined {
+	for (let index = 0; index < args.length; index += 1) {
+		if (args[index] === "--run-id") {
+			return args[index + 1];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Issue a review_decision gate for a completed review round. Returns the
+ * gate_id on success, or null if emission fails (best-effort; the review
+ * result is still valid without the gate).
+ */
+function tryIssueReviewDecisionGate(
+	projectRoot: string,
+	runId: string,
+	reviewPhase: ReviewPhase,
+	ledger: ReviewLedger,
+	reviewAgent: ReviewAgentName,
+): string | null {
+	try {
+		const store = createLocalFsGateRecordStore(projectRoot);
+		const round = Number(ledger.current_round ?? 0);
+		const roundId = `${reviewPhase}-round-${round}`;
+		const gateId = `review_decision-${runId}-${reviewPhase}-${round}`;
+		const findings: ReviewFindingSnapshot[] = (ledger.findings ?? [])
+			.filter((f) => {
+				const status = String(f.status ?? "");
+				return status === "new" || status === "open";
+			})
+			.map((f) => ({
+				id: String(f.id ?? ""),
+				severity: (f.severity ?? "medium") as ReviewFindingSnapshot["severity"],
+				status: String(f.status ?? ""),
+				title: String(f.title ?? ""),
+			}));
+		const provenance: ReviewRoundProvenance = {
+			run_id: runId,
+			review_phase: reviewPhase,
+			review_round_id: roundId,
+			findings,
+			reviewer_actor: "ai-agent",
+			reviewer_actor_id: reviewAgent,
+			approval_binding: "advisory",
+		};
+		const gate = issueReviewDecisionGate(provenance, {
+			store,
+			projectRoot,
+			gateId,
+			createdAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+		});
+		return gate.gate_id;
+	} catch (cause) {
+		const message = cause instanceof Error ? cause.message : String(cause);
+		process.stderr.write(
+			`Warning: failed to issue review_decision gate: ${message}\n`,
+		);
+		return null;
+	}
+}
+
 async function main(): Promise<void> {
 	const projectRoot = ensureGitRepo();
 	loadConfigEnv(projectRoot);
@@ -784,6 +902,7 @@ async function main(): Promise<void> {
 	const [subcommand, ...args] = process.argv.slice(2);
 	const reviewAgent = resolveReviewAgent(parseReviewAgentFlag(args));
 	const mainAgent = resolveMainAgent();
+	let runId = parseRunIdFlag(args);
 	if (!subcommand) {
 		process.stderr.write(`Usage: specflow-review-design <subcommand> <CHANGE_ID> [options]
 
@@ -796,6 +915,19 @@ Subcommands:
 		process.exit(1);
 	}
 
+	// Auto-discover run_id from the change_id when --run-id is not provided.
+	// This ensures review_decision gates are always emitted when a run exists.
+	if (!runId) {
+		const changeId = args.find((a) => !a.startsWith("-"));
+		if (changeId) {
+			const runStore = createLocalFsRunArtifactStore(projectRoot);
+			const latest = await findLatestRun(runStore, changeId);
+			if (latest) {
+				runId = latest.run_id;
+			}
+		}
+	}
+
 	let result: ReviewResult;
 	switch (subcommand) {
 		case "review":
@@ -805,6 +937,7 @@ Subcommands:
 				changeStore,
 				args,
 				reviewAgent,
+				runId,
 			);
 			break;
 		case "fix-review":
@@ -814,6 +947,7 @@ Subcommands:
 				changeStore,
 				args,
 				reviewAgent,
+				runId,
 			);
 			break;
 		case "autofix-loop":
@@ -824,6 +958,7 @@ Subcommands:
 				args,
 				reviewAgent,
 				mainAgent,
+				runId,
 			);
 			break;
 		default:

--- a/src/bin/specflow-run.ts
+++ b/src/bin/specflow-run.ts
@@ -7,7 +7,7 @@
 //  * gathering precondition inputs (reads, adapter seed, nextRunId, nowIso)
 //  * invoking pure core functions
 //  * persisting returned state via `RunArtifactStore.write` and applying
-//    `RecordMutation[]` via `InteractionRecordStore`
+//    `RecordMutation[]` via `GateRecordStore` (translated by the gate-mutation bridge)
 //  * mapping `Result<Ok, CoreRuntimeError>` to process stdout / stderr / exit code
 //
 // All workflow logic lives under `src/core/`. This file must not contain
@@ -37,9 +37,14 @@ import {
 	changeRef,
 	runRef,
 } from "../lib/artifact-types.js";
-import type { InteractionRecordStore } from "../lib/interaction-record-store.js";
+import {
+	gateRecordsToInteractionRecords,
+	mirrorMutationsToGateStore,
+} from "../lib/gate-mutation-bridge.js";
+import type { GateRecordStore } from "../lib/gate-record-store.js";
+import { GateRuntimeError, resolveGate } from "../lib/gate-runtime.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
-import { createLocalFsInteractionRecordStore } from "../lib/local-fs-interaction-record-store.js";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { createLocalWorkspaceContext } from "../lib/local-workspace-context.js";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
@@ -57,6 +62,123 @@ import type {
 	SchemaId,
 	SourceMetadata,
 } from "../types/contracts.js";
+import type { GateKind, GateRecord } from "../types/gate-records.js";
+import { UnmigratedRecordError } from "../types/gate-records.js";
+
+// ---------------------------------------------------------------------------
+// Gate-aware event mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a workflow event to a gate response token for the given gate kind.
+ * Returns null when the event does not correspond to a gate response,
+ * meaning the advance should proceed without gate resolution.
+ */
+function eventToGateResponse(event: string, gateKind: GateKind): string | null {
+	if (gateKind === "approval") {
+		if (event.startsWith("accept")) return "accept";
+		if (event === "reject") return "reject";
+		return null;
+	}
+	if (gateKind === "review_decision") {
+		if (event.startsWith("accept")) return "accept";
+		if (event === "reject") return "reject";
+		if (event === "request_changes") return "request_changes";
+		return null;
+	}
+	if (gateKind === "clarify") {
+		if (event === "clarify_response") return "clarify_response";
+		return null;
+	}
+	return null;
+}
+
+/**
+ * Returns true when `event` is an unambiguous gate-response token that
+ * should never appear as a raw workflow transition without a pending gate.
+ * `accept_*` events are NOT included because they serve dual duty as both
+ * gate responses (when a gate is pending) and regular workflow events
+ * (e.g. `accept_proposal` at phases without a gate).
+ * `reject` IS included because it is always a gate response — there is no
+ * workflow transition where `reject` is valid without a pending gate.
+ */
+function isUnambiguousGateResponseEvent(event: string): boolean {
+	return (
+		event === "reject" ||
+		event === "request_changes" ||
+		event === "clarify_response"
+	);
+}
+
+/**
+ * Find pending gates at the given phase. Returns the first matching
+ * approval or review_decision gate (which have at-most-one-pending
+ * concurrency), or the first matching clarify gate.
+ */
+function findPendingGateForPhase(
+	gates: readonly GateRecord[],
+	phase: string,
+): GateRecord | null {
+	for (const gate of gates) {
+		if (gate.status === "pending" && gate.originating_phase === phase) {
+			return gate;
+		}
+	}
+	return null;
+}
+
+/**
+ * If a pending gate exists for the current phase and the incoming event
+ * maps to a valid gate response, resolve the gate via the first-class
+ * gate runtime. This enforces `allowed_responses`, `eligible_responder_roles`,
+ * and invalid-response checks **before** the state machine advance fires.
+ *
+ * Gate validation errors (invalid response, ineligible role, gate not
+ * pending) abort the advance with a hard failure so that callers cannot
+ * bypass gate rules by sending raw workflow events.
+ *
+ * When no pending gate exists at the current phase, the advance proceeds
+ * normally — the event is a regular workflow transition, not a gate
+ * resolution.
+ */
+function resolveGateForEvent(
+	store: GateRecordStore,
+	runId: string,
+	currentPhase: string,
+	event: string,
+	gates: readonly GateRecord[],
+): void {
+	const pendingGate = findPendingGateForPhase(gates, currentPhase);
+
+	// When no pending gate exists at the current phase, most events proceed
+	// as regular workflow transitions. However, unambiguous gate-response
+	// tokens (request_changes, clarify_response) should never be sent as
+	// raw events without a corresponding pending gate.
+	if (!pendingGate) {
+		if (isUnambiguousGateResponseEvent(event)) {
+			throw new GateRuntimeError(
+				"gate_not_found",
+				`Event '${event}' is a gate-response event but no pending gate exists at phase '${currentPhase}'. ` +
+					`Gate-response events require a corresponding pending gate.`,
+			);
+		}
+		return;
+	}
+
+	const response = eventToGateResponse(event, pendingGate.gate_kind);
+	if (!response) return;
+
+	// Gate resolution failures are hard errors — the advance must not
+	// proceed if the gate runtime rejects the response.
+	resolveGate(store, {
+		run_id: runId,
+		gate_id: pendingGate.gate_id,
+		response,
+		actor: { actor: "human", actor_id: "cli" },
+		actor_role: "human-author",
+		resolved_at: nowIso(),
+	});
+}
 
 function fail(message: string): never {
 	process.stderr.write(`${message}\n`);
@@ -140,28 +262,25 @@ async function persistState(
 }
 
 /**
- * Apply a list of record mutations in order. Best-effort: a failure during
- * record persistence after the state has been written is surfaced as a
- * warning, but the transition itself is considered committed.
+ * Apply record mutations via the GateRecordStore. The bridge translates
+ * legacy RecordMutation shapes to GateRecord writes. Delete mutations are
+ * translated to `superseded` status writes so gate records persist as
+ * history (per workflow-gate-semantics spec).
+ *
+ * Best-effort per mutation: each mutation is attempted independently so one
+ * failure does not suppress the rest of the batch. Failures are surfaced as
+ * warnings; the transition itself is considered committed.
  */
-function applyRecordMutations(
-	records: InteractionRecordStore,
+function applyGateMutations(
+	store: GateRecordStore,
 	runId: string,
 	mutations: readonly RecordMutation[],
 ): void {
-	for (const mutation of mutations) {
-		try {
-			if (mutation.kind === "delete") {
-				records.delete(runId, mutation.recordId);
-			} else {
-				records.write(runId, mutation.record);
-			}
-		} catch (cause) {
-			const message = cause instanceof Error ? cause.message : String(cause);
-			process.stderr.write(
-				`Warning: interaction record mutation failed (${mutation.kind}): ${message}\n`,
-			);
-		}
+	const errors = mirrorMutationsToGateStore(store, runId, mutations);
+	for (const err of errors) {
+		process.stderr.write(
+			`Warning: gate record mutation failed (${err.kind}, ${err.recordId}): ${err.error.message}\n`,
+		);
 	}
 }
 
@@ -188,13 +307,13 @@ function renderResult<T>(
  */
 async function commitTransitionAndExit(
 	runStore: RunArtifactStore,
-	records: InteractionRecordStore | null,
+	gates: GateRecordStore | null,
 	runId: string,
 	transitionOk: TransitionOk<LocalRunState>,
 ): Promise<never> {
 	await persistState(runStore, runId, transitionOk.state);
-	if (records) {
-		applyRecordMutations(records, runId, transitionOk.recordMutations);
+	if (gates) {
+		applyGateMutations(gates, runId, transitionOk.recordMutations);
 	}
 	printSchemaJson("run-state", transitionOk.state);
 	process.exit(0);
@@ -286,7 +405,7 @@ async function runStart(args: readonly string[]): Promise<never> {
 	const root = ctx.projectRoot();
 	const runStore = createLocalFsRunArtifactStore(root);
 	const changeStore = createLocalFsChangeArtifactStore(root);
-	const records = createLocalFsInteractionRecordStore(root);
+	const gates = createLocalFsGateRecordStore(root);
 
 	const parsed = parseStartArgs(args);
 	const source: SourceMetadata | null = parsed.sourceFile
@@ -312,7 +431,7 @@ async function runStart(args: readonly string[]): Promise<never> {
 		if (!result.ok) renderResult("run-state", result);
 		return commitTransitionAndExit(
 			runStore,
-			records,
+			gates,
 			parsed.positional,
 			result.value,
 		);
@@ -337,7 +456,7 @@ async function runStart(args: readonly string[]): Promise<never> {
 		adapterSeed,
 	});
 	if (!result.ok) renderResult("run-state", result);
-	return commitTransitionAndExit(runStore, records, nextRunId, result.value);
+	return commitTransitionAndExit(runStore, gates, nextRunId, result.value);
 }
 
 async function runAdvance(args: readonly string[]): Promise<never> {
@@ -348,7 +467,7 @@ async function runAdvance(args: readonly string[]): Promise<never> {
 	}
 	const root = projectRoot();
 	const runStore = createLocalFsRunArtifactStore(root);
-	const records = createLocalFsInteractionRecordStore(root);
+	const gates = createLocalFsGateRecordStore(root);
 	const workflow = loadWorkflow(stateMachinePath(root));
 
 	// Read current state.
@@ -362,7 +481,40 @@ async function runAdvance(args: readonly string[]): Promise<never> {
 		runStore,
 		runId,
 	)) as RunStateOf<LocalRunState>;
-	const priorRecords = records.list(runId);
+
+	// Read prior records from the gate store and translate back to the legacy
+	// InteractionRecord shape for the core runtime's priorRecords input.
+	let gateRecords: readonly GateRecord[];
+	let priorRecords: readonly import("../types/interaction-records.js").InteractionRecord[];
+	try {
+		gateRecords = gates.list(runId);
+		priorRecords = gateRecordsToInteractionRecords(gateRecords);
+	} catch (cause) {
+		if (cause instanceof UnmigratedRecordError) {
+			fail(`Error: ${cause.message}`);
+		}
+		throw cause;
+	}
+
+	// Resolve any pending gate whose allowed_responses match the incoming
+	// event. This enforces the first-class gate validation (eligible roles,
+	// allowed responses) before the state machine transition fires. Gate
+	// validation failures abort the advance with a hard error.
+	try {
+		resolveGateForEvent(gates, runId, state.current_phase, event, gateRecords);
+	} catch (cause) {
+		if (cause instanceof GateRuntimeError) {
+			fail(`Error: gate resolution rejected: ${cause.message}`);
+		}
+		throw cause;
+	}
+
+	// Re-read gate records after resolution so that advanceRun() sees the
+	// resolved state, not the stale pending snapshot. Without this refresh,
+	// the core runtime's update mutations (based on the stale pending record)
+	// would overwrite the already-resolved gate via mirrorMutationsToGateStore.
+	gateRecords = gates.list(runId);
+	priorRecords = gateRecordsToInteractionRecords(gateRecords);
 
 	const result = advanceRun<LocalRunState>(
 		{
@@ -374,7 +526,7 @@ async function runAdvance(args: readonly string[]): Promise<never> {
 		{ workflow },
 	);
 	if (!result.ok) renderResult("run-state", result);
-	return commitTransitionAndExit(runStore, records, runId, result.value);
+	return commitTransitionAndExit(runStore, gates, runId, result.value);
 }
 
 async function runSuspend(args: readonly string[]): Promise<never> {

--- a/src/contracts/orchestrators.ts
+++ b/src/contracts/orchestrators.ts
@@ -113,6 +113,13 @@ export const orchestratorContracts: readonly OrchestratorContract[] = [
 		],
 	},
 	{
+		id: "specflow-migrate-records",
+		type: AssetType.Orchestrator,
+		filePath: "bin/specflow-migrate-records",
+		entryModule: "dist/bin/specflow-migrate-records.js",
+		references: [],
+	},
+	{
 		id: "specflow-run",
 		type: AssetType.Orchestrator,
 		filePath: "bin/specflow-run",

--- a/src/lib/fake-gate-record-store.ts
+++ b/src/lib/fake-gate-record-store.ts
@@ -1,0 +1,37 @@
+// FakeGateRecordStore — in-memory adapter for runtime and transition tests.
+//
+// No filesystem access. Records are stored in a Map keyed by `${runId}/${gateId}`.
+// Intentionally aliased as "Fake" rather than "InMemory" to match the task
+// graph's naming (bundle gate-record-foundation task 1.3).
+
+import type { GateRecord } from "../types/gate-records.js";
+import type { GateRecordStore } from "./gate-record-store.js";
+
+function key(runId: string, gateId: string): string {
+	return `${runId}/${gateId}`;
+}
+
+export function createFakeGateRecordStore(): GateRecordStore {
+	const store = new Map<string, GateRecord>();
+
+	return {
+		write(runId: string, record: GateRecord): void {
+			store.set(key(runId, record.gate_id), { ...record });
+		},
+
+		read(runId: string, gateId: string): GateRecord | null {
+			return store.get(key(runId, gateId)) ?? null;
+		},
+
+		list(runId: string): readonly GateRecord[] {
+			const prefix = `${runId}/`;
+			const records: GateRecord[] = [];
+			for (const [k, v] of store) {
+				if (k.startsWith(prefix)) {
+					records.push(v);
+				}
+			}
+			return records;
+		},
+	};
+}

--- a/src/lib/gate-mutation-bridge.ts
+++ b/src/lib/gate-mutation-bridge.ts
@@ -1,0 +1,230 @@
+// Bridge: translate legacy RecordMutation[] (ApprovalRecord/ClarifyRecord)
+// into GateRecord writes so the runtime emits both shapes during the transition
+// period described by workflow-gate-semantics.
+//
+// This is a short-lived compatibility helper. Once the transition to
+// GateRecord is complete across the whole pipeline, the legacy path can be
+// deleted and this bridge along with it.
+
+import type { RecordMutation } from "../core/types.js";
+import type {
+	ApprovalGatePayload,
+	ClarifyGatePayload,
+	GateRecord,
+} from "../types/gate-records.js";
+import type {
+	ApprovalRecord,
+	ApprovalStatus,
+	ClarifyRecord,
+	InteractionRecord,
+} from "../types/interaction-records.js";
+import type { GateRecordStore } from "./gate-record-store.js";
+
+/**
+ * Apply every mutation against the GateRecordStore by translating legacy
+ * record shapes to GateRecord shapes byte-for-byte (gate_id === record_id).
+ *
+ * Delete mutations are translated to a `superseded` status write so the gate
+ * remains in history (GateRecordStore has no delete API). If the gate is
+ * already resolved or superseded, the delete is a no-op.
+ *
+ * Each mutation is applied independently so that one failed write does not
+ * suppress the rest of the batch. Callers receive an array of per-mutation
+ * errors (empty on full success).
+ */
+export function mirrorMutationsToGateStore(
+	store: GateRecordStore,
+	runId: string,
+	mutations: readonly RecordMutation[],
+): readonly MirrorMutationError[] {
+	const errors: MirrorMutationError[] = [];
+	for (const mutation of mutations) {
+		try {
+			if (mutation.kind === "delete") {
+				applyDeleteAsSupersedeWrite(store, runId, mutation.recordId);
+			} else {
+				const gate = translateToGateRecord(mutation.record);
+				store.write(runId, gate);
+			}
+		} catch (cause) {
+			errors.push({
+				kind: mutation.kind,
+				recordId:
+					mutation.kind === "delete"
+						? mutation.recordId
+						: mutation.record.record_id,
+				error: cause instanceof Error ? cause : new Error(String(cause)),
+			});
+		}
+	}
+	return errors;
+}
+
+export interface MirrorMutationError {
+	readonly kind: string;
+	readonly recordId: string;
+	readonly error: Error;
+}
+
+/**
+ * Translate a legacy delete mutation into a `superseded` status write.
+ * If the gate is already resolved or superseded, the delete is a no-op.
+ * If the gate does not exist, this is also a no-op (idempotent).
+ */
+function applyDeleteAsSupersedeWrite(
+	store: GateRecordStore,
+	runId: string,
+	recordId: string,
+): void {
+	const existing = store.read(runId, recordId);
+	if (!existing) return;
+	if (existing.status !== "pending") return;
+	const superseded: GateRecord = {
+		...existing,
+		status: "superseded",
+		resolved_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+		resolved_response: null,
+	};
+	store.write(runId, superseded);
+}
+
+export function translateToGateRecord(record: InteractionRecord): GateRecord {
+	if (record.record_kind === "approval") {
+		return translateApproval(record);
+	}
+	return translateClarify(record);
+}
+
+function translateApproval(rec: ApprovalRecord): GateRecord {
+	const status: GateRecord["status"] =
+		rec.status === "pending" ? "pending" : "resolved";
+	const resolvedResponse: string | null =
+		rec.status === "approved"
+			? "accept"
+			: rec.status === "rejected"
+				? "reject"
+				: null;
+	return {
+		gate_id: rec.record_id,
+		gate_kind: "approval",
+		run_id: rec.run_id,
+		originating_phase: rec.phase_from,
+		status,
+		reason: `Approval required to move from ${rec.phase_from} to ${rec.phase_to}`,
+		payload: {
+			kind: "approval",
+			phase_from: rec.phase_from,
+			phase_to: rec.phase_to,
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["accept", "reject"],
+		created_at: rec.requested_at,
+		resolved_at: rec.decided_at,
+		decision_actor: rec.decision_actor,
+		resolved_response: resolvedResponse,
+		event_ids: [...rec.event_ids],
+	};
+}
+
+function translateClarify(rec: ClarifyRecord): GateRecord {
+	const status: GateRecord["status"] =
+		rec.status === "pending" ? "pending" : "resolved";
+	return {
+		gate_id: rec.record_id,
+		gate_kind: "clarify",
+		run_id: rec.run_id,
+		originating_phase: rec.phase,
+		status,
+		reason: "Clarification requested",
+		payload: {
+			kind: "clarify",
+			question: rec.question,
+			question_context: rec.question_context,
+			answer: rec.answer ?? undefined,
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["clarify_response"],
+		created_at: rec.asked_at,
+		resolved_at: rec.answered_at,
+		decision_actor: null,
+		resolved_response: rec.status === "resolved" ? "clarify_response" : null,
+		event_ids: [...rec.event_ids],
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Reverse bridge: GateRecord → InteractionRecord
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate gate records back to InteractionRecord shapes for backward-compatible
+ * reads by the core runtime. `review_decision` gates have no legacy equivalent
+ * and are excluded from the result.
+ */
+export function gateRecordsToInteractionRecords(
+	gates: readonly GateRecord[],
+): readonly InteractionRecord[] {
+	const results: InteractionRecord[] = [];
+	for (const gate of gates) {
+		const record = gateToInteractionRecord(gate);
+		if (record !== null) {
+			results.push(record);
+		}
+	}
+	return results;
+}
+
+function gateToInteractionRecord(gate: GateRecord): InteractionRecord | null {
+	if (gate.gate_kind === "approval") {
+		return gateToApprovalRecord(gate);
+	}
+	if (gate.gate_kind === "clarify") {
+		return gateToClarifyRecord(gate);
+	}
+	// review_decision has no legacy InteractionRecord equivalent
+	return null;
+}
+
+function gateToApprovalRecord(gate: GateRecord): ApprovalRecord {
+	const payload = gate.payload as ApprovalGatePayload;
+	let status: ApprovalStatus;
+	if (gate.status === "pending") {
+		status = "pending";
+	} else if (gate.resolved_response === "accept") {
+		status = "approved";
+	} else {
+		// resolved+reject and superseded both map to "rejected" (terminal)
+		status = "rejected";
+	}
+	return {
+		record_id: gate.gate_id,
+		record_kind: "approval",
+		run_id: gate.run_id,
+		phase_from: payload.phase_from,
+		phase_to: payload.phase_to,
+		status,
+		requested_at: gate.created_at,
+		decided_at: gate.resolved_at,
+		decision_actor: gate.decision_actor,
+		event_ids: [...gate.event_ids],
+	};
+}
+
+function gateToClarifyRecord(gate: GateRecord): ClarifyRecord {
+	const payload = gate.payload as ClarifyGatePayload;
+	return {
+		record_id: gate.gate_id,
+		record_kind: "clarify",
+		run_id: gate.run_id,
+		phase: gate.originating_phase,
+		question: payload.question,
+		...(payload.question_context
+			? { question_context: payload.question_context }
+			: {}),
+		answer: payload.answer ?? null,
+		status: gate.status === "pending" ? "pending" : "resolved",
+		asked_at: gate.created_at,
+		answered_at: gate.resolved_at,
+		event_ids: [...gate.event_ids],
+	};
+}

--- a/src/lib/gate-record-store.ts
+++ b/src/lib/gate-record-store.ts
@@ -1,0 +1,30 @@
+// GateRecordStore — persistence abstraction for gate records.
+//
+// The unified successor to InteractionRecordStore. Deliberately omits a
+// per-record `delete` operation: persistent gate objects are audit-relevant and
+// removal happens only through run-directory cascade deletion.
+
+import type { GateRecord } from "../types/gate-records.js";
+
+export interface GateRecordStore {
+	/** Persist a new or updated gate record. Atomic at the single-file level. */
+	write(runId: string, record: GateRecord): void;
+
+	/**
+	 * Read a single gate record. Returns null if not found. MUST throw
+	 * `UnmigratedRecordError` when a legacy-shaped file is encountered so callers
+	 * never silently consume unmigrated data.
+	 */
+	read(runId: string, gateId: string): GateRecord | null;
+
+	/**
+	 * List all gate records (including superseded ones) for a given run. MUST
+	 * throw `UnmigratedRecordError` if any file in the records directory uses
+	 * the legacy shape, because concurrency checks rely on list to be
+	 * authoritative.
+	 */
+	list(runId: string): readonly GateRecord[];
+
+	// No delete: run-directory cascade deletion is the only supported removal
+	// path. See workflow-gate-semantics and approval-clarify-persistence specs.
+}

--- a/src/lib/gate-runtime.ts
+++ b/src/lib/gate-runtime.ts
@@ -1,0 +1,440 @@
+// Runtime helpers for creating and resolving gates.
+//
+// Two public entry points:
+// - issueGate(...) : creates a new gate, applying kind-specific concurrency.
+//     * approval / review_decision: at most one pending per (run, phase);
+//       a new same-kind/same-phase gate supersedes the prior pending one.
+//     * clarify: multiple pending gates may coexist in one phase.
+// - resolveGate(...) : applies a response to a pending gate, validating
+//     allowed_responses and eligible_responder_roles.
+//
+// The supersede path uses a write-ahead intent journal (`.supersede-intent.json`)
+// and a run-scoped lock file (`.gate-lock`) to keep the paired old/new writes
+// recoverable after crashes. Recovery is lazy: `list()` and `read()` paths run
+// through `recoverPendingIntent` before returning results.
+
+import {
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readdirSync,
+	unlinkSync,
+	writeSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { ActorIdentity } from "../contracts/surface-events.js";
+import {
+	allowedResponsesFor,
+	defaultEligibleRolesFor,
+	type GateKind,
+	type GatePayload,
+	type GateRecord,
+	type GateStatus,
+} from "../types/gate-records.js";
+import { atomicWriteText, readText } from "./fs.js";
+import type { GateRecordStore } from "./gate-record-store.js";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export type GateRuntimeErrorKind =
+	| "invalid_gate_kind"
+	| "invalid_response"
+	| "role_not_eligible"
+	| "gate_not_pending"
+	| "gate_not_found"
+	| "concurrent_issuance_conflict";
+
+export class GateRuntimeError extends Error {
+	readonly kind: GateRuntimeErrorKind;
+	readonly gate_id?: string;
+	constructor(kind: GateRuntimeErrorKind, message: string, gateId?: string) {
+		super(message);
+		this.name = "GateRuntimeError";
+		this.kind = kind;
+		this.gate_id = gateId;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+export interface IssueGateInput {
+	readonly gate_id: string;
+	readonly gate_kind: GateKind;
+	readonly run_id: string;
+	readonly originating_phase: string;
+	readonly reason: string;
+	readonly payload: GatePayload;
+	/** Optional override of the per-kind default role set. */
+	readonly eligible_responder_roles?: readonly string[];
+	readonly created_at: string;
+	/** Event id to append to the new gate's history on creation. */
+	readonly creation_event_id?: string;
+}
+
+export interface ResolveGateInput {
+	readonly run_id: string;
+	readonly gate_id: string;
+	readonly response: string;
+	readonly actor: ActorIdentity;
+	/** Actor's active role (used to check eligibility). */
+	readonly actor_role: string;
+	readonly resolved_at: string;
+	/** Event id to append to the gate's history on resolution. */
+	readonly resolution_event_id?: string;
+	/** For clarify gates: the answer text to persist in payload. */
+	readonly answer?: string;
+}
+
+// ---------------------------------------------------------------------------
+// issueGate
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new gate in the store. For approval and review_decision kinds,
+ * supersedes any existing pending gate with the same originating_phase. Clarify
+ * gates are additive.
+ *
+ * Intent journal and lock file are used for approval/review_decision to make
+ * the paired supersede+create writes recoverable after crash.
+ */
+export function issueGate(
+	store: GateRecordStore,
+	projectRoot: string,
+	input: IssueGateInput,
+): GateRecord {
+	const roles =
+		input.eligible_responder_roles ?? defaultEligibleRolesFor(input.gate_kind);
+	const responses = allowedResponsesFor(input.gate_kind);
+
+	const newRecord: GateRecord = {
+		gate_id: input.gate_id,
+		gate_kind: input.gate_kind,
+		run_id: input.run_id,
+		originating_phase: input.originating_phase,
+		status: "pending",
+		reason: input.reason,
+		payload: input.payload,
+		eligible_responder_roles: [...roles],
+		allowed_responses: [...responses],
+		created_at: input.created_at,
+		resolved_at: null,
+		decision_actor: null,
+		resolved_response: null,
+		event_ids: input.creation_event_id ? [input.creation_event_id] : [],
+	};
+
+	if (input.gate_kind === "clarify") {
+		// No supersede; just write.
+		store.write(input.run_id, newRecord);
+		return newRecord;
+	}
+
+	// approval / review_decision: paired supersede + create under run lock + intent journal.
+	return runUnderRunLock(projectRoot, input.run_id, () => {
+		const supersedeTarget = findPendingSameKindPhase(
+			store,
+			input.run_id,
+			input.gate_kind,
+			input.originating_phase,
+		);
+
+		const intentPath = intentJournalPath(projectRoot, input.run_id);
+		const intent = {
+			version: 1,
+			kind: "supersede" as const,
+			run_id: input.run_id,
+			old_gate: supersedeTarget,
+			new_gate: newRecord,
+		};
+		atomicWriteText(intentPath, `${JSON.stringify(intent, null, 2)}\n`);
+
+		if (supersedeTarget) {
+			const superseded: GateRecord = {
+				...supersedeTarget,
+				status: "superseded",
+				resolved_at: input.created_at,
+				resolved_response: null,
+				event_ids: input.creation_event_id
+					? [...supersedeTarget.event_ids, input.creation_event_id]
+					: [...supersedeTarget.event_ids],
+			};
+			store.write(input.run_id, superseded);
+		}
+		store.write(input.run_id, newRecord);
+
+		// Success: clean up the intent journal.
+		try {
+			unlinkSync(intentPath);
+		} catch {
+			/* best effort */
+		}
+
+		return newRecord;
+	});
+}
+
+// ---------------------------------------------------------------------------
+// resolveGate
+// ---------------------------------------------------------------------------
+
+export function resolveGate(
+	store: GateRecordStore,
+	input: ResolveGateInput,
+): GateRecord {
+	const existing = store.read(input.run_id, input.gate_id);
+	if (!existing) {
+		throw new GateRuntimeError(
+			"gate_not_found",
+			`No gate ${input.gate_id} in run ${input.run_id}`,
+			input.gate_id,
+		);
+	}
+	if (existing.status !== "pending") {
+		throw new GateRuntimeError(
+			"gate_not_pending",
+			`Gate ${input.gate_id} is ${existing.status}; only pending gates can be resolved`,
+			input.gate_id,
+		);
+	}
+	if (!existing.allowed_responses.includes(input.response)) {
+		throw new GateRuntimeError(
+			"invalid_response",
+			`Response '${input.response}' is not in allowed_responses for ${existing.gate_kind}`,
+			input.gate_id,
+		);
+	}
+	if (!existing.eligible_responder_roles.includes(input.actor_role)) {
+		throw new GateRuntimeError(
+			"role_not_eligible",
+			`Actor role '${input.actor_role}' is not in eligible_responder_roles for gate ${input.gate_id}`,
+			input.gate_id,
+		);
+	}
+
+	const mergedPayload = mergeAnswerIntoPayload(
+		existing.payload,
+		input.answer,
+		input.response,
+	);
+
+	const resolved: GateRecord = {
+		...existing,
+		payload: mergedPayload,
+		status: "resolved",
+		resolved_at: input.resolved_at,
+		decision_actor: input.actor,
+		resolved_response: input.response,
+		event_ids: input.resolution_event_id
+			? [...existing.event_ids, input.resolution_event_id]
+			: [...existing.event_ids],
+	};
+
+	store.write(input.run_id, resolved);
+	return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mergeAnswerIntoPayload(
+	payload: GatePayload,
+	answer: string | undefined,
+	response: string,
+): GatePayload {
+	if (payload.kind !== "clarify") return payload;
+	if (response !== "clarify_response" || answer === undefined) return payload;
+	return { ...payload, answer };
+}
+
+function findPendingSameKindPhase(
+	store: GateRecordStore,
+	runId: string,
+	kind: GateKind,
+	phase: string,
+): GateRecord | null {
+	const all = store.list(runId);
+	for (const g of all) {
+		if (
+			g.status === "pending" &&
+			g.gate_kind === kind &&
+			g.originating_phase === phase
+		) {
+			return g;
+		}
+	}
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Lock file (O_CREAT|O_EXCL with stale-lock breaking)
+// ---------------------------------------------------------------------------
+
+const LOCK_STALE_MS = 30_000; // 30s matches design.md D4
+
+function lockPath(projectRoot: string, runId: string): string {
+	return resolve(projectRoot, ".specflow/runs", runId, "records", ".gate-lock");
+}
+
+function intentJournalPath(projectRoot: string, runId: string): string {
+	return resolve(
+		projectRoot,
+		".specflow/runs",
+		runId,
+		"records",
+		".supersede-intent.json",
+	);
+}
+
+function runUnderRunLock<T>(
+	projectRoot: string,
+	runId: string,
+	fn: () => T,
+): T {
+	const path = lockPath(projectRoot, runId);
+	mkdirSync(dirname(path), { recursive: true });
+	const startedAt = Date.now();
+	// Ensure containing directory exists; GateRecordStore.write also creates it.
+	const waitDeadline = startedAt + LOCK_STALE_MS * 2;
+	let acquired = false;
+	let fd = -1;
+	while (!acquired) {
+		try {
+			fd = openSync(path, "wx");
+			acquired = true;
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code !== "EEXIST") throw err;
+			// inspect the existing lock
+			if (isStaleLock(path)) {
+				try {
+					unlinkSync(path);
+				} catch {
+					/* best-effort */
+				}
+				continue;
+			}
+			if (Date.now() > waitDeadline) {
+				throw new GateRuntimeError(
+					"concurrent_issuance_conflict",
+					`Timed out waiting for gate lock at ${path}`,
+				);
+			}
+			sleep(100);
+		}
+	}
+	try {
+		writeSync(fd, `${process.pid}:${Date.now()}`);
+		return fn();
+	} finally {
+		if (fd !== -1) {
+			try {
+				closeSync(fd);
+			} catch {
+				/* best-effort */
+			}
+		}
+		try {
+			unlinkSync(path);
+		} catch {
+			/* best-effort */
+		}
+	}
+}
+
+function isStaleLock(path: string): boolean {
+	if (!existsSync(path)) return true;
+	try {
+		const content = readText(path).trim();
+		const parts = content.split(":");
+		const ts = Number(parts[1] ?? "0");
+		if (!Number.isFinite(ts)) return true;
+		return Date.now() - ts > LOCK_STALE_MS;
+	} catch {
+		return true;
+	}
+}
+
+// node:test supports async waits but we use a small synchronous spin to keep
+// issueGate synchronous for legacy call sites.
+function sleep(ms: number): void {
+	const end = Date.now() + ms;
+	while (Date.now() < end) {
+		// busy-wait deliberately short
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Recovery (intent journal replay)
+// ---------------------------------------------------------------------------
+
+/**
+ * Replay any leftover `.supersede-intent.json` files in a run's records
+ * directory. Completes a partial supersede by writing both records if missing,
+ * or rolls forward from the journal. Idempotent.
+ */
+export function recoverPendingIntent(
+	store: GateRecordStore,
+	projectRoot: string,
+	runId: string,
+): void {
+	const path = intentJournalPath(projectRoot, runId);
+	if (!existsSync(path)) return;
+	let raw: string;
+	try {
+		raw = readText(path);
+	} catch {
+		return;
+	}
+	let intent: unknown;
+	try {
+		intent = JSON.parse(raw);
+	} catch {
+		return;
+	}
+	if (
+		typeof intent !== "object" ||
+		intent === null ||
+		(intent as { kind?: string }).kind !== "supersede"
+	) {
+		return;
+	}
+	const payload = intent as {
+		old_gate: GateRecord | null;
+		new_gate: GateRecord;
+	};
+	// Re-apply writes; atomic writes are idempotent.
+	if (payload.old_gate) {
+		const superseded: GateRecord = {
+			...payload.old_gate,
+			status: "superseded" as GateStatus,
+			resolved_at: payload.old_gate.resolved_at ?? payload.new_gate.created_at,
+			resolved_response: null,
+		};
+		store.write(runId, superseded);
+	}
+	store.write(runId, payload.new_gate);
+	try {
+		unlinkSync(path);
+	} catch {
+		/* best-effort */
+	}
+}
+
+/** Find all run ids under projectRoot that currently have leftover intent journals. */
+export function listRunsWithPendingIntent(projectRoot: string): string[] {
+	const runsRoot = resolve(projectRoot, ".specflow/runs");
+	if (!existsSync(runsRoot)) return [];
+	const out: string[] = [];
+	for (const runId of readdirSync(runsRoot)) {
+		if (existsSync(intentJournalPath(projectRoot, runId))) {
+			out.push(runId);
+		}
+	}
+	return out;
+}

--- a/src/lib/local-fs-gate-record-store.ts
+++ b/src/lib/local-fs-gate-record-store.ts
@@ -1,0 +1,83 @@
+// LocalFsGateRecordStore — local filesystem adapter for gate records.
+// Path layout: .specflow/runs/<runId>/records/<gateId>.json
+//
+// Preserves the existing records/ directory so that run-directory cascade
+// deletion continues to work and migration can keep gate_id byte-for-byte
+// equal to the prior record_id.
+
+import { existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+	type GateRecord,
+	isGateRecordShape,
+	isLegacyRecordShape,
+	UnmigratedRecordError,
+} from "../types/gate-records.js";
+import { atomicWriteText, readText } from "./fs.js";
+import type { GateRecordStore } from "./gate-record-store.js";
+
+function recordsDir(runsDir: string, runId: string): string {
+	return resolve(runsDir, runId, "records");
+}
+
+function gatePath(runsDir: string, runId: string, gateId: string): string {
+	return resolve(recordsDir(runsDir, runId), `${gateId}.json`);
+}
+
+function parseOrThrow(path: string): GateRecord {
+	const raw = readText(path);
+	const parsed = JSON.parse(raw) as unknown;
+	if (isLegacyRecordShape(parsed)) {
+		throw new UnmigratedRecordError(path);
+	}
+	if (!isGateRecordShape(parsed)) {
+		throw new Error(`Malformed gate record at ${path}`);
+	}
+	return parsed;
+}
+
+export function createLocalFsGateRecordStore(
+	projectRoot: string,
+): GateRecordStore {
+	const runsDir = resolve(projectRoot, ".specflow/runs");
+
+	return {
+		write(runId: string, record: GateRecord): void {
+			const path = gatePath(runsDir, runId, record.gate_id);
+			atomicWriteText(path, `${JSON.stringify(record, null, 2)}\n`);
+		},
+
+		read(runId: string, gateId: string): GateRecord | null {
+			const path = gatePath(runsDir, runId, gateId);
+			if (!existsSync(path)) {
+				return null;
+			}
+			return parseOrThrow(path);
+		},
+
+		list(runId: string): readonly GateRecord[] {
+			const dir = recordsDir(runsDir, runId);
+			if (!existsSync(dir)) {
+				return [];
+			}
+			let entries: string[];
+			try {
+				entries = readdirSync(dir);
+			} catch {
+				return [];
+			}
+			const records: GateRecord[] = [];
+			for (const entry of entries) {
+				if (!entry.endsWith(".json")) continue;
+				// Skip migration/journal sentinels; they are not record files.
+				if (entry.startsWith(".")) continue;
+				const path = resolve(dir, entry);
+				// parseOrThrow will raise UnmigratedRecordError if any file in the
+				// directory still uses the legacy shape, so callers cannot proceed
+				// past list() without a migration.
+				records.push(parseOrThrow(path));
+			}
+			return records;
+		},
+	};
+}

--- a/src/lib/local-fs-interaction-record-store.ts
+++ b/src/lib/local-fs-interaction-record-store.ts
@@ -1,11 +1,53 @@
 // LocalFsInteractionRecordStore — local filesystem adapter for interaction records.
 // Path layout: .specflow/runs/<runId>/records/<recordId>.json
+//
+// Post-migration: if the `.migrated` sentinel exists in a run's records
+// directory, this store fails fast so callers are forced onto GateRecordStore.
 
 import { existsSync, readdirSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 import type { InteractionRecord } from "../types/interaction-records.js";
 import { atomicWriteText, readText } from "./fs.js";
 import type { InteractionRecordStore } from "./interaction-record-store.js";
+
+const MIGRATED_SENTINEL = ".migrated";
+
+/**
+ * Thrown when a run directory has been migrated to gate records and the legacy
+ * InteractionRecordStore should no longer be used. Callers should switch to
+ * GateRecordStore.
+ */
+export class MigratedDirectoryError extends Error {
+	readonly runId: string;
+	constructor(runId: string, detail?: string) {
+		super(
+			detail ??
+				`Run '${runId}' has been migrated to gate records. Use GateRecordStore instead of InteractionRecordStore.`,
+		);
+		this.name = "MigratedDirectoryError";
+		this.runId = runId;
+	}
+}
+
+function isGateRecordShape(parsed: unknown): boolean {
+	if (parsed === null || typeof parsed !== "object") return false;
+	const obj = parsed as Record<string, unknown>;
+	return typeof obj.gate_id === "string" && typeof obj.gate_kind === "string";
+}
+
+function isInteractionRecordShape(parsed: unknown): boolean {
+	if (parsed === null || typeof parsed !== "object") return false;
+	const obj = parsed as Record<string, unknown>;
+	return (
+		typeof obj.record_id === "string" && typeof obj.record_kind === "string"
+	);
+}
+
+function assertNotMigrated(dir: string, runId: string): void {
+	if (existsSync(resolve(dir, MIGRATED_SENTINEL))) {
+		throw new MigratedDirectoryError(runId);
+	}
+}
 
 function recordsDir(runsDir: string, runId: string): string {
 	return resolve(runsDir, runId, "records");
@@ -22,16 +64,35 @@ export function createLocalFsInteractionRecordStore(
 
 	return {
 		write(runId: string, record: InteractionRecord): void {
+			const dir = recordsDir(runsDir, runId);
+			assertNotMigrated(dir, runId);
 			const path = recordPath(runsDir, runId, record.record_id);
 			atomicWriteText(path, `${JSON.stringify(record, null, 2)}\n`);
 		},
 
 		read(runId: string, recordId: string): InteractionRecord | null {
+			const dir = recordsDir(runsDir, runId);
+			assertNotMigrated(dir, runId);
 			const path = recordPath(runsDir, runId, recordId);
 			if (!existsSync(path)) {
 				return null;
 			}
-			return JSON.parse(readText(path)) as InteractionRecord;
+			const parsed = JSON.parse(readText(path)) as unknown;
+			if (isGateRecordShape(parsed)) {
+				throw new MigratedDirectoryError(
+					runId,
+					`Gate-shaped record found at ${path}. ` +
+						`Run 'specflow-migrate-records' or use GateRecordStore.`,
+				);
+			}
+			if (!isInteractionRecordShape(parsed)) {
+				throw new MigratedDirectoryError(
+					runId,
+					`Unrecognized record format at ${path}. ` +
+						`Run 'specflow-migrate-records' to ensure all records are in the expected format.`,
+				);
+			}
+			return parsed as InteractionRecord;
 		},
 
 		list(runId: string): readonly InteractionRecord[] {
@@ -39,6 +100,7 @@ export function createLocalFsInteractionRecordStore(
 			if (!existsSync(dir)) {
 				return [];
 			}
+			assertNotMigrated(dir, runId);
 			let entries: string[];
 			try {
 				entries = readdirSync(dir);
@@ -48,17 +110,43 @@ export function createLocalFsInteractionRecordStore(
 			const records: InteractionRecord[] = [];
 			for (const entry of entries) {
 				if (!entry.endsWith(".json")) continue;
+				if (entry.startsWith(".")) continue;
 				const path = resolve(dir, entry);
 				try {
-					records.push(JSON.parse(readText(path)) as InteractionRecord);
-				} catch {
-					// Skip malformed files
+					const parsed = JSON.parse(readText(path)) as unknown;
+					// Fail fast if a gate-shaped file is found; the directory
+					// contains migrated data and callers must use GateRecordStore.
+					if (isGateRecordShape(parsed)) {
+						throw new MigratedDirectoryError(
+							runId,
+							`Gate-shaped record found at ${path}. ` +
+								`Run 'specflow-migrate-records' or use GateRecordStore.`,
+						);
+					}
+					// Fail fast on unrecognized JSON shapes — partial migration
+					// or unexpected files must not be silently tolerated. Every
+					// JSON file in the records directory must be a recognized
+					// InteractionRecord shape.
+					if (!isInteractionRecordShape(parsed)) {
+						throw new MigratedDirectoryError(
+							runId,
+							`Unrecognized record format at ${path}. ` +
+								`Run 'specflow-migrate-records' to ensure all records are in the expected format.`,
+						);
+					}
+					records.push(parsed as InteractionRecord);
+				} catch (cause) {
+					if (cause instanceof MigratedDirectoryError) throw cause;
+					// Skip files that cannot be parsed as JSON (corrupt/truncated).
+					// Recognizable-but-wrong shapes fail fast above.
 				}
 			}
 			return records;
 		},
 
 		delete(runId: string, recordId: string): void {
+			const dir = recordsDir(runsDir, runId);
+			assertNotMigrated(dir, runId);
 			const path = recordPath(runsDir, runId, recordId);
 			if (existsSync(path)) {
 				unlinkSync(path);

--- a/src/lib/migrate-records.ts
+++ b/src/lib/migrate-records.ts
@@ -1,0 +1,241 @@
+// Legacy record migration library.
+//
+// Converts every `.specflow/runs/<run_id>/records/*.json` file from the legacy
+// ApprovalRecord / ClarifyRecord shape into the unified GateRecord shape. The
+// migration is idempotent and reversible:
+// - Forward pass writes a `.migrated` sentinel and a `.backup/` snapshot per run.
+// - `--undo` restores the snapshot and removes the sentinel.
+// - Already-migrated directories are detected via the sentinel and left alone.
+
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	renameSync,
+	rmSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import type { GateRecord } from "../types/gate-records.js";
+import {
+	isGateRecordShape,
+	isLegacyRecordShape,
+} from "../types/gate-records.js";
+import type {
+	ApprovalRecord,
+	ClarifyRecord,
+} from "../types/interaction-records.js";
+import { atomicWriteText, readText } from "./fs.js";
+
+const SENTINEL_NAME = ".migrated";
+const BACKUP_DIR_NAME = ".backup";
+
+export interface MigrationResult {
+	readonly runsRoot: string;
+	readonly perRun: readonly RunMigrationResult[];
+}
+
+export interface RunMigrationResult {
+	readonly runId: string;
+	readonly status:
+		| "migrated"
+		| "already_migrated"
+		| "no_records"
+		| "error"
+		| "undone";
+	readonly migrated: number;
+	readonly skipped: number;
+	readonly error?: string;
+}
+
+export interface MigrationOptions {
+	readonly mode: "forward" | "undo";
+	/** Filter: run-id allowlist. Empty means all runs. */
+	readonly runIds?: readonly string[];
+}
+
+export function runMigration(
+	projectRoot: string,
+	options: MigrationOptions = { mode: "forward" },
+): MigrationResult {
+	const runsRoot = resolve(projectRoot, ".specflow/runs");
+	if (!existsSync(runsRoot) || !statSync(runsRoot).isDirectory()) {
+		return { runsRoot, perRun: [] };
+	}
+
+	const entries = readdirSync(runsRoot).filter((name) => {
+		if (options.runIds && options.runIds.length > 0) {
+			return options.runIds.includes(name);
+		}
+		return true;
+	});
+
+	const perRun: RunMigrationResult[] = [];
+	for (const runId of entries) {
+		const runDir = resolve(runsRoot, runId);
+		if (!statSync(runDir).isDirectory()) continue;
+		try {
+			if (options.mode === "forward") {
+				perRun.push(migrateRunForward(runDir, runId));
+			} else {
+				perRun.push(undoRun(runDir, runId));
+			}
+		} catch (err) {
+			perRun.push({
+				runId,
+				status: "error",
+				migrated: 0,
+				skipped: 0,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+	return { runsRoot, perRun };
+}
+
+function migrateRunForward(runDir: string, runId: string): RunMigrationResult {
+	const recordsDir = resolve(runDir, "records");
+	if (!existsSync(recordsDir)) {
+		return { runId, status: "no_records", migrated: 0, skipped: 0 };
+	}
+	const sentinel = resolve(recordsDir, SENTINEL_NAME);
+	if (existsSync(sentinel)) {
+		return { runId, status: "already_migrated", migrated: 0, skipped: 0 };
+	}
+	const backupDir = resolve(recordsDir, BACKUP_DIR_NAME);
+	mkdirSync(backupDir, { recursive: true });
+
+	const files = readdirSync(recordsDir).filter(
+		(f) => f.endsWith(".json") && !f.startsWith("."),
+	);
+
+	let migrated = 0;
+	let skipped = 0;
+	for (const filename of files) {
+		const path = resolve(recordsDir, filename);
+		const raw = readText(path);
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch (err) {
+			throw new Error(
+				`Cannot parse ${path}: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+		if (isGateRecordShape(parsed)) {
+			skipped += 1;
+			continue;
+		}
+		if (!isLegacyRecordShape(parsed)) {
+			throw new Error(
+				`Record at ${path} is neither legacy nor gate-shaped; cannot migrate.`,
+			);
+		}
+		// back up original byte-for-byte before mutating
+		copyFileSync(path, resolve(backupDir, filename));
+
+		const converted = convertLegacyRecord(parsed as unknown as LegacyRecord);
+		atomicWriteText(path, `${JSON.stringify(converted, null, 2)}\n`);
+		migrated += 1;
+	}
+
+	writeFileSync(sentinel, new Date().toISOString(), "utf8");
+	return { runId, status: "migrated", migrated, skipped };
+}
+
+function undoRun(runDir: string, runId: string): RunMigrationResult {
+	const recordsDir = resolve(runDir, "records");
+	if (!existsSync(recordsDir)) {
+		return { runId, status: "no_records", migrated: 0, skipped: 0 };
+	}
+	const sentinel = resolve(recordsDir, SENTINEL_NAME);
+	const backupDir = resolve(recordsDir, BACKUP_DIR_NAME);
+	if (!existsSync(sentinel) || !existsSync(backupDir)) {
+		return { runId, status: "no_records", migrated: 0, skipped: 0 };
+	}
+	const files = readdirSync(backupDir).filter((f) => f.endsWith(".json"));
+	for (const filename of files) {
+		const from = resolve(backupDir, filename);
+		const to = resolve(recordsDir, filename);
+		renameSync(from, to);
+	}
+	// remove backup directory (now empty) and sentinel
+	try {
+		rmSync(backupDir, { recursive: true, force: true });
+	} catch {
+		/* best effort */
+	}
+	unlinkSync(sentinel);
+	return { runId, status: "undone", migrated: files.length, skipped: 0 };
+}
+
+// --- conversion ---------------------------------------------------------
+
+type LegacyRecord = ApprovalRecord | ClarifyRecord;
+
+function convertLegacyRecord(legacy: LegacyRecord): GateRecord {
+	if (legacy.record_kind === "approval") {
+		return convertApproval(legacy);
+	}
+	return convertClarify(legacy);
+}
+
+function convertApproval(legacy: ApprovalRecord): GateRecord {
+	const status: GateRecord["status"] =
+		legacy.status === "pending" ? "pending" : "resolved";
+	const resolvedResponse: string | null =
+		legacy.status === "approved"
+			? "accept"
+			: legacy.status === "rejected"
+				? "reject"
+				: null;
+	return {
+		gate_id: legacy.record_id,
+		gate_kind: "approval",
+		run_id: legacy.run_id,
+		originating_phase: legacy.phase_from,
+		status,
+		reason: `Approval required to move from ${legacy.phase_from} to ${legacy.phase_to}`,
+		payload: {
+			kind: "approval",
+			phase_from: legacy.phase_from,
+			phase_to: legacy.phase_to,
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["accept", "reject"],
+		created_at: legacy.requested_at,
+		resolved_at: legacy.decided_at,
+		decision_actor: legacy.decision_actor,
+		resolved_response: resolvedResponse,
+		event_ids: [...legacy.event_ids],
+	};
+}
+
+function convertClarify(legacy: ClarifyRecord): GateRecord {
+	const status: GateRecord["status"] =
+		legacy.status === "pending" ? "pending" : "resolved";
+	return {
+		gate_id: legacy.record_id,
+		gate_kind: "clarify",
+		run_id: legacy.run_id,
+		originating_phase: legacy.phase,
+		status,
+		reason: "Clarification requested",
+		payload: {
+			kind: "clarify",
+			question: legacy.question,
+			question_context: legacy.question_context,
+			answer: legacy.answer ?? undefined,
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["clarify_response"],
+		created_at: legacy.asked_at,
+		resolved_at: legacy.answered_at,
+		decision_actor: null,
+		resolved_response: legacy.status === "resolved" ? "clarify_response" : null,
+		event_ids: [...legacy.event_ids],
+	};
+}

--- a/src/lib/record-id-alias.ts
+++ b/src/lib/record-id-alias.ts
@@ -1,0 +1,35 @@
+// Temporary compatibility helper: map a GateRecord to the `record_id` field
+// still referenced by `surface-event-contract` consumers.
+//
+// The follow-up change that updates `surface-event-contract` and
+// `workflow-run-state` will remove these references and delete this helper.
+//
+// Tracking reference: https://github.com/skr19930617/specflow/issues (create
+// a follow-up issue titled "Remove record_id alias from surface-event-contract
+// and workflow-run-state" immediately after archiving this change).
+
+import type { GateRecord } from "../types/gate-records.js";
+import type { InteractionRecord } from "../types/interaction-records.js";
+
+/**
+ * Return the string a surface-event `record_id` field should carry, given a
+ * gate record. During the transition period this is identical to the gate's
+ * own id so downstream consumers see no behavioral change.
+ */
+export function recordIdForGate(gate: GateRecord): string {
+	return gate.gate_id;
+}
+
+/**
+ * Return the string a surface-event `record_id` field should carry, given an
+ * either-shape record. Accepts legacy records unchanged so existing call sites
+ * continue to pass their typed record directly.
+ */
+export function recordIdFor(record: InteractionRecord | GateRecord): string {
+	if (isGateLike(record)) return record.gate_id;
+	return record.record_id;
+}
+
+function isGateLike(r: InteractionRecord | GateRecord): r is GateRecord {
+	return typeof (r as GateRecord).gate_id === "string";
+}

--- a/src/lib/review-decision-gate.ts
+++ b/src/lib/review-decision-gate.ts
@@ -1,0 +1,131 @@
+// Helper to issue a review_decision gate at the end of a review round.
+//
+// Review CLIs (`specflow-challenge-proposal`, `specflow-review-design`,
+// `specflow-review-apply`) call `issueReviewDecisionGate` after persisting a
+// completed round to the ledger. The helper:
+//   - builds the review_decision GateRecord payload with the full round
+//     provenance (review_round_id, findings, reviewer_actor, approval_binding).
+//   - issues the gate via `issueGate` so concurrency / supersede rules apply.
+//   - writes the gate_id back-reference into the ledger via the supplied
+//     `patchLedgerGateId` hook.
+//
+// The correlation-and-repair protocol (design D10) is:
+//   1) Ledger round is appended with gate_id = null.
+//   2) Gate is issued with review_round_id referencing the ledger round.
+//   3) Ledger round is patched with the issued gate_id.
+// If step 2 or 3 fails, the recovery routine can reconcile by listing pending
+// gates with matching review_round_id and patching the ledger back-reference.
+
+import type { ActorIdentity } from "../contracts/surface-events.js";
+import type {
+	GateRecord,
+	ReviewFindingSnapshot,
+} from "../types/gate-records.js";
+import type { GateRecordStore } from "./gate-record-store.js";
+import { type IssueGateInput, issueGate } from "./gate-runtime.js";
+
+export type ReviewPhase =
+	| "proposal_challenge"
+	| "design_review"
+	| "apply_review";
+
+export interface ReviewRoundProvenance {
+	readonly run_id: string;
+	readonly review_phase: ReviewPhase;
+	readonly review_round_id: string;
+	readonly findings: readonly ReviewFindingSnapshot[];
+	readonly reviewer_actor: "human" | "ai-agent" | "automation";
+	readonly reviewer_actor_id: string;
+	readonly approval_binding: "binding" | "advisory" | "not_applicable";
+	readonly reason?: string;
+}
+
+export interface IssueReviewDecisionGateDeps {
+	readonly store: GateRecordStore;
+	readonly projectRoot: string;
+	readonly gateId: string;
+	readonly createdAt: string;
+	readonly creationEventId?: string;
+}
+
+/**
+ * Build the IssueGateInput for a review_decision gate. Exported for testing
+ * payload construction without hitting the filesystem.
+ */
+export function buildReviewDecisionGateInput(
+	round: ReviewRoundProvenance,
+	gateId: string,
+	createdAt: string,
+	creationEventId?: string,
+): IssueGateInput {
+	return {
+		gate_id: gateId,
+		gate_kind: "review_decision",
+		run_id: round.run_id,
+		originating_phase: round.review_phase,
+		reason:
+			round.reason ??
+			`Review round ${round.review_round_id} completed with ${round.findings.length} finding(s); human-author decision required.`,
+		payload: {
+			kind: "review_decision",
+			review_round_id: round.review_round_id,
+			findings: round.findings,
+			reviewer_actor: round.reviewer_actor,
+			reviewer_actor_id: round.reviewer_actor_id,
+			approval_binding: round.approval_binding,
+		},
+		// eligible_responder_roles is intentionally omitted so the per-kind
+		// default policy (human-author only) is applied by issueGate.
+		created_at: createdAt,
+		creation_event_id: creationEventId,
+	};
+}
+
+/**
+ * Issue exactly one review_decision gate for a completed review round. If a
+ * prior pending review_decision gate exists for the same originating_phase, it
+ * is superseded atomically by issueGate.
+ */
+export function issueReviewDecisionGate(
+	round: ReviewRoundProvenance,
+	deps: IssueReviewDecisionGateDeps,
+): GateRecord {
+	const input = buildReviewDecisionGateInput(
+		round,
+		deps.gateId,
+		deps.createdAt,
+		deps.creationEventId,
+	);
+	return issueGate(deps.store, deps.projectRoot, input);
+}
+
+/**
+ * Given a list of a run's gates, find the review_decision gate whose
+ * payload.review_round_id matches the given round id. Used by the
+ * correlation-and-repair protocol to recover a dangling gate_id back-reference.
+ */
+export function findReviewDecisionGateByRoundId(
+	gates: readonly GateRecord[],
+	reviewRoundId: string,
+): GateRecord | null {
+	for (const g of gates) {
+		if (
+			g.gate_kind === "review_decision" &&
+			g.payload.kind === "review_decision" &&
+			g.payload.review_round_id === reviewRoundId
+		) {
+			return g;
+		}
+	}
+	return null;
+}
+
+/** Convenience: derive an `ActorIdentity` from the round provenance. */
+export function roundProvenanceToReviewerIdentity(
+	round: ReviewRoundProvenance,
+): ActorIdentity {
+	return {
+		actor: round.reviewer_actor,
+		actor_id: round.reviewer_actor_id,
+	};
+}

--- a/src/lib/review-ledger.ts
+++ b/src/lib/review-ledger.ts
@@ -844,3 +844,22 @@ export async function writeLedgerToStore(
 		`${JSON.stringify(ledger, null, 2)}\n`,
 	);
 }
+
+/**
+ * Patch the latest round_summary in the ledger with a gate_id back-reference.
+ * Returns a new ledger (immutable). If no round_summaries exist, returns the
+ * ledger unchanged.
+ */
+export function patchLatestRoundGateId(
+	ledger: ReviewLedger,
+	gateId: string,
+): ReviewLedger {
+	const summaries = ledger.round_summaries;
+	if (!summaries || summaries.length === 0) return ledger;
+	const updated: LedgerRoundSummary[] = [...summaries];
+	updated[updated.length - 1] = {
+		...updated[updated.length - 1],
+		gate_id: gateId,
+	};
+	return { ...ledger, round_summaries: updated };
+}

--- a/src/tests/fixtures/legacy-final/review-apply/output.json
+++ b/src/tests/fixtures/legacy-final/review-apply/output.json
@@ -74,5 +74,6 @@
 		"diff_warning": false,
 		"threshold": 1000
 	},
-	"error": null
+	"error": null,
+	"gate_id": null
 }

--- a/src/tests/fixtures/legacy-final/review-design/output.json
+++ b/src/tests/fixtures/legacy-final/review-design/output.json
@@ -68,5 +68,6 @@
 		"severity_summary": "HIGH: 1"
 	},
 	"rereview_classification": null,
-	"error": null
+	"error": null,
+	"gate_id": null
 }

--- a/src/tests/gate-mutation-bridge.test.ts
+++ b/src/tests/gate-mutation-bridge.test.ts
@@ -1,0 +1,295 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RecordMutation } from "../core/types.js";
+import { createFakeGateRecordStore } from "../lib/fake-gate-record-store.js";
+import {
+	gateRecordsToInteractionRecords,
+	mirrorMutationsToGateStore,
+	translateToGateRecord,
+} from "../lib/gate-mutation-bridge.js";
+import type { GateRecord } from "../types/gate-records.js";
+import type {
+	ApprovalRecord,
+	ClarifyRecord,
+} from "../types/interaction-records.js";
+
+function approvalRec(status: ApprovalRecord["status"]): ApprovalRecord {
+	return {
+		record_id: "approval-r-1",
+		record_kind: "approval",
+		run_id: "r",
+		phase_from: "spec_ready",
+		phase_to: "design_draft",
+		status,
+		requested_at: "2026-04-01T00:00:00Z",
+		decided_at: status === "pending" ? null : "2026-04-01T01:00:00Z",
+		decision_actor:
+			status === "pending" ? null : { actor: "human", actor_id: "yuki" },
+		event_ids: ["evt-1"],
+	};
+}
+
+function clarifyRec(status: ClarifyRecord["status"]): ClarifyRecord {
+	return {
+		record_id: "clarify-r-1",
+		record_kind: "clarify",
+		run_id: "r",
+		phase: "proposal_clarify",
+		question: "q?",
+		answer: status === "resolved" ? "a." : null,
+		status,
+		asked_at: "2026-04-02T00:00:00Z",
+		answered_at: status === "resolved" ? "2026-04-02T01:00:00Z" : null,
+		event_ids: ["evt-2"],
+	};
+}
+
+test("translateToGateRecord maps pending ApprovalRecord to pending GateRecord", () => {
+	const g = translateToGateRecord(approvalRec("pending"));
+	assert.equal(g.gate_kind, "approval");
+	assert.equal(g.status, "pending");
+	assert.equal(g.gate_id, "approval-r-1");
+	assert.equal(g.payload.kind, "approval");
+});
+
+test("translateToGateRecord maps approved ApprovalRecord to resolved GateRecord with resolved_response=accept", () => {
+	const g = translateToGateRecord(approvalRec("approved"));
+	assert.equal(g.status, "resolved");
+	assert.equal(g.resolved_response, "accept");
+	assert.equal(g.decision_actor?.actor_id, "yuki");
+});
+
+test("translateToGateRecord maps rejected ApprovalRecord to resolved GateRecord with resolved_response=reject", () => {
+	const g = translateToGateRecord(approvalRec("rejected"));
+	assert.equal(g.status, "resolved");
+	assert.equal(g.resolved_response, "reject");
+});
+
+test("translateToGateRecord maps clarify records with answer carried in payload", () => {
+	const g = translateToGateRecord(clarifyRec("resolved"));
+	assert.equal(g.gate_kind, "clarify");
+	assert.equal(g.status, "resolved");
+	if (g.payload.kind === "clarify") {
+		assert.equal(g.payload.answer, "a.");
+	} else {
+		assert.fail("payload kind mismatch");
+	}
+});
+
+test("mirrorMutationsToGateStore writes equivalent GateRecord per create mutation", () => {
+	const store = createFakeGateRecordStore();
+	const mutations: RecordMutation[] = [
+		{ kind: "create", record: approvalRec("pending") },
+		{ kind: "update", record: approvalRec("approved") },
+	];
+	const errors = mirrorMutationsToGateStore(store, "r", mutations);
+	assert.equal(errors.length, 0);
+	const listed = store.list("r");
+	// Both mutations target the same gate_id; the second write replaces the first.
+	assert.equal(listed.length, 1);
+	assert.equal(listed[0].status, "resolved");
+	assert.equal(listed[0].resolved_response, "accept");
+});
+
+test("mirrorMutationsToGateStore translates delete of pending gate to superseded status", () => {
+	const store = createFakeGateRecordStore();
+	const mutations: RecordMutation[] = [
+		{ kind: "create", record: approvalRec("pending") },
+		{ kind: "delete", recordId: "approval-r-1" },
+	];
+	const errors = mirrorMutationsToGateStore(store, "r", mutations);
+	assert.equal(errors.length, 0);
+	const listed = store.list("r");
+	// delete is translated to superseded; the gate record remains for audit.
+	assert.equal(listed.length, 1);
+	assert.equal(listed[0].status, "superseded");
+	assert.equal(listed[0].resolved_response, null);
+});
+
+test("mirrorMutationsToGateStore delete of already-resolved gate is a no-op", () => {
+	const store = createFakeGateRecordStore();
+	const mutations: RecordMutation[] = [
+		{ kind: "create", record: approvalRec("approved") },
+		{ kind: "delete", recordId: "approval-r-1" },
+	];
+	const errors = mirrorMutationsToGateStore(store, "r", mutations);
+	assert.equal(errors.length, 0);
+	const listed = store.list("r");
+	assert.equal(listed.length, 1);
+	// Already resolved — delete does not change status.
+	assert.equal(listed[0].status, "resolved");
+});
+
+test("mirrorMutationsToGateStore returns per-mutation errors without aborting batch", () => {
+	// Use a store that throws on a specific gate_id write.
+	const inner = createFakeGateRecordStore();
+	const failingStore: import("../lib/gate-record-store.js").GateRecordStore = {
+		write(runId: string, record: GateRecord): void {
+			if (record.gate_id === "clarify-r-1") {
+				throw new Error("disk full");
+			}
+			inner.write(runId, record);
+		},
+		read: inner.read.bind(inner),
+		list: inner.list.bind(inner),
+	};
+	const mutations: RecordMutation[] = [
+		{ kind: "create", record: approvalRec("pending") },
+		{ kind: "create", record: clarifyRec("pending") },
+	];
+	const errors = mirrorMutationsToGateStore(failingStore, "r", mutations);
+	// First mutation succeeds, second fails.
+	assert.equal(errors.length, 1);
+	assert.equal(errors[0].recordId, "clarify-r-1");
+	// The first mutation's record should still be present.
+	assert.equal(inner.list("r").length, 1);
+	assert.equal(inner.list("r")[0].gate_id, "approval-r-1");
+});
+
+// ---------------------------------------------------------------------------
+// Reverse bridge: GateRecord → InteractionRecord
+// ---------------------------------------------------------------------------
+
+function makeApprovalGate(
+	status: GateRecord["status"],
+	response: string | null = null,
+): GateRecord {
+	return {
+		gate_id: "approval-r-1",
+		gate_kind: "approval",
+		run_id: "r",
+		originating_phase: "spec_ready",
+		status,
+		reason: "Approval required",
+		payload: {
+			kind: "approval",
+			phase_from: "spec_ready",
+			phase_to: "design_draft",
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["accept", "reject"],
+		created_at: "2026-04-01T00:00:00Z",
+		resolved_at: status === "pending" ? null : "2026-04-01T01:00:00Z",
+		decision_actor:
+			status === "pending" ? null : { actor: "human", actor_id: "yuki" },
+		resolved_response: response,
+		event_ids: ["evt-1"],
+	};
+}
+
+function makeClarifyGate(
+	status: GateRecord["status"],
+	answer?: string,
+): GateRecord {
+	return {
+		gate_id: "clarify-r-1",
+		gate_kind: "clarify",
+		run_id: "r",
+		originating_phase: "proposal_clarify",
+		status,
+		reason: "Clarification requested",
+		payload: {
+			kind: "clarify",
+			question: "q?",
+			...(answer !== undefined ? { answer } : {}),
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["clarify_response"],
+		created_at: "2026-04-02T00:00:00Z",
+		resolved_at: status === "pending" ? null : "2026-04-02T01:00:00Z",
+		decision_actor: null,
+		resolved_response: status === "resolved" ? "clarify_response" : null,
+		event_ids: ["evt-2"],
+	};
+}
+
+test("gateRecordsToInteractionRecords translates pending approval gate to pending ApprovalRecord", () => {
+	const records = gateRecordsToInteractionRecords([
+		makeApprovalGate("pending"),
+	]);
+	assert.equal(records.length, 1);
+	const rec = records[0];
+	assert.equal(rec.record_kind, "approval");
+	assert.equal(rec.record_id, "approval-r-1");
+	if (rec.record_kind === "approval") {
+		assert.equal(rec.status, "pending");
+		assert.equal(rec.phase_from, "spec_ready");
+		assert.equal(rec.phase_to, "design_draft");
+	}
+});
+
+test("gateRecordsToInteractionRecords translates resolved+accept gate to approved ApprovalRecord", () => {
+	const records = gateRecordsToInteractionRecords([
+		makeApprovalGate("resolved", "accept"),
+	]);
+	assert.equal(records.length, 1);
+	if (records[0].record_kind === "approval") {
+		assert.equal(records[0].status, "approved");
+	}
+});
+
+test("gateRecordsToInteractionRecords translates resolved+reject gate to rejected ApprovalRecord", () => {
+	const records = gateRecordsToInteractionRecords([
+		makeApprovalGate("resolved", "reject"),
+	]);
+	if (records[0].record_kind === "approval") {
+		assert.equal(records[0].status, "rejected");
+	}
+});
+
+test("gateRecordsToInteractionRecords translates superseded gate to rejected ApprovalRecord", () => {
+	const records = gateRecordsToInteractionRecords([
+		makeApprovalGate("superseded"),
+	]);
+	if (records[0].record_kind === "approval") {
+		assert.equal(records[0].status, "rejected");
+	}
+});
+
+test("gateRecordsToInteractionRecords translates clarify gate with answer", () => {
+	const records = gateRecordsToInteractionRecords([
+		makeClarifyGate("resolved", "Because."),
+	]);
+	assert.equal(records.length, 1);
+	if (records[0].record_kind === "clarify") {
+		assert.equal(records[0].status, "resolved");
+		assert.equal(records[0].answer, "Because.");
+		assert.equal(records[0].question, "q?");
+	}
+});
+
+test("gateRecordsToInteractionRecords excludes review_decision gates", () => {
+	const reviewGate: GateRecord = {
+		gate_id: "review_decision-r-1",
+		gate_kind: "review_decision",
+		run_id: "r",
+		originating_phase: "design_review",
+		status: "pending",
+		reason: "round 1",
+		payload: {
+			kind: "review_decision",
+			review_round_id: "rd-1",
+			findings: [],
+			reviewer_actor: "ai-agent",
+			reviewer_actor_id: "codex",
+			approval_binding: "advisory",
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["accept", "reject", "request_changes"],
+		created_at: "2026-04-18T00:00:00Z",
+		resolved_at: null,
+		decision_actor: null,
+		resolved_response: null,
+		event_ids: [],
+	};
+	const records = gateRecordsToInteractionRecords([
+		makeApprovalGate("pending"),
+		reviewGate,
+		makeClarifyGate("pending"),
+	]);
+	// review_decision has no legacy equivalent; should be excluded.
+	assert.equal(records.length, 2);
+	assert.ok(
+		records.every((r) => r.record_kind !== ("review_decision" as string)),
+	);
+});

--- a/src/tests/gate-records.test.ts
+++ b/src/tests/gate-records.test.ts
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { createFakeGateRecordStore } from "../lib/fake-gate-record-store.js";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import type { GateRecord } from "../types/gate-records.js";
+import {
+	ALLOWED_RESPONSES_BY_KIND,
+	allowedResponsesFor,
+	DEFAULT_ELIGIBLE_ROLES_BY_KIND,
+	defaultEligibleRolesFor,
+	generateGateId,
+	isGateRecordShape,
+	isLegacyRecordShape,
+	UnmigratedRecordError,
+} from "../types/gate-records.js";
+
+// ---------------------------------------------------------------------------
+// generateGateId
+// ---------------------------------------------------------------------------
+
+test("generateGateId produces <kind>-<runId>-<sequence> format", () => {
+	assert.equal(
+		generateGateId("approval", "my-feature-1", 1),
+		"approval-my-feature-1-1",
+	);
+	assert.equal(
+		generateGateId("clarify", "my-feature-1", 3),
+		"clarify-my-feature-1-3",
+	);
+	assert.equal(
+		generateGateId("review_decision", "run-1", 2),
+		"review_decision-run-1-2",
+	);
+});
+
+// ---------------------------------------------------------------------------
+// Policy tables
+// ---------------------------------------------------------------------------
+
+test("ALLOWED_RESPONSES_BY_KIND matches the workflow-gate-semantics spec", () => {
+	assert.deepEqual(ALLOWED_RESPONSES_BY_KIND.approval, ["accept", "reject"]);
+	assert.deepEqual(ALLOWED_RESPONSES_BY_KIND.clarify, ["clarify_response"]);
+	assert.deepEqual(ALLOWED_RESPONSES_BY_KIND.review_decision, [
+		"accept",
+		"reject",
+		"request_changes",
+	]);
+});
+
+test("allowedResponsesFor exposes the same fixed table by function", () => {
+	assert.deepEqual(allowedResponsesFor("approval"), ["accept", "reject"]);
+	assert.deepEqual(allowedResponsesFor("clarify"), ["clarify_response"]);
+	assert.deepEqual(allowedResponsesFor("review_decision"), [
+		"accept",
+		"reject",
+		"request_changes",
+	]);
+});
+
+test("DEFAULT_ELIGIBLE_ROLES_BY_KIND defaults every kind to human-author", () => {
+	assert.deepEqual(DEFAULT_ELIGIBLE_ROLES_BY_KIND.approval, ["human-author"]);
+	assert.deepEqual(DEFAULT_ELIGIBLE_ROLES_BY_KIND.clarify, ["human-author"]);
+	assert.deepEqual(DEFAULT_ELIGIBLE_ROLES_BY_KIND.review_decision, [
+		"human-author",
+	]);
+});
+
+test("defaultEligibleRolesFor returns the policy-table entry", () => {
+	assert.deepEqual(defaultEligibleRolesFor("approval"), ["human-author"]);
+});
+
+// ---------------------------------------------------------------------------
+// Shape guards
+// ---------------------------------------------------------------------------
+
+test("isLegacyRecordShape detects ApprovalRecord / ClarifyRecord JSON", () => {
+	assert.equal(
+		isLegacyRecordShape({ record_kind: "approval", record_id: "x" }),
+		true,
+	);
+	assert.equal(
+		isLegacyRecordShape({ record_kind: "clarify", record_id: "x" }),
+		true,
+	);
+});
+
+test("isLegacyRecordShape returns false for GateRecord JSON", () => {
+	assert.equal(
+		isLegacyRecordShape({ gate_kind: "approval", gate_id: "g1" }),
+		false,
+	);
+});
+
+test("isLegacyRecordShape returns false for unrelated objects", () => {
+	assert.equal(isLegacyRecordShape({}), false);
+	assert.equal(isLegacyRecordShape(null), false);
+	assert.equal(isLegacyRecordShape("string"), false);
+});
+
+test("isGateRecordShape requires gate_id, gate_kind, and required arrays", () => {
+	const valid: GateRecord = makeApprovalGate("run-1", "approval-run-1-1");
+	assert.equal(isGateRecordShape(valid), true);
+	assert.equal(isGateRecordShape({ gate_id: "x" }), false);
+});
+
+// ---------------------------------------------------------------------------
+// UnmigratedRecordError
+// ---------------------------------------------------------------------------
+
+test("UnmigratedRecordError captures the offending path", () => {
+	const err = new UnmigratedRecordError("/path/to/legacy.json");
+	assert.equal(err.name, "UnmigratedRecordError");
+	assert.equal(err.gate_id_or_path, "/path/to/legacy.json");
+	assert.match(err.message, /specflow-migrate-records/);
+});
+
+// ---------------------------------------------------------------------------
+// FakeGateRecordStore
+// ---------------------------------------------------------------------------
+
+function makeApprovalGate(runId: string, gateId: string): GateRecord {
+	return {
+		gate_id: gateId,
+		gate_kind: "approval",
+		run_id: runId,
+		originating_phase: "spec_ready",
+		status: "pending",
+		reason: "Spec acceptance required",
+		payload: {
+			kind: "approval",
+			phase_from: "spec_ready",
+			phase_to: "design_draft",
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["accept", "reject"],
+		created_at: "2026-04-18T00:00:00Z",
+		resolved_at: null,
+		decision_actor: null,
+		resolved_response: null,
+		event_ids: [],
+	};
+}
+
+function makeClarifyGate(runId: string, gateId: string): GateRecord {
+	return {
+		gate_id: gateId,
+		gate_kind: "clarify",
+		run_id: runId,
+		originating_phase: "proposal_clarify",
+		status: "pending",
+		reason: "Clarification needed",
+		payload: {
+			kind: "clarify",
+			question: "What is the scope?",
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["clarify_response"],
+		created_at: "2026-04-18T00:00:00Z",
+		resolved_at: null,
+		decision_actor: null,
+		resolved_response: null,
+		event_ids: [],
+	};
+}
+
+test("FakeGateRecordStore.write + read roundtrips a record", () => {
+	const store = createFakeGateRecordStore();
+	const g = makeApprovalGate("run-1", "approval-run-1-1");
+	store.write("run-1", g);
+	assert.deepEqual(store.read("run-1", g.gate_id), g);
+});
+
+test("FakeGateRecordStore.read returns null for missing gate", () => {
+	const store = createFakeGateRecordStore();
+	assert.equal(store.read("run-1", "missing"), null);
+});
+
+test("FakeGateRecordStore.write replaces an existing record", () => {
+	const store = createFakeGateRecordStore();
+	const g = makeApprovalGate("run-1", "approval-run-1-1");
+	store.write("run-1", g);
+	const updated: GateRecord = {
+		...g,
+		status: "resolved",
+		resolved_at: "2026-04-18T01:00:00Z",
+		resolved_response: "accept",
+	};
+	store.write("run-1", updated);
+	assert.equal(store.read("run-1", g.gate_id)?.status, "resolved");
+});
+
+test("FakeGateRecordStore.list returns all records for a run", () => {
+	const store = createFakeGateRecordStore();
+	store.write("run-1", makeApprovalGate("run-1", "approval-run-1-1"));
+	store.write("run-1", makeClarifyGate("run-1", "clarify-run-1-1"));
+	store.write("run-1", makeClarifyGate("run-1", "clarify-run-1-2"));
+	const listed = store.list("run-1");
+	assert.equal(listed.length, 3);
+});
+
+test("FakeGateRecordStore.list isolates runs", () => {
+	const store = createFakeGateRecordStore();
+	store.write("run-1", makeApprovalGate("run-1", "approval-run-1-1"));
+	store.write("run-2", makeApprovalGate("run-2", "approval-run-2-1"));
+	assert.equal(store.list("run-1").length, 1);
+	assert.equal(store.list("run-2").length, 1);
+});
+
+test("FakeGateRecordStore has no delete API", () => {
+	const store = createFakeGateRecordStore();
+	// The type itself forbids `delete`; at runtime we confirm the property is absent.
+	assert.equal(
+		Object.hasOwn(store, "delete"),
+		false,
+		"GateRecordStore must not expose a delete operation",
+	);
+});
+
+// ---------------------------------------------------------------------------
+// LocalFsGateRecordStore
+// ---------------------------------------------------------------------------
+
+function makeTempRepo(): string {
+	const dir = mkdtempSync(resolve(tmpdir(), "specflow-gate-test-"));
+	return dir;
+}
+
+test("LocalFsGateRecordStore.write + read uses records/<gateId>.json", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		const g = makeApprovalGate("my-feature-1", "approval-my-feature-1-1");
+		store.write("my-feature-1", g);
+		const round = store.read("my-feature-1", g.gate_id);
+		assert.deepEqual(round, g);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LocalFsGateRecordStore.read returns null for non-existent gate", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		assert.equal(store.read("my-feature-1", "missing"), null);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LocalFsGateRecordStore.list returns empty for missing run directory", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		assert.deepEqual(store.list("never-existed"), []);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LocalFsGateRecordStore.list returns all .json records in order", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		store.write("r", makeApprovalGate("r", "approval-r-1"));
+		store.write("r", makeClarifyGate("r", "clarify-r-1"));
+		store.write("r", makeClarifyGate("r", "clarify-r-2"));
+		const listed = store.list("r");
+		assert.equal(listed.length, 3);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LocalFsGateRecordStore.read throws UnmigratedRecordError on legacy file", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			resolve(dir, "approval-r-1.json"),
+			JSON.stringify({
+				record_id: "approval-r-1",
+				record_kind: "approval",
+				run_id: "r",
+			}),
+		);
+		const store = createLocalFsGateRecordStore(root);
+		assert.throws(
+			() => store.read("r", "approval-r-1"),
+			(err: unknown) => err instanceof UnmigratedRecordError,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LocalFsGateRecordStore.list throws UnmigratedRecordError if any file is legacy-shaped", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		const store = createLocalFsGateRecordStore(root);
+		// write one valid GateRecord
+		store.write("r", makeApprovalGate("r", "approval-r-1"));
+		// write one legacy shape
+		writeFileSync(
+			resolve(dir, "approval-r-2.json"),
+			JSON.stringify({
+				record_id: "approval-r-2",
+				record_kind: "approval",
+				run_id: "r",
+			}),
+		);
+		assert.throws(
+			() => store.list("r"),
+			(err: unknown) => err instanceof UnmigratedRecordError,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LocalFsGateRecordStore.list skips dot-prefixed files (journal/sentinel)", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		const store = createLocalFsGateRecordStore(root);
+		store.write("r", makeApprovalGate("r", "approval-r-1"));
+		// Simulate .migrated sentinel and .supersede-intent.json
+		writeFileSync(resolve(dir, ".migrated"), "ok");
+		writeFileSync(
+			resolve(dir, ".supersede-intent.json"),
+			JSON.stringify({ old: null, new: null }),
+		);
+		const listed = store.list("r");
+		assert.equal(listed.length, 1);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LocalFsGateRecordStore.write uses atomic rename (no .tmp remnants)", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		store.write("r", makeApprovalGate("r", "approval-r-1"));
+		// After a successful write, there should be exactly one .json file and no stray .tmp files.
+		const dir = resolve(root, ".specflow/runs/r/records");
+		const entries = readdirSync(dir).filter((f: string) => f.endsWith(".tmp"));
+		assert.equal(entries.length, 0);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("LocalFsGateRecordStore has no delete API", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		assert.equal(
+			Object.hasOwn(store, "delete"),
+			false,
+			"GateRecordStore must not expose a delete operation",
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/src/tests/gate-runtime.test.ts
+++ b/src/tests/gate-runtime.test.ts
@@ -1,0 +1,405 @@
+import assert from "node:assert/strict";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { createFakeGateRecordStore } from "../lib/fake-gate-record-store.js";
+import {
+	GateRuntimeError,
+	issueGate,
+	listRunsWithPendingIntent,
+	recoverPendingIntent,
+	resolveGate,
+} from "../lib/gate-runtime.js";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import type { GateRecord } from "../types/gate-records.js";
+import { generateGateId } from "../types/gate-records.js";
+
+function makeTempRepo(): string {
+	return mkdtempSync(resolve(tmpdir(), "specflow-gate-rt-test-"));
+}
+
+// --- issueGate: basic paths -------------------------------------------------
+
+test("issueGate creates a pending approval gate with default roles and allowed_responses", () => {
+	const store = createFakeGateRecordStore();
+	const g = issueGate(store, "/tmp/doesntmatter", {
+		gate_id: generateGateId("approval", "r", 1),
+		gate_kind: "approval",
+		run_id: "r",
+		originating_phase: "spec_ready",
+		reason: "spec acceptance",
+		payload: {
+			kind: "approval",
+			phase_from: "spec_ready",
+			phase_to: "design_draft",
+		},
+		created_at: "2026-04-18T00:00:00Z",
+	});
+	assert.equal(g.status, "pending");
+	assert.deepEqual([...g.eligible_responder_roles], ["human-author"]);
+	assert.deepEqual([...g.allowed_responses], ["accept", "reject"]);
+});
+
+test("issueGate for clarify allows multiple concurrent pending gates in same phase (no supersede)", () => {
+	const store = createFakeGateRecordStore();
+	issueGate(store, "/tmp", {
+		gate_id: "clarify-r-1",
+		gate_kind: "clarify",
+		run_id: "r",
+		originating_phase: "proposal_clarify",
+		reason: "q1",
+		payload: { kind: "clarify", question: "q1" },
+		created_at: "2026-04-18T00:00:00Z",
+	});
+	issueGate(store, "/tmp", {
+		gate_id: "clarify-r-2",
+		gate_kind: "clarify",
+		run_id: "r",
+		originating_phase: "proposal_clarify",
+		reason: "q2",
+		payload: { kind: "clarify", question: "q2" },
+		created_at: "2026-04-18T00:00:01Z",
+	});
+	const pending = store
+		.list("r")
+		.filter((g) => g.gate_kind === "clarify" && g.status === "pending");
+	assert.equal(pending.length, 2);
+});
+
+// --- issueGate: supersede for approval/review_decision ----------------------
+
+test("issueGate supersedes the prior pending approval gate in same phase", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		const first = issueGate(store, root, {
+			gate_id: "approval-r-1",
+			gate_kind: "approval",
+			run_id: "r",
+			originating_phase: "spec_ready",
+			reason: "r1",
+			payload: {
+				kind: "approval",
+				phase_from: "spec_ready",
+				phase_to: "design_draft",
+			},
+			created_at: "2026-04-18T00:00:00Z",
+		});
+		const second = issueGate(store, root, {
+			gate_id: "approval-r-2",
+			gate_kind: "approval",
+			run_id: "r",
+			originating_phase: "spec_ready",
+			reason: "r2",
+			payload: {
+				kind: "approval",
+				phase_from: "spec_ready",
+				phase_to: "design_draft",
+			},
+			created_at: "2026-04-18T00:00:01Z",
+		});
+		const all = store.list("r");
+		const byId = new Map(all.map((g) => [g.gate_id, g]));
+		assert.equal(byId.get(first.gate_id)?.status, "superseded");
+		assert.equal(byId.get(second.gate_id)?.status, "pending");
+		// lock released
+		assert.equal(
+			existsSync(resolve(root, ".specflow/runs/r/records/.gate-lock")),
+			false,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("issueGate supersedes the prior pending review_decision gate in same phase", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		const first = issueGate(store, root, {
+			gate_id: "review_decision-r-1",
+			gate_kind: "review_decision",
+			run_id: "r",
+			originating_phase: "design_review",
+			reason: "round 1",
+			payload: {
+				kind: "review_decision",
+				review_round_id: "rd-1",
+				findings: [],
+				reviewer_actor: "ai-agent",
+				reviewer_actor_id: "codex",
+				approval_binding: "advisory",
+			},
+			created_at: "2026-04-18T00:00:00Z",
+		});
+		const second = issueGate(store, root, {
+			gate_id: "review_decision-r-2",
+			gate_kind: "review_decision",
+			run_id: "r",
+			originating_phase: "design_review",
+			reason: "round 2",
+			payload: {
+				kind: "review_decision",
+				review_round_id: "rd-2",
+				findings: [],
+				reviewer_actor: "ai-agent",
+				reviewer_actor_id: "codex",
+				approval_binding: "advisory",
+			},
+			created_at: "2026-04-18T00:00:01Z",
+		});
+		const all = store.list("r");
+		const byId = new Map(all.map((g) => [g.gate_id, g]));
+		assert.equal(byId.get(first.gate_id)?.status, "superseded");
+		assert.equal(byId.get(second.gate_id)?.status, "pending");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- resolveGate: success + validation --------------------------------------
+
+test("resolveGate resolves an approval gate with accept", () => {
+	const store = createFakeGateRecordStore();
+	const g = issueGate(store, "/tmp", {
+		gate_id: "approval-r-1",
+		gate_kind: "approval",
+		run_id: "r",
+		originating_phase: "spec_ready",
+		reason: "x",
+		payload: {
+			kind: "approval",
+			phase_from: "spec_ready",
+			phase_to: "design_draft",
+		},
+		created_at: "2026-04-18T00:00:00Z",
+	});
+	const resolved = resolveGate(store, {
+		run_id: "r",
+		gate_id: g.gate_id,
+		response: "accept",
+		actor: { actor: "human", actor_id: "yuki" },
+		actor_role: "human-author",
+		resolved_at: "2026-04-18T01:00:00Z",
+	});
+	assert.equal(resolved.status, "resolved");
+	assert.equal(resolved.resolved_response, "accept");
+	assert.equal(resolved.decision_actor?.actor_id, "yuki");
+});
+
+test("resolveGate stores clarify answer in payload", () => {
+	const store = createFakeGateRecordStore();
+	const g = issueGate(store, "/tmp", {
+		gate_id: "clarify-r-1",
+		gate_kind: "clarify",
+		run_id: "r",
+		originating_phase: "proposal_clarify",
+		reason: "q",
+		payload: { kind: "clarify", question: "What?" },
+		created_at: "2026-04-18T00:00:00Z",
+	});
+	const resolved = resolveGate(store, {
+		run_id: "r",
+		gate_id: g.gate_id,
+		response: "clarify_response",
+		actor: { actor: "human", actor_id: "yuki" },
+		actor_role: "human-author",
+		resolved_at: "2026-04-18T01:00:00Z",
+		answer: "Because.",
+	});
+	assert.equal(resolved.status, "resolved");
+	assert.equal(resolved.payload.kind, "clarify");
+	if (resolved.payload.kind === "clarify") {
+		assert.equal(resolved.payload.answer, "Because.");
+	}
+});
+
+test("resolveGate rejects an invalid response and leaves gate pending", () => {
+	const store = createFakeGateRecordStore();
+	const g = issueGate(store, "/tmp", {
+		gate_id: "approval-r-1",
+		gate_kind: "approval",
+		run_id: "r",
+		originating_phase: "spec_ready",
+		reason: "x",
+		payload: {
+			kind: "approval",
+			phase_from: "spec_ready",
+			phase_to: "design_draft",
+		},
+		created_at: "2026-04-18T00:00:00Z",
+	});
+	assert.throws(
+		() =>
+			resolveGate(store, {
+				run_id: "r",
+				gate_id: g.gate_id,
+				response: "request_changes",
+				actor: { actor: "human", actor_id: "yuki" },
+				actor_role: "human-author",
+				resolved_at: "2026-04-18T01:00:00Z",
+			}),
+		(err: unknown) =>
+			err instanceof GateRuntimeError && err.kind === "invalid_response",
+	);
+	const after = store.read("r", g.gate_id);
+	assert.equal(after?.status, "pending");
+});
+
+test("resolveGate rejects a response from an ineligible role", () => {
+	const store = createFakeGateRecordStore();
+	const g = issueGate(store, "/tmp", {
+		gate_id: "approval-r-1",
+		gate_kind: "approval",
+		run_id: "r",
+		originating_phase: "spec_ready",
+		reason: "x",
+		payload: {
+			kind: "approval",
+			phase_from: "spec_ready",
+			phase_to: "design_draft",
+		},
+		created_at: "2026-04-18T00:00:00Z",
+	});
+	assert.throws(
+		() =>
+			resolveGate(store, {
+				run_id: "r",
+				gate_id: g.gate_id,
+				response: "accept",
+				actor: { actor: "ai-agent", actor_id: "codex" },
+				actor_role: "ai-agent",
+				resolved_at: "2026-04-18T01:00:00Z",
+			}),
+		(err: unknown) =>
+			err instanceof GateRuntimeError && err.kind === "role_not_eligible",
+	);
+});
+
+test("resolveGate rejects a response to a non-pending gate", () => {
+	const store = createFakeGateRecordStore();
+	const g = issueGate(store, "/tmp", {
+		gate_id: "approval-r-1",
+		gate_kind: "approval",
+		run_id: "r",
+		originating_phase: "spec_ready",
+		reason: "x",
+		payload: {
+			kind: "approval",
+			phase_from: "spec_ready",
+			phase_to: "design_draft",
+		},
+		created_at: "2026-04-18T00:00:00Z",
+	});
+	// resolve once
+	resolveGate(store, {
+		run_id: "r",
+		gate_id: g.gate_id,
+		response: "accept",
+		actor: { actor: "human", actor_id: "yuki" },
+		actor_role: "human-author",
+		resolved_at: "2026-04-18T01:00:00Z",
+	});
+	// second resolution should fail
+	assert.throws(
+		() =>
+			resolveGate(store, {
+				run_id: "r",
+				gate_id: g.gate_id,
+				response: "reject",
+				actor: { actor: "human", actor_id: "yuki" },
+				actor_role: "human-author",
+				resolved_at: "2026-04-18T02:00:00Z",
+			}),
+		(err: unknown) =>
+			err instanceof GateRuntimeError && err.kind === "gate_not_pending",
+	);
+});
+
+// --- Intent journal recovery ------------------------------------------------
+
+test("recoverPendingIntent replays a leftover supersede intent", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		// Pretend a prior issueGate crashed after writing only the intent journal.
+		// Seed the run so the records directory exists.
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		const newRecord: GateRecord = {
+			gate_id: "approval-r-1",
+			gate_kind: "approval",
+			run_id: "r",
+			originating_phase: "spec_ready",
+			status: "pending",
+			reason: "x",
+			payload: {
+				kind: "approval",
+				phase_from: "spec_ready",
+				phase_to: "design_draft",
+			},
+			eligible_responder_roles: ["human-author"],
+			allowed_responses: ["accept", "reject"],
+			created_at: "2026-04-18T00:00:00Z",
+			resolved_at: null,
+			decision_actor: null,
+			resolved_response: null,
+			event_ids: [],
+		};
+		const intent = {
+			version: 1,
+			kind: "supersede",
+			old_gate: null,
+			new_gate: newRecord,
+		};
+		writeFileSync(
+			resolve(dir, ".supersede-intent.json"),
+			JSON.stringify(intent),
+		);
+
+		assert.deepEqual(listRunsWithPendingIntent(root), ["r"]);
+		recoverPendingIntent(store, root, "r");
+		// new_gate should be materialized and intent cleared
+		const read = store.read("r", "approval-r-1");
+		assert.equal(read?.status, "pending");
+		assert.equal(existsSync(resolve(dir, ".supersede-intent.json")), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- Lock staleness ---------------------------------------------------------
+
+test("issueGate breaks a stale lock and continues", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		// Pre-create a stale .gate-lock (timestamp way in the past)
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(resolve(dir, ".gate-lock"), `99999:0`);
+		const g = issueGate(store, root, {
+			gate_id: "approval-r-1",
+			gate_kind: "approval",
+			run_id: "r",
+			originating_phase: "spec_ready",
+			reason: "x",
+			payload: {
+				kind: "approval",
+				phase_from: "spec_ready",
+				phase_to: "design_draft",
+			},
+			created_at: "2026-04-18T00:00:00Z",
+		});
+		assert.equal(g.status, "pending");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/src/tests/migrate-records.test.ts
+++ b/src/tests/migrate-records.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import { runMigration } from "../lib/migrate-records.js";
+import {
+	isGateRecordShape,
+	UnmigratedRecordError,
+} from "../types/gate-records.js";
+import type {
+	ApprovalRecord,
+	ClarifyRecord,
+} from "../types/interaction-records.js";
+
+function makeTempRepo(): string {
+	return mkdtempSync(resolve(tmpdir(), "specflow-migrate-test-"));
+}
+
+function legacyApproval(runId: string, id: string): ApprovalRecord {
+	return {
+		record_id: id,
+		record_kind: "approval",
+		run_id: runId,
+		phase_from: "spec_ready",
+		phase_to: "design_draft",
+		status: "approved",
+		requested_at: "2026-04-01T00:00:00Z",
+		decided_at: "2026-04-01T01:00:00Z",
+		decision_actor: { actor: "human", actor_id: "yuki" },
+		event_ids: ["evt-1", "evt-2"],
+	};
+}
+
+function legacyClarify(runId: string, id: string): ClarifyRecord {
+	return {
+		record_id: id,
+		record_kind: "clarify",
+		run_id: runId,
+		phase: "proposal_clarify",
+		question: "What is the scope?",
+		question_context: "Context here",
+		answer: "Scope answer",
+		status: "resolved",
+		asked_at: "2026-04-02T00:00:00Z",
+		answered_at: "2026-04-02T01:00:00Z",
+		event_ids: ["evt-3"],
+	};
+}
+
+function seedLegacyRun(root: string, runId: string, records: unknown[]): void {
+	const dir = resolve(root, ".specflow/runs", runId, "records");
+	mkdirSync(dir, { recursive: true });
+	for (const r of records) {
+		const filename = `${(r as { record_id: string }).record_id}.json`;
+		writeFileSync(resolve(dir, filename), JSON.stringify(r), "utf8");
+	}
+}
+
+// --- forward migration ------------------------------------------------------
+
+test("migration converts legacy ApprovalRecord to GateRecord in place", () => {
+	const root = makeTempRepo();
+	try {
+		const runId = "my-feature-1";
+		const legacy = legacyApproval(runId, "approval-my-feature-1-1");
+		seedLegacyRun(root, runId, [legacy]);
+
+		const result = runMigration(root, { mode: "forward" });
+		assert.equal(result.perRun.length, 1);
+		const r = result.perRun[0];
+		assert.equal(r.status, "migrated");
+		assert.equal(r.migrated, 1);
+
+		const recordPath = resolve(
+			root,
+			`.specflow/runs/${runId}/records/approval-${runId}-1.json`,
+		);
+		const parsed = JSON.parse(readFileSync(recordPath, "utf8")) as unknown;
+		assert.equal(isGateRecordShape(parsed), true);
+		const gate = parsed as { gate_id: string; gate_kind: string };
+		assert.equal(gate.gate_id, "approval-my-feature-1-1");
+		assert.equal(gate.gate_kind, "approval");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("migration is idempotent (re-running on already migrated run reports already_migrated)", () => {
+	const root = makeTempRepo();
+	try {
+		const runId = "r";
+		seedLegacyRun(root, runId, [legacyApproval(runId, "approval-r-1")]);
+
+		const first = runMigration(root, { mode: "forward" });
+		assert.equal(first.perRun[0].status, "migrated");
+
+		const second = runMigration(root, { mode: "forward" });
+		assert.equal(second.perRun[0].status, "already_migrated");
+		assert.equal(second.perRun[0].migrated, 0);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("migration converts a mixed directory (approval + clarify)", () => {
+	const root = makeTempRepo();
+	try {
+		const runId = "r";
+		seedLegacyRun(root, runId, [
+			legacyApproval(runId, "approval-r-1"),
+			legacyClarify(runId, "clarify-r-1"),
+			legacyClarify(runId, "clarify-r-2"),
+		]);
+		const result = runMigration(root, { mode: "forward" });
+		assert.equal(result.perRun[0].migrated, 3);
+
+		const store = createLocalFsGateRecordStore(root);
+		const listed = store.list(runId);
+		assert.equal(listed.length, 3);
+		const kinds = listed.map((g) => g.gate_kind).sort();
+		assert.deepEqual(kinds, ["approval", "clarify", "clarify"]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("migration fails fast on unknown record_kind value", () => {
+	const root = makeTempRepo();
+	try {
+		const runId = "r";
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			resolve(dir, "weird-r-1.json"),
+			JSON.stringify({
+				record_id: "weird-r-1",
+				record_kind: "weird",
+				run_id: runId,
+			}),
+		);
+		const result = runMigration(root, { mode: "forward" });
+		assert.equal(result.perRun[0].status, "error");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("migration fails fast on partially corrupted legacy record (invalid JSON)", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(resolve(dir, "broken.json"), "{ not json");
+		const result = runMigration(root, { mode: "forward" });
+		assert.equal(result.perRun[0].status, "error");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("migration writes .migrated sentinel and .backup snapshot", () => {
+	const root = makeTempRepo();
+	try {
+		const runId = "r";
+		const legacy = legacyApproval(runId, "approval-r-1");
+		seedLegacyRun(root, runId, [legacy]);
+		runMigration(root, { mode: "forward" });
+		const dir = resolve(root, ".specflow/runs/r/records");
+		assert.equal(existsSync(resolve(dir, ".migrated")), true);
+		assert.equal(existsSync(resolve(dir, ".backup/approval-r-1.json")), true);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- undo -------------------------------------------------------------------
+
+test("undo restores original legacy files and removes the sentinel", () => {
+	const root = makeTempRepo();
+	try {
+		const runId = "r";
+		const legacy = legacyApproval(runId, "approval-r-1");
+		const originalBytes = JSON.stringify(legacy);
+		seedLegacyRun(root, runId, [legacy]);
+
+		runMigration(root, { mode: "forward" });
+		// verify gate shape is now on disk
+		const dir = resolve(root, ".specflow/runs/r/records");
+		const afterFwd = JSON.parse(
+			readFileSync(resolve(dir, "approval-r-1.json"), "utf8"),
+		);
+		assert.equal(isGateRecordShape(afterFwd), true);
+
+		const undoResult = runMigration(root, { mode: "undo" });
+		assert.equal(undoResult.perRun[0].status, "undone");
+
+		const afterUndo = readFileSync(
+			resolve(dir, "approval-r-1.json"),
+			"utf8",
+		).trim();
+		assert.equal(afterUndo, originalBytes);
+		assert.equal(existsSync(resolve(dir, ".migrated")), false);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- list() behavior against unmigrated data -------------------------------
+
+test("GateRecordStore.list raises UnmigratedRecordError on unmigrated run directories", () => {
+	const root = makeTempRepo();
+	try {
+		const runId = "r";
+		seedLegacyRun(root, runId, [legacyApproval(runId, "approval-r-1")]);
+		const store = createLocalFsGateRecordStore(root);
+		assert.throws(
+			() => store.list(runId),
+			(err: unknown) => err instanceof UnmigratedRecordError,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/src/tests/record-id-alias.test.ts
+++ b/src/tests/record-id-alias.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { recordIdFor, recordIdForGate } from "../lib/record-id-alias.js";
+import type { GateRecord } from "../types/gate-records.js";
+import type { ApprovalRecord } from "../types/interaction-records.js";
+
+function gate(): GateRecord {
+	return {
+		gate_id: "approval-r-1",
+		gate_kind: "approval",
+		run_id: "r",
+		originating_phase: "spec_ready",
+		status: "pending",
+		reason: "x",
+		payload: {
+			kind: "approval",
+			phase_from: "spec_ready",
+			phase_to: "design_draft",
+		},
+		eligible_responder_roles: ["human-author"],
+		allowed_responses: ["accept", "reject"],
+		created_at: "2026-04-18T00:00:00Z",
+		resolved_at: null,
+		decision_actor: null,
+		resolved_response: null,
+		event_ids: [],
+	};
+}
+
+function legacy(): ApprovalRecord {
+	return {
+		record_id: "approval-r-1",
+		record_kind: "approval",
+		run_id: "r",
+		phase_from: "spec_ready",
+		phase_to: "design_draft",
+		status: "pending",
+		requested_at: "2026-04-18T00:00:00Z",
+		decided_at: null,
+		decision_actor: null,
+		event_ids: [],
+	};
+}
+
+test("recordIdForGate returns gate.gate_id byte-for-byte", () => {
+	assert.equal(recordIdForGate(gate()), "approval-r-1");
+});
+
+test("recordIdFor returns gate_id for gate records", () => {
+	assert.equal(recordIdFor(gate()), "approval-r-1");
+});
+
+test("recordIdFor returns record_id for legacy records unchanged", () => {
+	assert.equal(recordIdFor(legacy()), "approval-r-1");
+});
+
+test("recordIdFor keeps gate_id === record_id post-migration (same bytes)", () => {
+	assert.equal(recordIdFor(gate()), recordIdFor(legacy()));
+});

--- a/src/tests/review-cli.test.ts
+++ b/src/tests/review-cli.test.ts
@@ -742,10 +742,7 @@ test("specflow-review-design does not inject task-plannable findings in rereview
 // --- Review gate issuance E2E tests (R5-F13) --------------------------------
 
 /** Helper: start a run for the given changeId and return the run_id. */
-function startRunForReview(
-	repoPath: string,
-	changeId: string,
-): string {
+function startRunForReview(repoPath: string, changeId: string): string {
 	const result = runNodeCli("specflow-run", ["start", changeId], repoPath);
 	assert.equal(result.status, 0, result.stderr);
 	const state = JSON.parse(result.stdout) as { run_id: string };
@@ -767,13 +764,7 @@ function readGateFile(
 	runId: string,
 	fileName: string,
 ): Record<string, unknown> {
-	const path = resolve(
-		repoPath,
-		".specflow/runs",
-		runId,
-		"records",
-		fileName,
-	);
+	const path = resolve(repoPath, ".specflow/runs", runId, "records", fileName);
 	return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
 }
 
@@ -824,12 +815,7 @@ test("specflow-review-design review emits a review_decision gate when --run-id i
 		const ledger = readJson<{
 			round_summaries: Array<{ gate_id?: string | null }>;
 		}>(
-			join(
-				repoPath,
-				"openspec/changes",
-				changeId,
-				"review-ledger-design.json",
-			),
+			join(repoPath, "openspec/changes", changeId, "review-ledger-design.json"),
 		);
 		assert.ok(ledger.round_summaries.length > 0);
 		const lastSummary =
@@ -856,7 +842,11 @@ test("specflow-review-apply review emits a review_decision gate when --run-id is
 				output: JSON.stringify({
 					decision: "APPROVE",
 					findings: [
-						{ title: "Check error handling", severity: "medium", category: "correctness" },
+						{
+							title: "Check error handling",
+							severity: "medium",
+							category: "correctness",
+						},
 					],
 					summary: "review complete",
 				}),
@@ -888,14 +878,7 @@ test("specflow-review-apply review emits a review_decision gate when --run-id is
 		// Ledger should have gate_id back-reference
 		const ledger = readJson<{
 			round_summaries: Array<{ gate_id?: string | null }>;
-		}>(
-			join(
-				repoPath,
-				"openspec/changes",
-				changeId,
-				"review-ledger.json",
-			),
-		);
+		}>(join(repoPath, "openspec/changes", changeId, "review-ledger.json"));
 		assert.ok(ledger.round_summaries.length > 0);
 		const lastSummary =
 			ledger.round_summaries[ledger.round_summaries.length - 1];

--- a/src/tests/review-cli.test.ts
+++ b/src/tests/review-cli.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
-import { existsSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
 import test from "node:test";
 import {
 	addDesignArtifacts,
@@ -728,6 +734,233 @@ test("specflow-review-design does not inject task-plannable findings in rereview
 		// In rereview mode, no task-plannable findings are injected
 		assert.equal(json.ledger.counts.new, 0);
 		assert.equal(json.ledger.counts.resolved, 1);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- Review gate issuance E2E tests (R5-F13) --------------------------------
+
+/** Helper: start a run for the given changeId and return the run_id. */
+function startRunForReview(
+	repoPath: string,
+	changeId: string,
+): string {
+	const result = runNodeCli("specflow-run", ["start", changeId], repoPath);
+	assert.equal(result.status, 0, result.stderr);
+	const state = JSON.parse(result.stdout) as { run_id: string };
+	return state.run_id;
+}
+
+/** Helper: list gate record files in a run's records directory. */
+function listGateFiles(repoPath: string, runId: string): string[] {
+	const dir = join(repoPath, ".specflow/runs", runId, "records");
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir).filter(
+		(f: string) => f.endsWith(".json") && !f.startsWith("."),
+	);
+}
+
+/** Helper: read a gate record JSON from disk. */
+function readGateFile(
+	repoPath: string,
+	runId: string,
+	fileName: string,
+): Record<string, unknown> {
+	const path = resolve(
+		repoPath,
+		".specflow/runs",
+		runId,
+		"records",
+		fileName,
+	);
+	return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+test("specflow-review-design review emits a review_decision gate when --run-id is provided", () => {
+	const tempRoot = makeTempDir("review-design-gate-emit-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		addDesignArtifacts(repoPath, changeId);
+		const runId = startRunForReview(repoPath, changeId);
+		const env = createCodexEnv(tempRoot, [
+			{
+				exitCode: 0,
+				output: JSON.stringify({
+					decision: "APPROVE",
+					findings: [
+						{ title: "Minor gap", severity: "medium", category: "design" },
+					],
+					summary: "mostly ok",
+				}),
+			},
+		]);
+		const result = runNodeCli(
+			"specflow-review-design",
+			["review", changeId, "--run-id", runId],
+			repoPath,
+			env,
+		);
+		assert.equal(result.status, 0, result.stderr);
+		const json = JSON.parse(result.stdout) as {
+			status: string;
+			gate_id: string | null;
+		};
+		assert.equal(json.status, "success");
+		// gate_id should be non-null
+		assert.ok(json.gate_id, "gate_id should be set in the review result");
+		assert.match(json.gate_id, /review_decision/);
+
+		// Gate file should exist on disk
+		const gateFiles = listGateFiles(repoPath, runId);
+		const gateFile = gateFiles.find((f) => f.includes("design_review"));
+		assert.ok(gateFile, "gate file for design_review should exist on disk");
+		const gate = readGateFile(repoPath, runId, gateFile!);
+		assert.equal(gate.gate_kind, "review_decision");
+		assert.equal(gate.status, "pending");
+		assert.equal(gate.originating_phase, "design_review");
+
+		// Ledger should have gate_id back-reference in round_summaries
+		const ledger = readJson<{
+			round_summaries: Array<{ gate_id?: string | null }>;
+		}>(
+			join(
+				repoPath,
+				"openspec/changes",
+				changeId,
+				"review-ledger-design.json",
+			),
+		);
+		assert.ok(ledger.round_summaries.length > 0);
+		const lastSummary =
+			ledger.round_summaries[ledger.round_summaries.length - 1];
+		assert.equal(
+			lastSummary.gate_id,
+			json.gate_id,
+			"ledger round_summary should back-reference the gate_id",
+		);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-review-apply review emits a review_decision gate when --run-id is provided", () => {
+	const tempRoot = makeTempDir("review-apply-gate-emit-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		addImplementationDiff(repoPath);
+		const runId = startRunForReview(repoPath, changeId);
+		const env = createCodexEnv(tempRoot, [
+			{
+				exitCode: 0,
+				output: JSON.stringify({
+					decision: "APPROVE",
+					findings: [
+						{ title: "Check error handling", severity: "medium", category: "correctness" },
+					],
+					summary: "review complete",
+				}),
+			},
+		]);
+		const result = runNodeCli(
+			"specflow-review-apply",
+			["review", changeId, "--run-id", runId],
+			repoPath,
+			env,
+		);
+		assert.equal(result.status, 0, result.stderr);
+		const json = JSON.parse(result.stdout) as {
+			status: string;
+			gate_id: string | null;
+		};
+		assert.equal(json.status, "success");
+		assert.ok(json.gate_id, "gate_id should be set in the review result");
+		assert.match(json.gate_id, /review_decision/);
+
+		// Gate file should exist on disk
+		const gateFiles = listGateFiles(repoPath, runId);
+		const gateFile = gateFiles.find((f) => f.includes("apply_review"));
+		assert.ok(gateFile, "gate file for apply_review should exist on disk");
+		const gate = readGateFile(repoPath, runId, gateFile!);
+		assert.equal(gate.gate_kind, "review_decision");
+		assert.equal(gate.status, "pending");
+
+		// Ledger should have gate_id back-reference
+		const ledger = readJson<{
+			round_summaries: Array<{ gate_id?: string | null }>;
+		}>(
+			join(
+				repoPath,
+				"openspec/changes",
+				changeId,
+				"review-ledger.json",
+			),
+		);
+		assert.ok(ledger.round_summaries.length > 0);
+		const lastSummary =
+			ledger.round_summaries[ledger.round_summaries.length - 1];
+		assert.equal(lastSummary.gate_id, json.gate_id);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-challenge-proposal emits distinct gate IDs across successive rounds", () => {
+	const tempRoot = makeTempDir("challenge-gate-round-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const runId = startRunForReview(repoPath, changeId);
+		const challengeResponse = {
+			exitCode: 0,
+			output: JSON.stringify({
+				challenges: [
+					{
+						id: "C1",
+						category: "scope",
+						question: "Is this in scope?",
+						context: "test",
+					},
+				],
+				summary: "one challenge",
+			}),
+		};
+		const env = createCodexEnv(tempRoot, [
+			challengeResponse,
+			challengeResponse,
+		]);
+		// Run challenge twice to verify distinct gate IDs
+		const result1 = runNodeCli(
+			"specflow-challenge-proposal",
+			["challenge", changeId, "--run-id", runId],
+			repoPath,
+			env,
+		);
+		assert.equal(result1.status, 0, result1.stderr);
+		const json1 = JSON.parse(result1.stdout) as {
+			gate_id: string | null;
+		};
+		assert.ok(json1.gate_id, "first challenge should emit a gate_id");
+
+		const result2 = runNodeCli(
+			"specflow-challenge-proposal",
+			["challenge", changeId, "--run-id", runId],
+			repoPath,
+			env,
+		);
+		assert.equal(result2.status, 0, result2.stderr);
+		const json2 = JSON.parse(result2.stdout) as {
+			gate_id: string | null;
+		};
+		assert.ok(json2.gate_id, "second challenge should emit a gate_id");
+
+		// Gate IDs must be distinct (round numbering should differ)
+		assert.notEqual(
+			json1.gate_id,
+			json2.gate_id,
+			"successive challenge rounds must produce distinct gate IDs",
+		);
+		assert.match(json1.gate_id!, /challenge-1/);
+		assert.match(json2.gate_id!, /challenge-2/);
 	} finally {
 		removeTempDir(tempRoot);
 	}

--- a/src/tests/review-decision-gate.test.ts
+++ b/src/tests/review-decision-gate.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import { createFakeGateRecordStore } from "../lib/fake-gate-record-store.js";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import type { ReviewRoundProvenance } from "../lib/review-decision-gate.js";
+import {
+	buildReviewDecisionGateInput,
+	findReviewDecisionGateByRoundId,
+	issueReviewDecisionGate,
+} from "../lib/review-decision-gate.js";
+import type { ReviewFindingSnapshot } from "../types/gate-records.js";
+
+function makeTempRepo(): string {
+	return mkdtempSync(resolve(tmpdir(), "specflow-rdg-test-"));
+}
+
+function samplefindings(): ReviewFindingSnapshot[] {
+	return [
+		{ id: "P1", severity: "high", status: "new", title: "Find 1" },
+		{ id: "P2", severity: "medium", status: "new", title: "Find 2" },
+	];
+}
+
+function sampleRound(
+	phase: ReviewRoundProvenance["review_phase"],
+	roundId: string,
+): ReviewRoundProvenance {
+	return {
+		run_id: "r",
+		review_phase: phase,
+		review_round_id: roundId,
+		findings: samplefindings(),
+		reviewer_actor: "ai-agent",
+		reviewer_actor_id: "codex",
+		approval_binding: "advisory",
+	};
+}
+
+// --- payload construction ---------------------------------------------------
+
+test("buildReviewDecisionGateInput carries full round provenance in payload", () => {
+	const input = buildReviewDecisionGateInput(
+		sampleRound("design_review", "rd-1"),
+		"review_decision-r-1",
+		"2026-04-18T00:00:00Z",
+	);
+	assert.equal(input.gate_kind, "review_decision");
+	assert.equal(input.originating_phase, "design_review");
+	assert.equal(input.payload.kind, "review_decision");
+	if (input.payload.kind === "review_decision") {
+		assert.equal(input.payload.review_round_id, "rd-1");
+		assert.equal(input.payload.findings.length, 2);
+		assert.equal(input.payload.reviewer_actor, "ai-agent");
+		assert.equal(input.payload.reviewer_actor_id, "codex");
+		assert.equal(input.payload.approval_binding, "advisory");
+	}
+});
+
+test("buildReviewDecisionGateInput omits eligible_responder_roles so default policy (human-author) applies", () => {
+	const input = buildReviewDecisionGateInput(
+		sampleRound("design_review", "rd-1"),
+		"review_decision-r-1",
+		"2026-04-18T00:00:00Z",
+	);
+	assert.equal(input.eligible_responder_roles, undefined);
+});
+
+// --- issuance round-trip ----------------------------------------------------
+
+test("issueReviewDecisionGate writes exactly one pending review_decision gate", () => {
+	const store = createFakeGateRecordStore();
+	const gate = issueReviewDecisionGate(sampleRound("design_review", "rd-1"), {
+		store,
+		projectRoot: "/tmp",
+		gateId: "review_decision-r-1",
+		createdAt: "2026-04-18T00:00:00Z",
+	});
+	assert.equal(gate.status, "pending");
+	// human-author only, per default policy
+	assert.deepEqual([...gate.eligible_responder_roles], ["human-author"]);
+	const pending = store
+		.list("r")
+		.filter((g) => g.status === "pending" && g.gate_kind === "review_decision");
+	assert.equal(pending.length, 1);
+});
+
+test("issueReviewDecisionGate for the same phase supersedes the previous pending gate", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsGateRecordStore(root);
+		issueReviewDecisionGate(sampleRound("design_review", "rd-1"), {
+			store,
+			projectRoot: root,
+			gateId: "review_decision-r-1",
+			createdAt: "2026-04-18T00:00:00Z",
+		});
+		issueReviewDecisionGate(sampleRound("design_review", "rd-2"), {
+			store,
+			projectRoot: root,
+			gateId: "review_decision-r-2",
+			createdAt: "2026-04-18T00:00:01Z",
+		});
+		const listed = store.list("r");
+		const byId = new Map(listed.map((g) => [g.gate_id, g]));
+		assert.equal(byId.get("review_decision-r-1")?.status, "superseded");
+		assert.equal(byId.get("review_decision-r-2")?.status, "pending");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("findReviewDecisionGateByRoundId locates the gate for a given review_round_id", () => {
+	const store = createFakeGateRecordStore();
+	issueReviewDecisionGate(sampleRound("apply_review", "rd-apply-7"), {
+		store,
+		projectRoot: "/tmp",
+		gateId: "review_decision-r-10",
+		createdAt: "2026-04-18T00:00:00Z",
+	});
+	const found = findReviewDecisionGateByRoundId(store.list("r"), "rd-apply-7");
+	assert.ok(found);
+	assert.equal(found?.gate_id, "review_decision-r-10");
+});
+
+test("proposal_challenge and design_review and apply_review each accept one gate per round", () => {
+	const store = createFakeGateRecordStore();
+	issueReviewDecisionGate(sampleRound("proposal_challenge", "rd-p1"), {
+		store,
+		projectRoot: "/tmp",
+		gateId: "review_decision-r-1",
+		createdAt: "2026-04-18T00:00:00Z",
+	});
+	issueReviewDecisionGate(sampleRound("design_review", "rd-d1"), {
+		store,
+		projectRoot: "/tmp",
+		gateId: "review_decision-r-2",
+		createdAt: "2026-04-18T00:00:01Z",
+	});
+	issueReviewDecisionGate(sampleRound("apply_review", "rd-a1"), {
+		store,
+		projectRoot: "/tmp",
+		gateId: "review_decision-r-3",
+		createdAt: "2026-04-18T00:00:02Z",
+	});
+	const pending = store
+		.list("r")
+		.filter((g) => g.gate_kind === "review_decision" && g.status === "pending");
+	assert.equal(pending.length, 3);
+	assert.deepEqual(
+		new Set(pending.map((g) => g.originating_phase)),
+		new Set(["proposal_challenge", "design_review", "apply_review"]),
+	);
+});
+
+test("eligible_responder_roles is ['human-author'] for every review_decision gate", () => {
+	const store = createFakeGateRecordStore();
+	for (const phase of [
+		"proposal_challenge",
+		"design_review",
+		"apply_review",
+	] as const) {
+		issueReviewDecisionGate(sampleRound(phase, `rd-${phase}`), {
+			store,
+			projectRoot: "/tmp",
+			gateId: `review_decision-${phase}-1`,
+			createdAt: "2026-04-18T00:00:00Z",
+		});
+	}
+	for (const gate of store.list("r")) {
+		if (gate.gate_kind !== "review_decision") continue;
+		assert.deepEqual([...gate.eligible_responder_roles], ["human-author"]);
+	}
+});

--- a/src/tests/specflow-run-persistence.test.ts
+++ b/src/tests/specflow-run-persistence.test.ts
@@ -1,0 +1,282 @@
+// Regression tests for specflow-run persistence wiring.
+//
+// Covers:
+// - Gate records are written via mirrorMutationsSafely (R1-F01)
+// - Delete mutations are skipped, preserving history (R1-F02)
+// - Migrated directories are rejected by InteractionRecordStore (R1-F03)
+
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+import type { RecordMutation } from "../core/types.js";
+import { createFakeGateRecordStore } from "../lib/fake-gate-record-store.js";
+import { mirrorMutationsToGateStore } from "../lib/gate-mutation-bridge.js";
+import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import {
+	createLocalFsInteractionRecordStore,
+	MigratedDirectoryError,
+} from "../lib/local-fs-interaction-record-store.js";
+import type {
+	ApprovalRecord,
+	ClarifyRecord,
+} from "../types/interaction-records.js";
+
+function makeTempRepo(): string {
+	return mkdtempSync(resolve(tmpdir(), "specflow-run-persist-test-"));
+}
+
+function approvalRecord(
+	runId: string,
+	id: string,
+	status: ApprovalRecord["status"] = "pending",
+): ApprovalRecord {
+	return {
+		record_id: id,
+		record_kind: "approval",
+		run_id: runId,
+		phase_from: "spec_ready",
+		phase_to: "design_draft",
+		status,
+		requested_at: "2026-04-18T00:00:00Z",
+		decided_at: status === "pending" ? null : "2026-04-18T01:00:00Z",
+		decision_actor:
+			status === "pending" ? null : { actor: "human", actor_id: "yuki" },
+		event_ids: ["evt-1"],
+	};
+}
+
+function clarifyRecord(runId: string, id: string): ClarifyRecord {
+	return {
+		record_id: id,
+		record_kind: "clarify",
+		run_id: runId,
+		phase: "proposal_clarify",
+		question: "What is the scope?",
+		answer: null,
+		status: "pending",
+		asked_at: "2026-04-18T00:00:00Z",
+		answered_at: null,
+		event_ids: ["evt-2"],
+	};
+}
+
+// ---------------------------------------------------------------------------
+// R1-F01: Gate records are persisted via mirroring
+// ---------------------------------------------------------------------------
+
+test("mirrorMutationsToGateStore writes gate records for create/update mutations", () => {
+	const store = createFakeGateRecordStore();
+	const mutations: RecordMutation[] = [
+		{ kind: "create", record: approvalRecord("r", "approval-r-1") },
+		{ kind: "create", record: clarifyRecord("r", "clarify-r-1") },
+	];
+	mirrorMutationsToGateStore(store, "r", mutations);
+	const listed = store.list("r");
+	assert.equal(listed.length, 2, "Both mutations should produce gate records");
+	const kinds = listed.map((g) => g.gate_kind).sort();
+	assert.deepEqual(kinds, ["approval", "clarify"]);
+});
+
+test("Gate mirroring to LocalFsGateRecordStore persists files on disk", () => {
+	const root = makeTempRepo();
+	try {
+		const gateStore = createLocalFsGateRecordStore(root);
+		const mutations: RecordMutation[] = [
+			{ kind: "create", record: approvalRecord("r1", "approval-r1-1") },
+		];
+		mirrorMutationsToGateStore(gateStore, "r1", mutations);
+
+		const readBack = gateStore.read("r1", "approval-r1-1");
+		assert.ok(readBack, "Gate record should be persisted on disk");
+		assert.equal(readBack.gate_kind, "approval");
+		assert.equal(readBack.gate_id, "approval-r1-1");
+		assert.equal(readBack.status, "pending");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// ---------------------------------------------------------------------------
+// R1-F02: Delete mutations are skipped — history preserved
+// ---------------------------------------------------------------------------
+
+test("mirrorMutationsToGateStore ignores delete mutations (gate history preserved)", () => {
+	const store = createFakeGateRecordStore();
+	const mutations: RecordMutation[] = [
+		{ kind: "create", record: approvalRecord("r", "approval-r-1") },
+		{ kind: "delete", recordId: "approval-r-1" },
+	];
+	mirrorMutationsToGateStore(store, "r", mutations);
+	const listed = store.list("r");
+	assert.equal(
+		listed.length,
+		1,
+		"Delete mutation must not remove the gate record",
+	);
+	assert.equal(listed[0].gate_id, "approval-r-1");
+});
+
+test("GateRecordStore has no delete API — records persist for audit", () => {
+	const store = createFakeGateRecordStore();
+	assert.equal(
+		Object.hasOwn(store, "delete"),
+		false,
+		"GateRecordStore must not expose delete",
+	);
+});
+
+test("Gate records survive create→update→delete sequence in mirror", () => {
+	const store = createFakeGateRecordStore();
+	const mutations: RecordMutation[] = [
+		{ kind: "create", record: approvalRecord("r", "approval-r-1", "pending") },
+		{
+			kind: "update",
+			record: approvalRecord("r", "approval-r-1", "approved"),
+		},
+		{ kind: "delete", recordId: "approval-r-1" },
+	];
+	mirrorMutationsToGateStore(store, "r", mutations);
+	const listed = store.list("r");
+	assert.equal(listed.length, 1, "Gate record must survive a delete mutation");
+	assert.equal(
+		listed[0].status,
+		"resolved",
+		"Final state should reflect the update, not the delete",
+	);
+	assert.equal(listed[0].resolved_response, "accept");
+});
+
+// ---------------------------------------------------------------------------
+// R1-F03: Migrated directories are rejected by InteractionRecordStore
+// ---------------------------------------------------------------------------
+
+test("InteractionRecordStore.list throws MigratedDirectoryError when .migrated sentinel exists", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(resolve(dir, ".migrated"), "2026-04-18T00:00:00Z");
+		writeFileSync(
+			resolve(dir, "approval-r-1.json"),
+			JSON.stringify(approvalRecord("r", "approval-r-1")),
+		);
+
+		const store = createLocalFsInteractionRecordStore(root);
+		assert.throws(
+			() => store.list("r"),
+			(err: unknown) => err instanceof MigratedDirectoryError,
+			"list() must throw MigratedDirectoryError on migrated directory",
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("InteractionRecordStore.read throws MigratedDirectoryError when .migrated sentinel exists", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(resolve(dir, ".migrated"), "2026-04-18T00:00:00Z");
+		writeFileSync(
+			resolve(dir, "approval-r-1.json"),
+			JSON.stringify(approvalRecord("r", "approval-r-1")),
+		);
+
+		const store = createLocalFsInteractionRecordStore(root);
+		assert.throws(
+			() => store.read("r", "approval-r-1"),
+			(err: unknown) => err instanceof MigratedDirectoryError,
+			"read() must throw MigratedDirectoryError on migrated directory",
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("InteractionRecordStore.write throws MigratedDirectoryError when .migrated sentinel exists", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(resolve(dir, ".migrated"), "2026-04-18T00:00:00Z");
+
+		const store = createLocalFsInteractionRecordStore(root);
+		assert.throws(
+			() => store.write("r", approvalRecord("r", "approval-r-1")),
+			(err: unknown) => err instanceof MigratedDirectoryError,
+			"write() must throw MigratedDirectoryError on migrated directory",
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("InteractionRecordStore.delete throws MigratedDirectoryError when .migrated sentinel exists", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(resolve(dir, ".migrated"), "2026-04-18T00:00:00Z");
+
+		const store = createLocalFsInteractionRecordStore(root);
+		assert.throws(
+			() => store.delete("r", "approval-r-1"),
+			(err: unknown) => err instanceof MigratedDirectoryError,
+			"delete() must throw MigratedDirectoryError on migrated directory",
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("InteractionRecordStore works normally when no .migrated sentinel exists", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsInteractionRecordStore(root);
+		const rec = approvalRecord("r", "approval-r-1");
+		store.write("r", rec);
+		const readBack = store.read("r", "approval-r-1");
+		assert.ok(readBack, "Should read back the written record");
+		assert.equal(readBack.record_id, "approval-r-1");
+		const listed = store.list("r");
+		assert.equal(listed.length, 1);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("InteractionRecordStore.list throws MigratedDirectoryError on unrecognized JSON shape (not gate, not legacy)", () => {
+	const root = makeTempRepo();
+	try {
+		const dir = resolve(root, ".specflow/runs/r/records");
+		mkdirSync(dir, { recursive: true });
+		// A valid JSON file that is neither gate-shaped nor interaction-record-shaped.
+		writeFileSync(
+			resolve(dir, "mystery.json"),
+			JSON.stringify({ foo: "bar", baz: 42 }),
+		);
+
+		const store = createLocalFsInteractionRecordStore(root);
+		assert.throws(
+			() => store.list("r"),
+			(err: unknown) => err instanceof MigratedDirectoryError,
+			"list() must throw on unrecognized record format",
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("InteractionRecordStore.list returns empty for non-existent run (no false positive on sentinel check)", () => {
+	const root = makeTempRepo();
+	try {
+		const store = createLocalFsInteractionRecordStore(root);
+		const listed = store.list("nonexistent-run");
+		assert.deepEqual(listed, []);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/src/tests/specflow-run.test.ts
+++ b/src/tests/specflow-run.test.ts
@@ -9,8 +9,15 @@
 // against in-memory stores.
 
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
 import test from "node:test";
 import {
 	createBareHome,
@@ -378,6 +385,156 @@ test("specflow-run reads legacy run.json and infers terminal status", () => {
 		};
 		assert.equal(statusJson.run_id, legacyRunId);
 		assert.equal(statusJson.status, "terminal");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- Gate record persistence regression tests (F05) -----------------------
+
+test("specflow-run writes gate records on disk when entering an approval gate phase", () => {
+	const tempRoot = makeTempDir("specflow-run-gate-persist-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+
+		// Advance through phases until reaching spec_ready (approval gate).
+		const phasesBeforeGate: Array<[string, string]> = [
+			["propose", "proposal_draft"],
+			["check_scope", "proposal_scope"],
+			["continue_proposal", "proposal_clarify"],
+			["challenge_proposal", "proposal_challenge"],
+			["reclarify", "proposal_reclarify"],
+			["accept_proposal", "spec_draft"],
+			["validate_spec", "spec_validate"],
+			["spec_validated", "spec_verify"],
+			["spec_verified", "spec_ready"],
+		];
+		for (const [event, expectedPhase] of phasesBeforeGate) {
+			const json = advancePhase(repoPath, runId, event);
+			assert.equal(json.current_phase, expectedPhase, event);
+		}
+
+		// Verify gate record files exist on disk.
+		const recordsDir = join(repoPath, ".specflow/runs", runId, "records");
+		assert.ok(existsSync(recordsDir), "records directory should exist");
+		const files = readdirSync(recordsDir).filter(
+			(f: string) => f.endsWith(".json") && !f.startsWith("."),
+		);
+		assert.ok(files.length > 0, "at least one gate record should be written");
+
+		// The record file should be gate-shaped (gate_id, gate_kind) not legacy-shaped.
+		const firstFile = readFileSync(resolve(recordsDir, files[0]), "utf8");
+		const parsed = JSON.parse(firstFile) as Record<string, unknown>;
+		assert.equal(typeof parsed.gate_id, "string", "should have gate_id");
+		assert.equal(typeof parsed.gate_kind, "string", "should have gate_kind");
+		assert.equal(parsed.status, "pending", "gate should be pending");
+		assert.equal(parsed.gate_kind, "approval", "should be an approval gate");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run preserves gate history when approval is resolved (no physical delete)", () => {
+	const tempRoot = makeTempDir("specflow-run-gate-history-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+
+		// Advance to spec_ready (creates pending approval gate).
+		const phases: string[] = [
+			"propose",
+			"check_scope",
+			"continue_proposal",
+			"challenge_proposal",
+			"reclarify",
+			"accept_proposal",
+			"validate_spec",
+			"spec_validated",
+			"spec_verified",
+		];
+		for (const event of phases) {
+			advancePhase(repoPath, runId, event);
+		}
+
+		const recordsDir = join(repoPath, ".specflow/runs", runId, "records");
+		const filesBefore = readdirSync(recordsDir).filter(
+			(f: string) => f.endsWith(".json") && !f.startsWith("."),
+		);
+		assert.ok(
+			filesBefore.length > 0,
+			"should have gate record(s) before resolve",
+		);
+
+		// Accept spec → resolves the approval gate and enters design_draft (new phase).
+		advancePhase(repoPath, runId, "accept_spec");
+
+		// All original record files should still exist (not deleted).
+		for (const file of filesBefore) {
+			assert.ok(
+				existsSync(resolve(recordsDir, file)),
+				`gate record ${file} should still exist after resolution`,
+			);
+		}
+
+		// The resolved gate should have status "resolved", not be deleted.
+		const resolvedContent = readFileSync(
+			resolve(recordsDir, filesBefore[0]),
+			"utf8",
+		);
+		const resolved = JSON.parse(resolvedContent) as Record<string, unknown>;
+		assert.equal(
+			resolved.status,
+			"resolved",
+			"gate should be resolved, not deleted",
+		);
+		assert.equal(resolved.resolved_response, "accept");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run advance rejects unmigrated legacy records with a clear error", () => {
+	const tempRoot = makeTempDir("specflow-run-unmigrated-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const startJson = startRun(repoPath, changeId);
+		const runId = startJson.run_id;
+
+		// Plant a legacy-shaped record file in the records directory.
+		const recordsDir = join(repoPath, ".specflow/runs", runId, "records");
+		mkdirSync(recordsDir, { recursive: true });
+		writeFileSync(
+			join(recordsDir, "approval-legacy-1.json"),
+			JSON.stringify({
+				record_id: "approval-legacy-1",
+				record_kind: "approval",
+				run_id: runId,
+				phase_from: "spec_ready",
+				phase_to: "design_draft",
+				status: "pending",
+				requested_at: "2026-01-01T00:00:00Z",
+				decided_at: null,
+				decision_actor: null,
+				event_ids: [],
+			}),
+			"utf8",
+		);
+
+		// Advance should fail because the gate store detects legacy records.
+		const result = runNodeCli(
+			"specflow-run",
+			["advance", runId, "propose"],
+			repoPath,
+		);
+		assert.notEqual(result.status, 0, "should fail on unmigrated records");
+		assert.match(
+			result.stderr,
+			/specflow-migrate-records/,
+			"error should mention migration command",
+		);
 	} finally {
 		removeTempDir(tempRoot);
 	}

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -386,6 +386,8 @@ export interface LedgerRoundSummary extends JsonMap {
 	readonly stagnant_rounds?: number;
 	readonly max_rounds?: number;
 	readonly stop_reason?: string | null;
+	/** Back-reference to the review_decision gate issued for this round. */
+	readonly gate_id?: string | null;
 }
 
 export interface ReviewLedger extends JsonMap {
@@ -486,6 +488,8 @@ export interface ReviewResult extends JsonMap {
 	readonly warning?: string;
 	readonly ledger_recovery?: string;
 	readonly rereview_classification?: RereviewClassification | null;
+	/** Gate ID of the review_decision gate issued for this round, if any. */
+	readonly gate_id?: string | null;
 	readonly error?: string | null;
 }
 
@@ -502,6 +506,8 @@ export interface ChallengeResult extends JsonMap {
 	readonly change_id: string;
 	readonly challenges: readonly ChallengeItem[];
 	readonly summary: string;
+	/** Gate ID of the review_decision gate issued for this challenge round, if any. */
+	readonly gate_id?: string | null;
 	readonly error?: string | null;
 	readonly parse_error?: boolean;
 	readonly raw_response?: string | null;

--- a/src/types/gate-records.ts
+++ b/src/types/gate-records.ts
@@ -1,0 +1,196 @@
+// GateRecord types — unified persistence unit for workflow gates.
+//
+// Defined by the workflow-gate-semantics capability. A Gate is a first-class
+// persistent workflow object representing a pending decision point in a run.
+// Each Gate is one of three kinds (approval, clarify, review_decision) and
+// carries kind-specific context in its `payload`.
+
+import type { ActorIdentity } from "../contracts/surface-events.js";
+
+// ---------------------------------------------------------------------------
+// Discriminators
+// ---------------------------------------------------------------------------
+
+/** The three supported gate kinds. */
+export type GateKind = "approval" | "clarify" | "review_decision";
+
+/** Terminal status machine: pending is initial; resolved and superseded are terminal. */
+export type GateStatus = "pending" | "resolved" | "superseded";
+
+// ---------------------------------------------------------------------------
+// Payload shapes (discriminated by kind)
+// ---------------------------------------------------------------------------
+
+export interface ApprovalGatePayload {
+	readonly kind: "approval";
+	readonly phase_from: string;
+	readonly phase_to: string;
+}
+
+export interface ClarifyGatePayload {
+	readonly kind: "clarify";
+	readonly question: string;
+	readonly question_context?: string;
+	readonly answer?: string;
+}
+
+/** Review-round provenance persisted with the gate so surfaces can render without replaying the ledger. */
+export interface ReviewDecisionGatePayload {
+	readonly kind: "review_decision";
+	readonly review_round_id: string;
+	readonly findings: readonly ReviewFindingSnapshot[];
+	readonly reviewer_actor: string;
+	readonly reviewer_actor_id: string;
+	readonly approval_binding: "binding" | "advisory" | "not_applicable";
+}
+
+/**
+ * A minimal snapshot of a review finding carried in a review_decision gate payload.
+ * Full finding objects still live in the review ledger; the gate only needs enough
+ * context for surfaces to render the pending decision.
+ */
+export interface ReviewFindingSnapshot {
+	readonly id: string;
+	readonly severity: "critical" | "high" | "medium" | "low";
+	readonly status: string;
+	readonly title: string;
+}
+
+export type GatePayload =
+	| ApprovalGatePayload
+	| ClarifyGatePayload
+	| ReviewDecisionGatePayload;
+
+// ---------------------------------------------------------------------------
+// GateRecord
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical persistence shape for every workflow gate. Stored at
+ * `.specflow/runs/<run_id>/records/<gate_id>.json`.
+ */
+export interface GateRecord {
+	readonly gate_id: string;
+	readonly gate_kind: GateKind;
+	readonly run_id: string;
+	readonly originating_phase: string;
+	readonly status: GateStatus;
+	readonly reason: string;
+	readonly payload: GatePayload;
+	readonly eligible_responder_roles: readonly string[];
+	readonly allowed_responses: readonly string[];
+	readonly created_at: string;
+	readonly resolved_at: string | null;
+	readonly decision_actor: ActorIdentity | null;
+	/** When resolved, the response token (accept/reject/request_changes/clarify_response) that produced the terminal state. Null for pending and superseded. */
+	readonly resolved_response: string | null;
+	readonly event_ids: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Runtime-owned policy tables
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed `allowed_responses` set for each gate kind. The runtime is the single
+ * source of truth; the table is intentionally inspectable in one place and
+ * MUST match the workflow-gate-semantics spec.
+ */
+export const ALLOWED_RESPONSES_BY_KIND: {
+	readonly [K in GateKind]: readonly string[];
+} = {
+	approval: ["accept", "reject"],
+	clarify: ["clarify_response"],
+	review_decision: ["accept", "reject", "request_changes"],
+} as const;
+
+/**
+ * Default per-kind eligible responder role policy. All three kinds default to
+ * `human-author` in this change; delegated or multi-role cases remain a future
+ * extension point per the design's Open Questions.
+ */
+export const DEFAULT_ELIGIBLE_ROLES_BY_KIND: {
+	readonly [K in GateKind]: readonly string[];
+} = {
+	approval: ["human-author"],
+	clarify: ["human-author"],
+	review_decision: ["human-author"],
+} as const;
+
+/** Returns a copy of the fixed allowed_responses list for the given gate kind. */
+export function allowedResponsesFor(kind: GateKind): readonly string[] {
+	return ALLOWED_RESPONSES_BY_KIND[kind];
+}
+
+/** Returns a copy of the default eligible_responder_roles list for the given gate kind. */
+export function defaultEligibleRolesFor(kind: GateKind): readonly string[] {
+	return DEFAULT_ELIGIBLE_ROLES_BY_KIND[kind];
+}
+
+// ---------------------------------------------------------------------------
+// Gate ID generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a deterministic gate_id in `<kind>-<runId>-<sequence>` format.
+ * Matches the legacy record_id scheme so migration can preserve ids byte-for-byte.
+ */
+export function generateGateId(
+	kind: GateKind,
+	runId: string,
+	sequence: number,
+): string {
+	return `${kind}-${runId}-${sequence}`;
+}
+
+// ---------------------------------------------------------------------------
+// Error type for unmigrated legacy records
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when `GateRecordStore.read` or `list` encounters a legacy-shaped file
+ * (record_kind present, gate_kind absent). The runtime fails fast so that
+ * concurrency checks and pending-gate queries never silently consume unmigrated
+ * data. Callers should direct users to run `specflow-migrate-records` first.
+ */
+export class UnmigratedRecordError extends Error {
+	readonly gate_id_or_path: string;
+	constructor(gateIdOrPath: string, message?: string) {
+		super(
+			message ??
+				`Legacy interaction record found at ${gateIdOrPath}. Run 'specflow-migrate-records' before continuing.`,
+		);
+		this.name = "UnmigratedRecordError";
+		this.gate_id_or_path = gateIdOrPath;
+	}
+}
+
+/**
+ * Type guard: does the parsed JSON object look like a legacy ApprovalRecord or
+ * ClarifyRecord (has `record_kind` and/or `record_id` but no `gate_kind`)?
+ */
+export function isLegacyRecordShape(parsed: unknown): boolean {
+	if (parsed === null || typeof parsed !== "object") return false;
+	const obj = parsed as Record<string, unknown>;
+	const hasLegacyMarker =
+		typeof obj.record_kind === "string" || typeof obj.record_id === "string";
+	const hasGateMarker =
+		typeof obj.gate_kind === "string" && typeof obj.gate_id === "string";
+	return hasLegacyMarker && !hasGateMarker;
+}
+
+/** Type guard: does the parsed JSON object satisfy the GateRecord shape? */
+export function isGateRecordShape(parsed: unknown): parsed is GateRecord {
+	if (parsed === null || typeof parsed !== "object") return false;
+	const obj = parsed as Record<string, unknown>;
+	return (
+		typeof obj.gate_id === "string" &&
+		typeof obj.gate_kind === "string" &&
+		typeof obj.run_id === "string" &&
+		typeof obj.originating_phase === "string" &&
+		typeof obj.status === "string" &&
+		Array.isArray(obj.eligible_responder_roles) &&
+		Array.isArray(obj.allowed_responses) &&
+		Array.isArray(obj.event_ids)
+	);
+}


### PR DESCRIPTION
## Summary

- Introduce `workflow-gate-semantics` capability defining **Gate** as a first-class persistent workflow object covering `approval`, `clarify`, and `review_decision` kinds.
- Replace `ApprovalRecord` / `ClarifyRecord` / `InteractionRecordStore` with unified `GateRecord` + `GateRecordStore` schema (no per-record `delete`), add atomic supersede with run-scoped lock and write-ahead intent journal.
- Ship `specflow-migrate-records` CLI with forward / `--undo` and `.migrated` sentinel; provide `issueReviewDecisionGate` helper for review-round gate emission; preserve surface-event compatibility via temporary `recordIdForGate` alias.

## Issue

Closes https://github.com/skr19930617/specflow/issues/166

## Accepted risk

Four HIGH findings are carried forward at merge time and must be addressed in a follow-up change:

- `runAdvance` full gate-resolution wiring (`specflow-run advance` does not yet call `resolveGate()` end-to-end).
- Review CLI end-to-end `review_decision` gate emission verification.
- Transactional ledger↔gate correlation protocol (write-then-crash recovery).
- Spec-level coverage of the `GateRecord.resolved_response` field (field is populated in code; spec/tests need formal coverage).

Full details in `openspec/changes/archive/2026-04-18-define-gate-semantics-.../approval-summary.md`.

## Test plan

- [x] `npm run build` passes
- [x] `node --test dist/tests/*.test.js` — 607 tests pass
- [x] `openspec validate <change> --type change` — valid
- [x] `specflow-spec-verify <change>` — pairings reviewed, no unintended conflicts
- [ ] Run `specflow-migrate-records --all` against real `.specflow/runs/*` data before enabling GateRecordStore as primary persistence
- [ ] Verify review CLI changes emit exactly one `review_decision` gate per round against a fresh fixture
- [ ] File follow-up tracking issue for `surface-event-contract` / `workflow-run-state` spec updates (removes the `record_id` alias)