### PR TITLE
feat: define workflow event semantics for state change, gate resolution, and progress observation (#167)

### DIFF
--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/.openspec.yaml
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/approval-summary.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/approval-summary.md
@@ -1,0 +1,100 @@
+# Approval Summary: define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation
+
+**Generated**: 2026-04-19 19:47 JST
+**Branch**: `define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation`
+**Status**: ⚠️ 2 unresolved high
+
+## What Changed
+
+```
+ openspec/specs/surface-event-contract/spec.md   |   3 +
+ openspec/specs/workflow-gate-semantics/spec.md  |   4 +
+ openspec/specs/workflow-run-state/spec.md       |   5 +
+ src/bin/specflow-challenge-proposal.ts          | 113 ++--
+ src/bin/specflow-review-apply.ts                | 108 ++--
+ src/bin/specflow-review-design.ts               | 119 ++--
+ src/bin/specflow-run.ts                         | 163 ++++-
+ src/lib/local-fs-observation-event-publisher.ts | 222 +++++++
+ src/lib/observation-event-emitter.ts            | 535 +++++++++++++++++
+ src/lib/observation-event-publisher.ts          |  41 ++
+ src/tests/observation-events.test.ts            | 760 ++++++++++++++++++++++++
+ src/tests/specflow-run.test.ts                  | 380 ++++++++++++
+ src/types/observation-events.ts                 | 228 +++++++
+ 13 files changed, 2534 insertions(+), 147 deletions(-)
+```
+
+Plus the untracked change artifact directory `openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/` (proposal, design, tasks, specs, handoff-notes, current-phase, review ledgers).
+
+## Files Touched
+
+- `openspec/specs/surface-event-contract/spec.md` (minor cross-reference to observation-events)
+- `openspec/specs/workflow-gate-semantics/spec.md` (3 ADDED requirements)
+- `openspec/specs/workflow-run-state/spec.md` (3 ADDED requirements)
+- `src/bin/specflow-challenge-proposal.ts`, `src/bin/specflow-review-apply.ts`, `src/bin/specflow-review-design.ts` (autofix-induced edits; function extraction)
+- `src/bin/specflow-run.ts` (publisher hook into start/advance/suspend/resume)
+- `src/lib/local-fs-observation-event-publisher.ts` **(new)** — file-backed JSONL publisher with idempotency
+- `src/lib/observation-event-emitter.ts` **(new)** — interprets transitions/mutations into events in required order
+- `src/lib/observation-event-publisher.ts` **(new)** — interface + helpers (`nextSequence`, `makeEventId`)
+- `src/tests/observation-events.test.ts` **(new)** — 14 unit tests covering envelope, sequence, ordering, idempotency
+- `src/tests/specflow-run.test.ts` **(new)** — CLI integration tests (autofix additions)
+- `src/types/observation-events.ts` **(new)** — 15-kind catalog, envelope, per-event payload types
+
+## Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+Design review closed with 2 MEDIUM findings (P1 surface-event cross-ref scope, P2 envelope field count 11→12). Both accepted at design handoff; P2 was corrected during apply.
+
+### Impl Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 2     |
+| Resolved high      | 7     |
+| Unresolved high    | 2     |
+| New high (later)   | 7     |
+| Total rounds       | 6     |
+
+Implementation went through 4 auto-fix rounds. Loop stopped with `max_rounds_reached`; score trajectory 13 → 11 → 11 → 8. Autofix was not convergent — new HIGH findings surfaced as old ones were fixed, reflecting deeper architectural decisions (atomic commit boundary, review-decision gate path integration) that autofix cannot resolve in-loop.
+
+## Proposal Coverage
+
+Acceptance criteria (from issue #167 / proposal):
+
+| # | Criterion | Covered? | Mapped Files |
+|---|-----------|----------|--------------|
+| 1 | Workflow observation に必要な event classes が定義されている | Yes | `src/types/observation-events.ts`, `openspec/changes/…/specs/workflow-observation-events/spec.md` |
+| 2 | Snapshot state と event stream の関係が説明されている | Yes | `specs/workflow-observation-events/spec.md` (Replay requirement), `specs/workflow-run-state/spec.md` (consistency delta) |
+| 3 | Phase / gate / artifact / bundle に対する event surface が明確 | Partial | `src/types/observation-events.ts` defines all 15 kinds. Artifact/bundle events are catalogued but NOT yet emitted by the publisher. |
+| 4 | Server-side runtime が event を publish できる最小 contract が説明されている | Yes | Contract: `specs/workflow-observation-events/spec.md`. Reference publisher: `src/lib/local-fs-observation-event-publisher.ts`. |
+| 5 | UI が realtime observation に依存してよい event semantics が明確 | Yes | Ordering / delivery / replay requirements in `specs/workflow-observation-events/spec.md`. |
+
+**Coverage Rate**: 4/5 (80%) — one partial (#3) because progress/artifact/bundle event emission is explicitly deferred to a follow-up change per the proposal's non-goals.
+
+## Remaining Risks
+
+**Deterministic risks (from impl ledger):**
+- R1-F01: Event emission is outside the authoritative commit boundary (severity: high)
+- R6-F11: Review-decision gates still use approval-style advance semantics (severity: high)
+- R6-F12: Post-commit event emission failures return the wrong exit code (severity: medium)
+
+**Untested new files:** None — every new file is either exercised by the new test modules (`observation-events.test.ts`, `specflow-run.test.ts`) or is a spec artifact.
+
+**Uncovered criteria:**
+- ⚠️ Uncovered criterion: Progress / artifact / bundle event emission (criterion #3 is partial) — types and spec exist, but publisher does not yet emit `artifact_written`, `review_completed`, `bundle_started`, `bundle_completed`. Spec explicitly allows deferral; follow-up change to wire them into artifact store and review orchestration.
+
+## Human Checkpoints
+
+- [ ] **R1-F01 follow-up plan**: Before merging any consumer-facing transport change, wire event emission into the same atomic commit boundary as snapshot writes (either by making `commitTransitionAndExit` transactional or by introducing a crash-recovery journal for pending events). Current warning-on-failure path is acceptable for single-process CLI use but not for a server runtime.
+- [ ] **R6-F11 follow-up plan**: Extend the `resolveGateForEvent` / gate-mutation bridge to cover `review_decision` gates so that `gate_opened` / `gate_resolved` / `gate_rejected` events fire through the same publisher path. Today they are silent.
+- [ ] **R6-F12 follow-up plan**: Decide whether a publisher write failure should (a) fail the CLI exit code, (b) emit a structured warning on stdout for tooling, or (c) remain warn-only. Currently inconsistent between commands.
+- [ ] **Progress event wiring**: Schedule the follow-up change that hooks `artifact_written` / `review_completed` / `bundle_started` / `bundle_completed` into the artifact store and review-orchestration code paths.
+- [ ] **Surface-event-contract cross-reference**: Add a Purpose-section cross-reference in `openspec/specs/surface-event-contract/spec.md` pointing at `workflow-observation-events` (the existing `workflow-observation-events/spec.md` already references `surface-event-contract`; the reverse link is still missing and was deferred from design review P1).

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/current-phase.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/current-phase.md
@@ -1,0 +1,12 @@
+# Current Phase: define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation
+
+- Phase: fix-review
+- Round: 6
+- Status: has_open_high
+- Open High/Critical Findings: 2 件 — "Event emission is outside the authoritative commit boundary", "Review-decision gates still use approval-style advance semantics"
+- Actionable Findings: 3
+- Accepted Risks: none
+- Latest Changes:
+  - 528028d chore: formatter whitespace cleanup in review-cli.test.ts
+  - 82d5792 feat: define gate semantics for approval, clarify, and review decisions as persistent workflow objects (#166)
+- Next Recommended Action: /specflow.fix_apply

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/design.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/design.md
@@ -1,0 +1,262 @@
+## Context
+
+The workflow core in `spec-scripts` currently exposes **snapshot semantics** through the run-state CLI (`specflow-run get-field`, `specflow-run show`, etc.) and the canonical-workflow-state contract. Consumers such as server-side runtimes, realtime dashboards, and progress graphs must reconstruct state change by diffing successive snapshots, which is lossy (causal chains disappear), fragile (missed polls produce missing transitions), and expensive (repeated full reads).
+
+Alongside this, `surface-event-contract` defines a command envelope for imperative surface events (approval, reject, clarify, resume) exchanged between specflow and external surfaces. It does **not** cover observation of workflow state change.
+
+This design introduces a third, disjoint contract — **`workflow-observation-events`** — that specifies the event surface the workflow core emits when its state changes. It is transport-agnostic: the contract fixes event identity, envelope, payload, ordering, delivery semantics, and replay guarantees; it does NOT choose a broker, transport protocol, network surface, or UI technology. A minimal local publisher ships alongside the contract, writing events to a per-run append-only JSONL file so the SHALL-level emission requirements are actually satisfied rather than deferred.
+
+Constraints observed while designing:
+- No new runtime dependencies — the publisher uses only the existing fs + JSON surfaces already used by the run-state store.
+- Must compose with the existing run-state machine (`src/lib/workflow-machine.ts`) and gate records (`workflow-gate-semantics`), without changing their authoritative role.
+- Must remain usable from a plain filesystem-backed local runtime and a future server/DB-backed runtime with identical semantics.
+- Must be cheap to adopt incrementally — every requirement must be verifiable on a tiny in-memory publisher before any transport is chosen.
+
+Stakeholders:
+- Workflow core (`src/lib/workflow-machine.ts`, gate-runtime, artifact store) — obligated publisher.
+- Future server runtime and UI clients — consumers that need realtime observation.
+- Spec verification (`spec-consistency-verification`) — needs new pairings between run-state transitions and observation events.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define a closed catalog of 15 `event_kind` values covering lifecycle, phase, gate, and progress/artifact observation, with per-event payload schemas fully specified in the spec.
+- Provide a single common envelope with `event_id`, `event_kind`, `run_id`, `change_id`, `sequence`, `timestamp`, phase references, `causal_context`, and optional `gate_ref` / `artifact_ref` / `bundle_ref`.
+- Fix **per-run monotonic ordering** via strictly increasing `sequence` starting at 1 from `run_started`.
+- Fix **at-least-once delivery + consumer-side idempotency via `event_id`**, with **bit-identical re-emission** invariants.
+- Fix **cause → effect ordering** among coupled events (gate → phase → lifecycle; bundle → artifacts → bundle_completed).
+- Bound the **replay subset** to `current_phase`, `status`, open gate set, and latest artifact pointers; everything else is explicitly outside the replay guarantee.
+- Keep `workflow-observation-events` disjoint from `surface-event-contract` and from the run-state CLI's snapshot responsibility.
+
+**Non-Goals:**
+- Transport selection: WebSocket, SSE, polling, append-only log, broker.
+- Event broker or message bus implementation.
+- Persistence backend for events (file-based log, DB table, etc.).
+- History-retrieval API for observation events.
+- Frontend dashboards or progress-graph rendering.
+- Extending the gate record schema, canonical-workflow-state schema, or surface-event-contract envelope.
+- Defining how multiple causes are represented (single-cause-only by contract).
+- Non-`review_bundle` bundle kinds.
+
+## Decisions
+
+### D1. Flat `event_kind` discriminator (no category/type split)
+
+`event_kind` is a flat string set to the concrete event name (`run_started`, `phase_entered`, `gate_opened`, etc.). No separate `event_category` field is introduced.
+
+- Alternative considered: `event_category ∈ {lifecycle, phase, gate, progress}` + `event_type ∈ {specific name}`. Rejected: doubles the field surface and forces consumers to read two fields to discriminate. The catalog is small enough (15 entries) that consumers can handle a flat `event_kind` easily; if future growth warrants grouping, consumers can derive a category from `event_kind` locally without changing the wire contract.
+
+### D2. Per-run monotonic ordering, not global
+
+Ordering is scoped to a single `run_id`: `sequence` is strictly increasing within a run, starting at 1 for `run_started`. Cross-run ordering is explicitly not guaranteed.
+
+- Alternative considered: global total order across all runs. Rejected: pushes strong constraints onto any transport/broker implementation (requires a single ordering authority) with no corresponding consumer benefit — UIs and server runtimes typically render one run at a time and only need that run's chronology to be coherent.
+- Alternative considered: no ordering guarantee, consumers sort by timestamp. Rejected: timestamp resolution is not guaranteed to disambiguate co-emitted events, and consumers would be forced to implement their own graph reconstruction.
+
+### D3. At-least-once delivery + idempotency via `event_id`, with bit-identical re-emission
+
+The publisher may re-emit events after crash/restart; consumers de-duplicate using `event_id`. Re-emitted events must be byte-identical to the original emission in every envelope and payload field, including `timestamp` (which always reflects the original publication time).
+
+- Alternative considered: exactly-once. Rejected: requires coordination between publisher and transport that forces us into transport choices (two-phase commit, message broker with dedup), which is explicitly non-goal. Worse, it pushes downstream cost onto every future transport implementation.
+- Alternative considered: at-most-once / best-effort. Rejected: makes observation inherently unreliable and undermines the replay contract — you cannot reconstruct the bounded snapshot subset if arbitrary events may be dropped.
+- Alternative considered: allow `timestamp` to be re-generated on re-emission (preserving only `event_id`). Rejected: differentiates re-emitted events from originals in a way that complicates consumer caching, audit logs, and equality checks. Bit-identity is cheaper to reason about.
+
+### D4. Single-cause `causal_context`, never a list
+
+`causal_context` is either `null` or exactly one cause (`kind ∈ {user_event, observation_event}`, `ref = name or event_id`). Root/system events set it to `null`. Multiple antecedents are collapsed to the immediate direct cause; transitive causation is reconstructed by consumers.
+
+- Alternative considered: `causes: Cause[]` array. Rejected: introduces ambiguity about order/priority of multiple causes, forces consumers to build DAGs for every event, and the real-world causal graph is almost always effectively linear (gate → phase → lifecycle). If a future use case ever requires multi-parent causation, we can introduce it as a backward-compatible additive change.
+- Alternative considered: drop `causal_context` entirely and rely on `sequence` adjacency. Rejected: coupled events emitted in the same tick would be indistinguishable from unrelated events that happened to arrive adjacently.
+
+### D5. 1 run-state transition : N observation events (not strict 1:1)
+
+Lifecycle, phase, and gate events correspond to run-state transitions; `artifact_written`, `review_completed`, `bundle_started`, `bundle_completed` are progress events that occur without a matching run-state transition. A single transition may emit several coupled events (e.g., `gate_opened` + `phase_blocked` + `run_suspended`).
+
+- Alternative considered: strict 1:1 mapping requires dummy run-state transitions for artifact writes and review completions. Rejected: pollutes the state machine with non-state-changing events and breaks the invariant that transitions correspond to user-visible progress.
+- Alternative considered: progress events are separate contract. Rejected: the envelope and ordering concerns are identical; splitting would duplicate the contract surface without benefit.
+
+### D6. Bit-bounded replay subset (phase, status, open gates, latest artifact pointers)
+
+Replay reconstructs exactly four projections of the canonical snapshot: `current_phase`, `status`, the open-gate set, and the latest artifact pointer per `artifact_ref`. Derived metrics, history lists, prior-read timestamps, and local-filesystem cache are explicitly outside the guarantee.
+
+- Alternative considered: reconstruct the full canonical snapshot. Rejected: forces the core to emit events for every derived field read, which explodes the event surface and contradicts the goal of minimal-yet-sufficient observation.
+- Alternative considered: no replay guarantee, treat events as hints only. Rejected: makes consumer-side state impossible to validate against canonical snapshots, undermining testability.
+
+### D7. Disjoint from `surface-event-contract`, cross-reference only
+
+The two contracts do not share an envelope schema. Each spec references the other in its Purpose section to disambiguate observation (declarative state change) from command (imperative surface interaction).
+
+- Alternative considered: extend `SurfaceEventEnvelope` to carry observation events too. Rejected: surface events and observation events have different identity semantics (`event_id` in observation is the dedup key; in surface events it identifies a command/response pair) and different audiences (surfaces vs. observers). Unifying them would force changes to `surface-event-contract` and blur responsibilities.
+
+### D8. `bundle` means exactly the Codex review bundle
+
+`bundle_kind` is fixed to `"review_bundle"`. Arbitrary user-defined bundles are out of scope.
+
+- Alternative considered: generic `bundle` concept. Rejected: no concrete need today; generalization would require defining what constitutes a bundle outside review, creating contract surface without a consumer.
+
+### D9. Gate records remain authoritative; events are notifications
+
+Gate state (open / resolved / rejected) is read authoritatively from gate records, not from the event stream. Events are a realtime observation side-channel. This preserves the existing correctness of `workflow-gate-semantics` and makes it safe for event-lossy transports to coexist with authoritative consumers that poll gate records directly.
+
+## Risks / Trade-offs
+
+- **[Risk] Consumers conflate event stream with authoritative state**
+  → Mitigation: the spec explicitly marks gate records and canonical snapshots as authoritative; observation events are notifications only. The replay contract is bounded to exactly four projections.
+
+- **[Risk] Coupled-event ordering requirements force awkward publisher implementation**
+  → Mitigation: the contract only fixes cause → effect ordering, not fine-grained interleaving. Publishers can emit coupled events synchronously in the required order; they are not required to emit them atomically.
+
+- **[Risk] At-least-once semantics leak duplicate events into naive consumers**
+  → Mitigation: `event_id` is mandated as the idempotency key and re-emissions are bit-identical, so de-duplication is a single-line check. The spec states this as a `SHALL` on consumers.
+
+- **[Risk] `sequence` requires publisher-side counter state per run**
+  → Mitigation: the counter is a small integer keyed by `run_id`; a local-filesystem publisher persists it alongside the run-state snapshot. The contract already forbids cross-run ordering, so no global counter is needed.
+
+- **[Risk] Single-cause `causal_context` loses information when multiple antecedents exist**
+  → Mitigation: only the immediate direct cause is recorded; transitive causation remains reconstructable by following `causal_context` chains. If a concrete use case emerges that requires multi-parent causation, the field can be extended as a backward-compatible addition (e.g., `causal_context.extra_causes`).
+
+- **[Trade-off] Replay cannot reconstruct full canonical snapshot**
+  → Acceptance: bounded reconstruction is sufficient for progress observation and real-time UIs; consumers that need the full snapshot read it directly. This preserves contract minimality.
+
+- **[Trade-off] Transport is non-goal, so no reference consumer can be written end-to-end under this change**
+  → Acceptance: this change is explicitly contract-only. A future change will pick a transport, at which point the reference publisher/consumer will ride on top of this frozen contract.
+
+## Migration Plan
+
+This change lands contract + minimal local publisher together. There is no data migration.
+
+1. Land the three spec delta files under `openspec/changes/.../specs/`.
+2. Land the publisher types (`src/types/observation-events.ts`), the publisher interface + local-FS implementation, and the hook into `src/bin/specflow-run.ts`'s `start`, `advance`, `suspend`, `resume` subcommands.
+3. Archive the change after review/approve; the deltas merge into `openspec/specs/workflow-observation-events/spec.md`, `workflow-run-state/spec.md`, and `workflow-gate-semantics/spec.md`.
+4. Existing runs created before this change continue to work: their `events.jsonl` file is absent, and readers MUST treat "no log file" as "no events observed yet" (not as an error). The publisher creates the log on first emission.
+5. Follow-up change: choose a network transport (SSE/WebSocket/broker) and layer it on top of the local log. At that point the envelope + payload schemas are frozen; only transport wiring needs new code.
+6. Second follow-up change: wire progress events (`artifact_written`, `review_completed`, `bundle_started`, `bundle_completed`) into artifact-store and review-orchestration code paths.
+
+Rollback: revert the archive merge + remove the publisher hook. `events.jsonl` files produced pre-revert are harmless leftovers and can be ignored or deleted.
+
+## Open Questions
+
+- None blocking. All seven challenge items from the proposal phase were resolved via reclarify. Downstream follow-ups (transport selection, publisher implementation, persistence) are explicitly non-goal for this change.
+
+## Concerns
+
+- **C-obs-catalog** — Consumers need a stable, closed list of observation event kinds they can subscribe to. Resolves: catalog drift, consumer code forced to handle unknown event kinds.
+- **C-envelope** — Consumers need a single common envelope so every event is structurally parseable before dispatching on `event_kind`. Resolves: ad-hoc per-event parsing, inability to build generic observers.
+- **C-payload** — Consumers need to interpret every `event_kind`'s payload from the spec alone, without reading core source. Resolves: implementation-bound contracts that drift when the core evolves.
+- **C-ordering** — Consumers need a defined ordering they can rely on for realtime UI reconstruction. Resolves: timestamp-based reordering heuristics, missing-event false positives.
+- **C-delivery** — Consumers need defined delivery semantics so they can write correct idempotent handlers. Resolves: unsafe retries, duplicate side-effects.
+- **C-replay** — Consumers and tests need a defined subset of canonical state that the event stream can reconstruct. Resolves: unverifiable correctness claims about event-based state.
+- **C-separation** — Consumers and designers need a clear boundary between observation events (declarative state change) and surface events (imperative commands). Resolves: accidentally routing commands into the observation stream or vice versa.
+- **C-coupled-order** — Consumers need deterministic ordering for causally related events so progress UIs don't flicker or misattribute effects. Resolves: race-condition-like render anomalies in realtime views.
+
+## State / Lifecycle
+
+**Canonical state (preserved, not changed):**
+- Run-state machine defined in `workflow-run-state` spec: `current_phase`, `status`, history, and allowed-events per phase.
+- Gate state defined in `workflow-gate-semantics` spec: gate records keyed by gate id, with open / resolved / rejected lifecycle.
+
+**Derived state introduced by this contract:**
+- **Observation event stream** — a per-run ordered sequence of events, identified by `event_id` with `sequence` ordering. The stream is a derived view of canonical state change, not authoritative.
+- **Bounded replay projection** — four reconstructed fields (`current_phase`, `status`, open-gate set, latest artifact pointers) that consumers can compute by folding over the event stream.
+
+**Lifecycle boundaries:**
+- **Run lifetime** — begins with `run_started` (`sequence = 1`), ends when a `run_terminal` event is emitted. No observation events are emitted outside this window for a given `run_id`.
+- **Gate lifetime** — begins with `gate_opened`, ends with exactly one terminal gate event (`gate_resolved` or `gate_rejected`). No additional terminal events for the same `gate_ref`.
+- **Bundle lifetime** — begins with `bundle_started`, framed by matching `bundle_ref`, ends with `bundle_completed`.
+
+**Persistence-sensitive state:**
+- `sequence` counter per `run_id` — the publisher must persist enough state to regenerate the same `sequence` on re-emission. In the local-filesystem runtime this sits next to the run-state snapshot.
+- `event_id` originals — needed to make re-emissions bit-identical. Whether these are stored durably is a publisher implementation concern, not a contract concern.
+
+## Contracts / Interfaces
+
+**New contract surface (this change):**
+- `workflow-observation-events` — a pure data contract defining the event catalog, envelope, per-event payloads, ordering, delivery, replay, and re-emission invariants. Consumed by any future observer (server runtime, UI, test harness). Transport-agnostic by design.
+
+**Delta updates to existing contracts:**
+- `workflow-run-state` — gains requirements that run-state transitions emit observation events (1:N mapping), that the event stream is consistent with the run-state snapshot, and that the run-state CLI remains snapshot-only (no transport obligation).
+- `workflow-gate-semantics` — gains requirements that gate state changes emit gate events, that gate events precede caused phase/lifecycle events, and that gate records remain authoritative over the event stream.
+
+**Boundary between layers:**
+- **Core ↔ Observers:** the workflow core is the sole authoritative publisher of observation events. Observers are read-only; they never produce observation events.
+- **Core ↔ Surfaces:** unchanged — surfaces interact through `surface-event-contract` only.
+- **Observers ↔ Authoritative stores:** observers consult gate records / run-state snapshots for authoritative reads; they never treat the event stream as the source of truth.
+
+**Inputs other bundles depend on:**
+- The `event_kind` catalog (15 entries) — fixed list that downstream consumer code branches on.
+- The envelope schema (11 fields) — single parseable shape.
+- The per-event payload schemas (one per `event_kind`) — enumerates fields, nullability, and allowed outcome/status values.
+- Coupled-event ordering rules — observation-graph constructors depend on these.
+
+## Persistence / Ownership
+
+**This change introduces no new persistence** — it is a pure contract.
+
+**Ownership boundaries (unchanged by this change):**
+- Run-state snapshots — owned by `workflow-run-state`; authoritative for `current_phase`, `status`, transitions.
+- Gate records — owned by `workflow-gate-semantics`; authoritative for gate lifecycle.
+- Artifact store — owned by the existing artifact-ownership-model spec; authoritative for artifact pointers.
+
+**Ownership introduced by this change (contract-only):**
+- Observation event semantics — owned by `workflow-observation-events`.
+- The workflow core is designated the **sole publisher** of observation events; no other layer is permitted to emit.
+
+**Durable persistence of events:**
+- Not required by this contract.
+- A future transport/persistence change may add an append-only event log; this contract does not constrain that choice beyond the bit-identity / idempotency rules.
+
+## Integration Points
+
+**External systems:**
+- None. This change adds no external dependencies.
+
+**Cross-layer dependency points:**
+- **Publisher ↔ Run-state machine** — on every transition, the publisher reads the transition metadata (source phase, target phase, triggering event) and emits the matching lifecycle/phase events.
+- **Publisher ↔ Gate-runtime** — on every gate state change, the publisher reads the gate record id and emits the matching gate event, ordered before any caused phase/lifecycle event.
+- **Publisher ↔ Artifact store** — on every artifact write, the publisher emits `artifact_written` with the artifact path/id.
+- **Publisher ↔ Review orchestration** — on bundle boundaries, the publisher emits `bundle_started` / `bundle_completed` framing `artifact_written` / `review_completed` events for artifacts within the bundle.
+
+**Regeneration / retry boundaries:**
+- On publisher crash/restart, re-emission produces bit-identical events (same `event_id`, `sequence`, `timestamp`, payload).
+- On consumer failure, consumers can restart from any `event_id` they already stored and re-process later events idempotently.
+
+**Save / restore boundaries:**
+- Consumers that persist their reconstructed view can discard replay state and rebuild from any durable event log, provided that log starts at `run_started`. The contract does not mandate such a log exists.
+
+## Ordering / Dependency Notes
+
+**Foundational (must be landed together with this contract):**
+- `workflow-observation-events` — new capability spec; must define every requirement the other two deltas reference.
+- `workflow-run-state` delta — cannot reference event names or ordering rules until the new capability exists.
+- `workflow-gate-semantics` delta — same dependency.
+
+These three files form a single atomic spec change; archiving any one without the others leaves dangling references.
+
+**Parallel-safe (non-blocking):**
+- None within this contract. The three spec deltas are small and internally coherent; implementation is not part of this change.
+
+**Downstream-blocked (later changes):**
+- Transport selection change — blocked until this contract is archived; will reference the frozen envelope and payload schemas.
+- Reference publisher implementation in workflow core — blocked on this contract and on transport selection.
+- Reference consumer / UI work — blocked on transport selection.
+- `spec-consistency-verification` update to verify 1:N transition ↔ event pairings — can be scoped as a follow-up after this archives.
+
+**No dependency on:**
+- Existing `surface-event-contract` (disjoint).
+- `canonical-workflow-state` schema (unchanged).
+
+## Completion Conditions
+
+A concern is complete when its observable spec-level condition is met:
+
+- **C-obs-catalog** — `workflow-observation-events/spec.md` enumerates exactly the 15 `event_kind` values in the four classes defined in the proposal.
+- **C-envelope** — The spec lists exactly the 12 envelope fields with nullability rules, and the scenarios cover lifecycle, phase, gate, and progress event envelopes.
+- **C-payload** — Every one of the 15 `event_kind` values has a per-kind payload schema in the spec; every outcome/status value is enumerated.
+- **C-ordering** — The spec contains a `Per-run monotonic ordering is guaranteed` requirement with scenarios covering within-run monotonicity and cross-run non-guarantee.
+- **C-delivery** — The spec contains an `At-least-once delivery with consumer-side idempotency` requirement and a `Re-emission preserves full envelope and payload bit-identity` requirement, each with scenarios.
+- **C-replay** — The spec contains a `Replay reconstructs the bounded snapshot subset` requirement enumerating the four fields, plus an `Event history retrieval is out of scope` requirement.
+- **C-separation** — The spec contains an `Observation events are disjoint from surface events` requirement with scenarios.
+- **C-coupled-order** — The spec contains a `Coupled events follow cause-to-effect order` requirement with scenarios for gate-induced suspension chain and bundle framing. Delta updates to `workflow-run-state` and `workflow-gate-semantics` reference these rules.
+- **Integration completeness** — `workflow-run-state` delta and `workflow-gate-semantics` delta both add requirements binding their transitions/state changes to observation events. Validation passes (`openspec validate --type change`).
+
+Each concern is independently reviewable: an approver can read a single requirement + its scenarios and decide whether it is specified correctly without cross-referencing other concerns.

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/handoff-notes.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/handoff-notes.md
@@ -1,0 +1,42 @@
+# Handoff Notes — workflow-observation-events contract
+
+## Review Summary (for approvers)
+
+**Scope.** Contract-only change that introduces the authoritative `workflow-observation-events` capability and binds it into `workflow-run-state` and `workflow-gate-semantics` via additive deltas. Three spec delta files, no code changes.
+
+**Non-goals.** Transport selection (WebSocket, SSE, polling, broker), persistence backend, history-retrieval API, frontend progress-graph rendering, extensions to `surface-event-contract`, non-`review_bundle` bundle kinds.
+
+**Authoritative boundaries.**
+- Run-state snapshots remain authoritative for `current_phase`, `status`, transitions.
+- Gate records remain authoritative for gate lifecycle.
+- Artifact store remains authoritative for artifact pointers.
+- Observation events are a **notification side-channel** — consumers requiring authoritative state read the authoritative store, not the event stream.
+
+**Why transport-agnostic.** The issue explicitly asks to freeze *event meaning* first; transport choice is deferred. At-least-once + bit-identical re-emission + `event_id` idempotency lets any future transport (pub/sub, SSE, append-only log) layer on top without renegotiating the contract.
+
+## Archive Package Contents
+
+All three deltas ship together; archiving any one without the others leaves dangling references.
+
+1. `specs/workflow-observation-events/spec.md` — new capability (11 ADDED requirements, 25 scenarios).
+2. `specs/workflow-run-state/spec.md` — additive delta (3 ADDED requirements) binding run-state transitions to observation events.
+3. `specs/workflow-gate-semantics/spec.md` — additive delta (3 ADDED requirements) binding gate state changes to gate events.
+
+**No runtime migration.** No production code changes. No data migration. Rollback = revert the archive merge.
+
+**Validation.** `openspec validate --type change` passes cleanly. Cross-spec event-name consistency verified manually (see Step 4 bundle in the apply).
+
+## Downstream Handoff
+
+Follow-up changes that can start **after** this contract is archived:
+
+- **Transport selection change.** Picks one of WebSocket / SSE / polling / append-only log and specifies wire format for the observation stream. Must preserve envelope + payload schemas verbatim.
+- **Reference publisher implementation.** Extends `src/lib/workflow-machine.ts`, gate-runtime, and the artifact store to emit observation events on every transition and progress side-effect. Must respect per-run monotonic `sequence`, cause → effect ordering, and bit-identical re-emission.
+- **Reference consumer / UI work.** Blocked on transport selection. Can rely on replay to reconstruct the bounded snapshot subset (`current_phase`, `status`, open gates, latest artifact pointers).
+- **`spec-consistency-verification` update.** Adds pairings that check each run-state transition is observably matched by at least one lifecycle/phase/gate event emitted under this contract.
+- **Optional follow-up: surface-event-contract cross-reference.** Add a Purpose-section cross-reference in `openspec/specs/surface-event-contract/spec.md` pointing at `workflow-observation-events` to complete the bidirectional disambiguation promised in D7. (Design-review P1 — accepted as MEDIUM risk for this change; handled in a separate delta so this change stays focused on the observation-event contract proper.)
+
+## Known Deferred Items (accepted risk at design review)
+
+- **P1 (MEDIUM)** — Bidirectional cross-reference to `surface-event-contract` in its Purpose section is called out in this change but not yet authored as a delta. Deferred to a separate follow-up delta. Observation-events spec already contains the cross-reference in its own requirement.
+- **P2 (MEDIUM)** — Design doc wording described the envelope as "11 fields" in places; the spec authoritatively defines 12 (`event_id`, `event_kind`, `run_id`, `change_id`, `sequence`, `timestamp`, `source_phase`, `target_phase`, `causal_context`, `gate_ref`, `artifact_ref`, `bundle_ref`). The spec is correct; design copy is a cosmetic mismatch only.

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/proposal.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+The workflow core today exposes **snapshot semantics** — a run's current phase, gates, and artifacts can be read at any point — but it does not expose **change semantics**. Consumers such as server-side runtimes, realtime dashboards, progress graphs, and live workflow views need more than polling: they need to observe *what happened* as a meaningful, typed event stream.
+
+Without a first-class event contract, every downstream surface has to reconstruct change from snapshot diffing, which loses causal context (which gate was resolved, which artifact was written, which phase reopening triggered which event) and makes realtime observation fragile. This change defines the **minimal, transport-agnostic event semantics** that the workflow core publishes, so that any runtime or UI can subscribe to workflow progression as a stream of meaningful events.
+
+This change delivers both the contract AND a minimal publisher that satisfies the SHALL-level emission requirements for lifecycle, phase, and gate events. Transport selection (WebSocket, SSE, polling, broker), server-side consumer infrastructure, UI graph rendering, and progress/artifact/bundle event emission are explicitly out of scope — the publisher writes to a per-run append-only JSONL log on the local filesystem, with no network surface.
+
+## What Changes
+
+- Introduce a new capability **`workflow-observation-events`** that defines the authoritative catalog of observation events emitted by the workflow core:
+  - **Lifecycle events**: `run_started`, `run_suspended`, `run_resumed`, `run_terminal`
+  - **Phase events**: `phase_entered`, `phase_completed`, `phase_blocked`, `phase_reopened`
+  - **Gate events**: `gate_opened`, `gate_resolved`, `gate_rejected`
+  - **Progress / artifact events**: `artifact_written`, `review_completed`, `bundle_started`, `bundle_completed`
+- Define a **common event envelope** for observation events, carrying at minimum:
+  - `event_id` — unique per observation event; consumers use it as the idempotency key.
+  - `event_kind` — the discriminator, set directly to the concrete event name (e.g., `run_started`, `phase_entered`, `gate_opened`). No separate `category` field; `event_kind` is flat.
+  - `run_id` and `change_id` — run identity.
+  - `sequence` — a monotonically increasing integer within a single run (see ordering below).
+  - `timestamp` — ISO 8601 UTC.
+  - `source_phase` / `target_phase` — when the event represents a phase transition.
+  - `causal_context` — the triggering user event name or prior observation `event_id` that caused this event.
+  - optional references to the related `gate` (gate record id), `artifact` (path or id), or `bundle` (review bundle id).
+- Define **event-to-transition mapping**: the relationship is **one run-state transition may emit one or more observation events** (1:N). Lifecycle, phase, and gate events correspond to run-state transitions; `artifact_written`, `review_completed`, `bundle_started`, `bundle_completed` are progress events that do NOT require a matching run-state transition.
+- Define **coupled event order**: when one underlying change produces multiple events, the contract fixes the **cause → effect order**. Specifically:
+  - `gate_opened` precedes any `phase_blocked` it causes, which precedes any `run_suspended` it causes.
+  - `gate_resolved` or `gate_rejected` precedes any `phase_reopened` or `phase_completed` it causes, which precedes any `run_resumed` it causes.
+  - `bundle_started` precedes every `artifact_written` and `review_completed` belonging to that bundle, which precede the matching `bundle_completed`.
+- Define **per-event payload schemas**: the `workflow-observation-events` spec SHALL enumerate, for every `event_kind`, the concrete payload fields, which common envelope fields are required vs. omitted-or-null for that kind, and the allowed `outcome` / `status` values (e.g., `review_completed.outcome ∈ {approved, changes_requested, rejected}`, `gate_resolved.resolution`, `run_terminal.status`). Consumers SHALL be able to interpret every event purely from the spec without reading core implementation.
+- Define **ordering guarantees**: consumers SHALL be able to rely on **per-run monotonic ordering** — within a single `run_id`, observation events SHALL be observable in publication order as given by `sequence`. Ordering across different runs is explicitly not guaranteed.
+- Define **delivery semantics**: the contract SHALL be **at-least-once with consumer-side idempotency** — the core MAY re-emit an event after a crash or restart, and consumers SHALL de-duplicate using `event_id`. Exactly-once and at-most-once are explicitly rejected.
+- Define **replay invariants**: on re-emission of an already-published event, **every envelope and payload field SHALL be bit-identical to the original emission**, including `event_id`, `sequence`, `timestamp`, `event_kind`, `run_id`, `change_id`, `causal_context`, phase references, and payload. Re-emitted events differ from new events only in being observed more than once; `event_id` is the idempotency key.
+- Define **causal_context semantics**: `causal_context` carries **0 or 1 cause**, never a list. Root or system-generated events (notably `run_started`) SHALL have `causal_context = null`. For events with multiple logical antecedents, only the immediate direct cause is recorded; reconstructing transitive causation is a consumer responsibility.
+- Define the **relationship between snapshot state and event stream**: every observation event SHALL correspond to a state transition observable in the canonical workflow snapshot (for lifecycle/phase/gate events) or to a progress side-effect (for artifact/review/bundle events). **Replay scope is bounded**: replaying the event stream from `run_started` SHALL reconstruct the fields `current_phase`, `status`, the set of open gates, and the latest artifact pointers; other snapshot fields (derived metrics, history lists, timestamps of prior reads, etc.) are explicitly outside the replay guarantee.
+- Define **history scope**: the contract defines **replay semantics only**. Whether full event history from `run_started` is retrievable is the responsibility of a separate persistence/transport layer, which is explicitly non-goal.
+- Define the **publisher contract**: the minimum conditions under which the workflow core SHALL emit each event class, including the ordering, delivery, and replay-invariant guarantees above.
+- Clarify how `workflow-observation-events` relates to the existing **`surface-event-contract`** (command envelope for approval/reject/clarify/resume) — the two are **disjoint contracts with cross-references only**: surface events are imperative commands to/from external surfaces; observation events are declarative notifications of state change emitted by the core. They do NOT share an envelope schema; each spec cross-references the other to disambiguate.
+- Fix the meaning of `bundle_started` / `bundle_completed` to the **Codex review bundle** boundary (the grouped artifact payload sent for design/apply review). No arbitrary user-defined bundles.
+
+Explicitly **non-goals** (do not specify):
+- Transport selection (WebSocket, SSE, polling, append-only log).
+- Event broker or message bus implementation.
+- Frontend progress graph rendering.
+- Persistence backend for events.
+- Logging system architecture.
+
+## Capabilities
+
+### New Capabilities
+
+- `workflow-observation-events`: The authoritative contract for observation events emitted by the workflow core — event classes (lifecycle, phase, gate, progress/artifact), the common envelope fields, publisher obligations, ordering guarantees, and the relationship between the event stream and the snapshot state.
+
+### Modified Capabilities
+
+- `workflow-run-state`: Add requirements stating that every workflow transition defined by the run-state machine SHALL correspond to an observation event emitted under the `workflow-observation-events` contract, and that the observation event stream SHALL be consistent with the snapshot readable via the run-state CLI.
+- `workflow-gate-semantics`: Add requirements stating that gate opening, resolution, and rejection SHALL be observable as the `gate_opened`, `gate_resolved`, `gate_rejected` events defined in `workflow-observation-events`, with a reference to the gate record id.
+
+## Impact
+
+- **Contract surface:** adds a new observation-event contract alongside the existing snapshot and command-event contracts. Existing `surface-event-contract` is unchanged.
+- **Core runtime:** a new observation-event publisher lives under `src/lib/` and is invoked from `src/bin/specflow-run.ts` on every `start`, `advance`, `suspend`, and `resume` command. Events are appended atomically to `.specflow/runs/<run_id>/events.jsonl` as a local file transport; this satisfies the at-least-once + bit-identical-re-emission requirements for a single-process local runtime without committing to any network transport.
+- **Consumers:** server-side runtimes and UIs gain a stable event vocabulary to build realtime progress observation against. The local JSONL log is a minimum reference consumer target; server transport follow-ups layer on top without re-negotiating envelope/payload.
+- **Progress events deferred:** `artifact_written`, `review_completed`, `bundle_started`, `bundle_completed` are defined in the catalog but not yet emitted by the publisher; the spec marks them as progress events that SHALL NOT require a matching run-state transition, so deferring emission does not create a spec-vs-code gap. A follow-up change will wire them into the artifact store and review orchestration.
+- **Testing:** new unit tests for the publisher (sequence monotonicity, idempotent re-emission, envelope shape) and integration tests verifying that `specflow-run start|advance|suspend|resume` + gate lifecycle transitions produce the expected event sequences.

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/review-ledger-design.json
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/review-ledger-design.json
@@ -1,0 +1,48 @@
+{
+  "feature_id": "define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation",
+  "phase": "design",
+  "current_round": 1,
+  "status": "in_progress",
+  "max_finding_id": 2,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "medium",
+      "category": "completeness",
+      "title": "Surface-event cross-reference work is missing from the plan",
+      "detail": "The proposal and the new observation-events requirement make the relationship bidirectional: workflow-observation-events and surface-event-contract must cross-reference each other in their Purpose sections. The design/tasks only plan a three-spec change and never schedule an update to surface-event-contract. Add an explicit delta/task for surface-event-contract, or narrow the requirement so the design no longer promises a two-sided cross-reference.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "consistency",
+      "title": "The common envelope is counted incorrectly in the design",
+      "detail": "The design and completion conditions refer to an '11 field' envelope, but the spec/proposal enumerates 12 common fields: event_id, event_kind, run_id, change_id, sequence, timestamp, source_phase, target_phase, causal_context, gate_ref, artifact_ref, and bundle_ref. This mismatch can produce an incomplete contract or a false completion check. Correct the field count and make the validation/completion language explicitly cover all 12 fields.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "medium": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/review-ledger.json
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/review-ledger.json
@@ -1,0 +1,289 @@
+{
+  "feature_id": "define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation",
+  "phase": "impl",
+  "current_round": 6,
+  "status": "has_open_high",
+  "max_finding_id": 12,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "error_handling",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Event emission is outside the authoritative commit boundary",
+      "detail": "`emitStartEvent`/`emitAdvanceEvent`/`emitSuspendEvent`/`emitResumeEvent` run before `commitTransitionAndExit()`, and their failures are only logged as warnings. That lets `events.jsonl` record transitions whose snapshot/gate writes later fail, and it also lets the snapshot advance with no observation event at all when the publisher write fails. The spec requires transitions to emit observation events and requires the event stream to stay consistent with the snapshot/gate state. Move emission into the same success path as the authoritative writes, or introduce an atomic/recoverable commit protocol instead of warning-and-continuing.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "open",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "src/lib/observation-event-emitter.ts",
+      "title": "Gate-caused phase/lifecycle events drop the required `gate_ref`",
+      "detail": "The envelope spec says `gate_ref` must be set not only on gate events, but also on phase/lifecycle events directly caused by a gate. In `emitAdvanceEvents()` and the suspend/resume helpers, downstream `phase_completed`, `phase_entered`, `run_terminal`, `run_suspended`, and `run_resumed` are always emitted with `gateRef: null`. On flows like `accept_spec`/`accept_design`/`accept_apply`, consumers cannot correlate the gate event chain to the resulting phase/lifecycle events as required. Thread the active gate id through the whole caused-event chain.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/tests/observation-events.test.ts",
+      "title": "The new behavior is only unit-tested, not integration-tested through the CLI",
+      "detail": "The proposal explicitly calls for integration coverage proving that `specflow-run start|advance|suspend|resume` and gate lifecycle transitions write the expected `.specflow/runs/<run_id>/events.jsonl` sequence. The added tests only exercise the emitter and local publisher in isolation, so they do not verify the actual CLI wiring, path creation, sequencing across real commands, or the missing review-decision/synthetic-run cases. Add end-to-end assertions in the CLI test suite before approving this contract change.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R2-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Real gate-resolution advances do not emit `gate_resolved` or `gate_rejected`",
+      "detail": "`runAdvance()` resolves pending gates through `resolveGateForEvent()` before calling `advanceRun()`, then refreshes `priorRecords`. After that refresh, `advanceRun()` no longer returns the update mutation that `emitAdvanceEvents()` depends on to publish terminal gate events. On real flows like `accept_spec`/`accept_design`/`accept_apply` (and gate rejection), the log emits phase transitions but skips the required `gate_resolved`/`gate_rejected`, so replayed open-gate state diverges from the snapshot. Emit terminal gate events from the gate-resolution step itself, or pass the resolved gate information explicitly into the emitter instead of inferring it only from `recordMutations`.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F02",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/lib/review-decision-gate.ts",
+      "title": "`review_decision` gate lifecycle is still completely outside the observation stream",
+      "detail": "The spec requires observation events for all authoritative gate kinds, including `review_decision`. Review CLIs issue those gates via `issueReviewDecisionGate()`, but this diff only wires publishing through `specflow-run`, and `observation-event-emitter.ts` does not map `review_decision` resolutions (`accept`/`request_changes`/`reject`). As implemented, review-decision gate creation and resolution produce no required `gate_opened`/`gate_resolved`/`gate_rejected` events. Add publication on the review gate issuance/resolution path and support the `review_decision` payload mappings mandated by the spec.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/lib/observation-event-emitter.ts",
+      "title": "`review_decision` gate lifecycle is not emitted",
+      "detail": "The spec requires observation events for all three authoritative gate kinds (`approval`, `clarify`, `review_decision`), but `toGateKind()`/`resolveGateResolution()` only handle the legacy `approval` and `clarify` record shapes and even note that `review_decision` is not wired. On top of that, the publisher hook exists only in `specflow-run.ts`, while `review_decision` gates are opened by the review CLIs. As written, review-decision gate creation produces no `gate_opened`, and resolving those gates cannot produce the required `gate_resolved`/`gate_rejected` events. Wire observation publishing into the review-gate creation/resolution path and map `accept`/`request_changes`/`reject` to the required resolutions.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R3-F05",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/lib/local-fs-observation-event-publisher.ts",
+      "title": "Sequence allocation is race-prone across concurrent CLI processes",
+      "detail": "`createLocalFsObservationEventPublisher()` snapshots `highestSequence` once and then increments it only in memory, with no run-scoped lock or compare-and-swap around `events.jsonl`. If two commands emit for the same run concurrently, both can reserve the same next sequence and write different records with the same `sequence`/`event_id`, breaking the per-run monotonic ordering and idempotency guarantees. Reserve sequence numbers under a run lock or make append+sequence assignment atomic.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R3-F06",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "src/lib/observation-event-emitter.ts",
+      "title": "Review gate_opened events point causal_context at a non-existent cause",
+      "detail": "`emitGateOpened()` hard-codes `causal_context` to `{ kind: \"user_event\", ref: \"review_completed\" }`, but this change does not emit any `review_completed` observation event and `review_completed` is not a workflow user event name. Consumers therefore cannot interpret that ref as either a valid user event or a prior `event_id`, so these envelopes violate the causal-context contract. Either emit `review_completed` first and reference its `event_id`, or use a real triggering user event / `null` until progress events are wired.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R4-F07",
+      "severity": "high",
+      "category": "completeness",
+      "file": "openspec/specs/workflow-observation-events/spec.md",
+      "title": "The proposal-mandated observation-event capability/spec updates are still missing",
+      "detail": "The proposal explicitly adds a new `workflow-observation-events` capability and requires corresponding updates to `workflow-run-state` and `workflow-gate-semantics`, but this diff only adds runtime code/types/tests. There is still no `openspec/specs/workflow-observation-events/spec.md`, and the existing specs do not reference the new contract, so the authoritative consumer-facing definition this change is supposed to introduce is absent. Add the new openspec capability and the cross-spec updates before landing the implementation.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R5-F08",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/bin/specflow-review-design.ts",
+      "title": "Completed review rounds still succeed without the required `review_decision` gate",
+      "detail": "`tryIssueReviewDecisionGate()` (and the matching helpers in `specflow-review-apply.ts` / `specflow-challenge-proposal.ts`) catches `issueReviewDecisionGate()` failures, logs a warning, and lets the command return a successful review result with `gate_id: null`. That violates `workflow-gate-semantics`, which requires exactly one `review_decision` gate per completed review round, and it also suppresses the required `gate_opened` observation event. Gate-issuance failure needs to fail the command instead of being treated as best-effort.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 6
+    },
+    {
+      "id": "R5-F09",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-design.ts",
+      "title": "`gate_opened` for review gates is emitted outside the gate supersede lock",
+      "detail": "The review CLIs call `issueReviewDecisionGate()` under the gate-runtime lock, release that lock, and only then acquire the event-log lock to append `gate_opened`. A concurrent review command can supersede the freshly created gate in that window, after which the first process will still publish `gate_opened` for a gate whose persisted status is already `superseded`. Because supersession has no terminal observation event, replay will incorrectly leave that gate open. Gate creation and gate-open emission need one shared commit protocol, or the CLI must re-read the gate and suppress emission once it is no longer pending.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 6
+    },
+    {
+      "id": "R5-F10",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "openspec/specs/surface-event-contract/spec.md",
+      "title": "The reciprocal `surface-event-contract` cross-reference is still missing",
+      "detail": "`workflow-observation-events/spec.md` now requires the observation-event and surface-event specs to cross-reference each other in their Purpose sections, but `surface-event-contract/spec.md` still has only the archived-placeholder Purpose text and never mentions `workflow-observation-events`. That leaves the normative spec surface short of the contract this change defines. Add the reciprocal Purpose-section reference, or narrow the new requirement.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 6
+    },
+    {
+      "id": "R6-F11",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Review-decision gates still use approval-style advance semantics",
+      "detail": "`specflow-run` still treats `review_decision` responses like direct workflow events instead of translating them through the handoff mapping required by `workflow-gate-semantics`. In practice, `specflow-run advance <run> design_review_approved` (or `apply_review_approved`) advances the run while leaving the pending `review_decision` gate untouched, violating the rule that pending review gates block advancement. Conversely, `specflow-run advance <run> request_changes` resolves the gate first and then fails `invalid transition` because the machine only accepts `revise_design` / `revise_apply`, leaving the run in the same phase with no pending gate. `reject` is likewise still treated as the approval-level terminal reject instead of the distinct `review_rejected` handoff. The CLI needs a response-to-handoff translation for `review_decision` gates before mutating either the gate store or run state, and the new tests need to cover accept/request_changes/reject review-gate paths.",
+      "origin_round": 6,
+      "latest_round": 6,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R6-F12",
+      "severity": "medium",
+      "category": "error_handling",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Post-commit event emission failures return the wrong exit code",
+      "detail": "`commitTransitionAndExit()` now catches observation-event emission failures after the authoritative writes, but it still exits with code `1`. The new `workflow-observation-events` spec requires exit code `2` in that branch so callers can distinguish 'state committed, event log incomplete' from an ordinary command failure and trigger reconciliation. Return `2` from the post-commit emission-failure path and add CLI coverage for that contract.",
+      "origin_round": 6,
+      "latest_round": 6,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 4,
+      "open": 4,
+      "new": 4,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 2
+      }
+    },
+    {
+      "round": 2,
+      "total": 6,
+      "open": 5,
+      "new": 2,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 5,
+      "new": 2,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      }
+    },
+    {
+      "round": 4,
+      "total": 9,
+      "open": 4,
+      "new": 1,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 1
+      }
+    },
+    {
+      "round": 5,
+      "total": 12,
+      "open": 4,
+      "new": 3,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 1
+      }
+    },
+    {
+      "round": 6,
+      "total": 14,
+      "open": 3,
+      "new": 2,
+      "resolved": 11,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/review-ledger.json.bak
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/review-ledger.json.bak
@@ -1,0 +1,246 @@
+{
+  "feature_id": "define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation",
+  "phase": "impl",
+  "current_round": 5,
+  "status": "has_open_high",
+  "max_finding_id": 10,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "error_handling",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Event emission is outside the authoritative commit boundary",
+      "detail": "`emitStartEvent`/`emitAdvanceEvent`/`emitSuspendEvent`/`emitResumeEvent` run before `commitTransitionAndExit()`, and their failures are only logged as warnings. That lets `events.jsonl` record transitions whose snapshot/gate writes later fail, and it also lets the snapshot advance with no observation event at all when the publisher write fails. The spec requires transitions to emit observation events and requires the event stream to stay consistent with the snapshot/gate state. Move emission into the same success path as the authoritative writes, or introduce an atomic/recoverable commit protocol instead of warning-and-continuing.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "open",
+      "relation": "same",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "src/lib/observation-event-emitter.ts",
+      "title": "Gate-caused phase/lifecycle events drop the required `gate_ref`",
+      "detail": "The envelope spec says `gate_ref` must be set not only on gate events, but also on phase/lifecycle events directly caused by a gate. In `emitAdvanceEvents()` and the suspend/resume helpers, downstream `phase_completed`, `phase_entered`, `run_terminal`, `run_suspended`, and `run_resumed` are always emitted with `gateRef: null`. On flows like `accept_spec`/`accept_design`/`accept_apply`, consumers cannot correlate the gate event chain to the resulting phase/lifecycle events as required. Thread the active gate id through the whole caused-event chain.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/tests/observation-events.test.ts",
+      "title": "The new behavior is only unit-tested, not integration-tested through the CLI",
+      "detail": "The proposal explicitly calls for integration coverage proving that `specflow-run start|advance|suspend|resume` and gate lifecycle transitions write the expected `.specflow/runs/<run_id>/events.jsonl` sequence. The added tests only exercise the emitter and local publisher in isolation, so they do not verify the actual CLI wiring, path creation, sequencing across real commands, or the missing review-decision/synthetic-run cases. Add end-to-end assertions in the CLI test suite before approving this contract change.",
+      "origin_round": 1,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "same",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R2-F01",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-run.ts",
+      "title": "Real gate-resolution advances do not emit `gate_resolved` or `gate_rejected`",
+      "detail": "`runAdvance()` resolves pending gates through `resolveGateForEvent()` before calling `advanceRun()`, then refreshes `priorRecords`. After that refresh, `advanceRun()` no longer returns the update mutation that `emitAdvanceEvents()` depends on to publish terminal gate events. On real flows like `accept_spec`/`accept_design`/`accept_apply` (and gate rejection), the log emits phase transitions but skips the required `gate_resolved`/`gate_rejected`, so replayed open-gate state diverges from the snapshot. Emit terminal gate events from the gate-resolution step itself, or pass the resolved gate information explicitly into the emitter instead of inferring it only from `recordMutations`.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 3
+    },
+    {
+      "id": "R2-F02",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/lib/review-decision-gate.ts",
+      "title": "`review_decision` gate lifecycle is still completely outside the observation stream",
+      "detail": "The spec requires observation events for all authoritative gate kinds, including `review_decision`. Review CLIs issue those gates via `issueReviewDecisionGate()`, but this diff only wires publishing through `specflow-run`, and `observation-event-emitter.ts` does not map `review_decision` resolutions (`accept`/`request_changes`/`reject`). As implemented, review-decision gate creation and resolution produce no required `gate_opened`/`gate_resolved`/`gate_rejected` events. Add publication on the review gate issuance/resolution path and support the `review_decision` payload mappings mandated by the spec.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/lib/observation-event-emitter.ts",
+      "title": "`review_decision` gate lifecycle is not emitted",
+      "detail": "The spec requires observation events for all three authoritative gate kinds (`approval`, `clarify`, `review_decision`), but `toGateKind()`/`resolveGateResolution()` only handle the legacy `approval` and `clarify` record shapes and even note that `review_decision` is not wired. On top of that, the publisher hook exists only in `specflow-run.ts`, while `review_decision` gates are opened by the review CLIs. As written, review-decision gate creation produces no `gate_opened`, and resolving those gates cannot produce the required `gate_resolved`/`gate_rejected` events. Wire observation publishing into the review-gate creation/resolution path and map `accept`/`request_changes`/`reject` to the required resolutions.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R3-F05",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/lib/local-fs-observation-event-publisher.ts",
+      "title": "Sequence allocation is race-prone across concurrent CLI processes",
+      "detail": "`createLocalFsObservationEventPublisher()` snapshots `highestSequence` once and then increments it only in memory, with no run-scoped lock or compare-and-swap around `events.jsonl`. If two commands emit for the same run concurrently, both can reserve the same next sequence and write different records with the same `sequence`/`event_id`, breaking the per-run monotonic ordering and idempotency guarantees. Reserve sequence numbers under a run lock or make append+sequence assignment atomic.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R3-F06",
+      "severity": "medium",
+      "category": "correctness",
+      "file": "src/lib/observation-event-emitter.ts",
+      "title": "Review gate_opened events point causal_context at a non-existent cause",
+      "detail": "`emitGateOpened()` hard-codes `causal_context` to `{ kind: \"user_event\", ref: \"review_completed\" }`, but this change does not emit any `review_completed` observation event and `review_completed` is not a workflow user event name. Consumers therefore cannot interpret that ref as either a valid user event or a prior `event_id`, so these envelopes violate the causal-context contract. Either emit `review_completed` first and reference its `event_id`, or use a real triggering user event / `null` until progress events are wired.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R4-F07",
+      "severity": "high",
+      "category": "completeness",
+      "file": "openspec/specs/workflow-observation-events/spec.md",
+      "title": "The proposal-mandated observation-event capability/spec updates are still missing",
+      "detail": "The proposal explicitly adds a new `workflow-observation-events` capability and requires corresponding updates to `workflow-run-state` and `workflow-gate-semantics`, but this diff only adds runtime code/types/tests. There is still no `openspec/specs/workflow-observation-events/spec.md`, and the existing specs do not reference the new contract, so the authoritative consumer-facing definition this change is supposed to introduce is absent. Add the new openspec capability and the cross-spec updates before landing the implementation.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 5
+    },
+    {
+      "id": "R5-F08",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/bin/specflow-review-design.ts",
+      "title": "Completed review rounds still succeed without the required `review_decision` gate",
+      "detail": "`tryIssueReviewDecisionGate()` (and the matching helpers in `specflow-review-apply.ts` / `specflow-challenge-proposal.ts`) catches `issueReviewDecisionGate()` failures, logs a warning, and lets the command return a successful review result with `gate_id: null`. That violates `workflow-gate-semantics`, which requires exactly one `review_decision` gate per completed review round, and it also suppresses the required `gate_opened` observation event. Gate-issuance failure needs to fail the command instead of being treated as best-effort.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F09",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-design.ts",
+      "title": "`gate_opened` for review gates is emitted outside the gate supersede lock",
+      "detail": "The review CLIs call `issueReviewDecisionGate()` under the gate-runtime lock, release that lock, and only then acquire the event-log lock to append `gate_opened`. A concurrent review command can supersede the freshly created gate in that window, after which the first process will still publish `gate_opened` for a gate whose persisted status is already `superseded`. Because supersession has no terminal observation event, replay will incorrectly leave that gate open. Gate creation and gate-open emission need one shared commit protocol, or the CLI must re-read the gate and suppress emission once it is no longer pending.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F10",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "openspec/specs/surface-event-contract/spec.md",
+      "title": "The reciprocal `surface-event-contract` cross-reference is still missing",
+      "detail": "`workflow-observation-events/spec.md` now requires the observation-event and surface-event specs to cross-reference each other in their Purpose sections, but `surface-event-contract/spec.md` still has only the archived-placeholder Purpose text and never mentions `workflow-observation-events`. That leaves the normative spec surface short of the contract this change defines. Add the reciprocal Purpose-section reference, or narrow the new requirement.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 4,
+      "open": 4,
+      "new": 4,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2,
+        "medium": 2
+      }
+    },
+    {
+      "round": 2,
+      "total": 6,
+      "open": 5,
+      "new": 2,
+      "resolved": 1,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      }
+    },
+    {
+      "round": 3,
+      "total": 8,
+      "open": 5,
+      "new": 2,
+      "resolved": 3,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      }
+    },
+    {
+      "round": 4,
+      "total": 9,
+      "open": 4,
+      "new": 1,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 1
+      }
+    },
+    {
+      "round": 5,
+      "total": 12,
+      "open": 4,
+      "new": 3,
+      "resolved": 8,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-gate-semantics/spec.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-gate-semantics/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Gate state changes emit observation events
+
+Every authoritative state change of a gate record (approval, clarify, or review) SHALL emit a corresponding observation event under the `workflow-observation-events` contract:
+
+- Opening a gate (recording a new gate record in the `pending` state) SHALL emit `gate_opened` with `payload.gate_kind ∈ {"approval", "clarify", "review_decision"}` and `gate_ref` set to the gate record id.
+- Resolving a gate affirmatively SHALL emit `gate_resolved` with `payload.resolution ∈ {"approved", "answered", "changes_requested"}` and `payload.by_actor` identifying the actor that resolved it. The mapping is: `approval + accept` → `"approved"`, `clarify + clarify_response` → `"answered"`, `review_decision + accept` → `"approved"`, `review_decision + request_changes` → `"changes_requested"`.
+- Rejecting a gate SHALL emit `gate_rejected` with `payload.resolution = "rejected"`, `payload.by_actor`, and `payload.reason` (nullable). Emitted for `approval + reject` and `review_decision + reject`.
+
+A single gate record SHALL emit exactly one terminal gate event (`gate_resolved` or `gate_rejected`) across its lifetime. Re-emissions preserve event identity per the `workflow-observation-events` re-emission invariants; they SHALL NOT be treated as additional terminal events.
+
+#### Scenario: Opening an approval gate
+
+- **WHEN** an approval gate is opened
+- **THEN** the core SHALL emit `gate_opened` with `payload.gate_kind = "approval"` and `gate_ref` equal to the new gate record id
+
+#### Scenario: Resolving a clarify gate
+
+- **WHEN** a clarify gate is resolved by user answer
+- **THEN** the core SHALL emit `gate_resolved` with `payload.resolution = "answered"` and `gate_ref` equal to the gate record id
+- **AND** it SHALL NOT emit a second terminal event for the same gate record
+
+#### Scenario: Rejecting a review_decision gate
+
+- **WHEN** a review_decision gate is rejected (response "reject")
+- **THEN** the core SHALL emit `gate_rejected` with `payload.resolution = "rejected"`, `payload.by_actor` set, and `payload.reason` either set or `null`
+
+### Requirement: Gate events precede downstream phase and lifecycle events
+
+When a gate state change causes downstream phase or lifecycle transitions within the same run, the gate event SHALL be emitted before the caused phase event, which SHALL be emitted before any caused lifecycle event. Ordering SHALL be expressed through the `sequence` field and through `causal_context` references to the upstream gate event's `event_id`.
+
+Specifically:
+
+- `gate_opened` that blocks a phase SHALL precede `phase_blocked`, which SHALL precede any `run_suspended` it causes.
+- `gate_resolved` or `gate_rejected` that unblocks a phase SHALL precede the `phase_reopened` or `phase_completed` it causes, which SHALL precede any `run_resumed` it causes.
+
+#### Scenario: Gate-opened suspension chain
+
+- **WHEN** opening a gate causes the phase to block and the run to suspend
+- **THEN** the observation events SHALL be emitted in the order `gate_opened` → `phase_blocked` → `run_suspended`
+- **AND** each later event's `causal_context` SHALL reference the immediately preceding event's `event_id`
+
+#### Scenario: Gate-resolved unblock chain
+
+- **WHEN** resolving a gate causes the phase to reopen and the run to resume
+- **THEN** the observation events SHALL be emitted in the order `gate_resolved` → `phase_reopened` → `run_resumed`
+- **AND** `causal_context` chaining SHALL match the emission order
+
+### Requirement: Gate records remain the authoritative store
+
+The `workflow-observation-events` contract SHALL NOT replace gate records as the authoritative store of gate state. Observation events are notifications of state change; a gate record remains the single source of truth for whether a gate is open, resolved, or rejected. Consumers that need authoritative gate state SHALL read the gate record; consumers that need realtime observation MAY rely on the event stream, subject to the at-least-once delivery and idempotency rules.
+
+#### Scenario: Gate record is authoritative
+
+- **WHEN** a consumer needs to know whether a gate is currently open
+- **THEN** it SHALL consult the gate record, not the event stream alone
+- **AND** the event stream SHALL only serve as a notification channel consistent with the record
+
+#### Scenario: Event loss does not corrupt gate state
+
+- **WHEN** an observation event for a gate is lost before consumer receipt
+- **THEN** the gate record SHALL remain correct
+- **AND** subsequent reads of the gate record SHALL produce the same authoritative result

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-observation-events/spec.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-observation-events/spec.md
@@ -1,0 +1,255 @@
+## ADDED Requirements
+
+### Requirement: The workflow core defines the authoritative catalog of observation event kinds
+
+The workflow core SHALL define a closed catalog of `event_kind` values that constitute the observation event contract. Every emitted observation event SHALL set `event_kind` to exactly one value from this catalog; undefined kinds SHALL NOT be emitted.
+
+The catalog SHALL comprise the following four classes:
+
+- **Lifecycle events** (4): `run_started`, `run_suspended`, `run_resumed`, `run_terminal`.
+- **Phase events** (4): `phase_entered`, `phase_completed`, `phase_blocked`, `phase_reopened`.
+- **Gate events** (3): `gate_opened`, `gate_resolved`, `gate_rejected`.
+- **Progress/artifact events** (4): `artifact_written`, `review_completed`, `bundle_started`, `bundle_completed`.
+
+`event_kind` SHALL be a flat string discriminator; the contract SHALL NOT introduce a separate `event_category` field.
+
+#### Scenario: Only catalogued event kinds are emitted
+
+- **WHEN** the workflow core emits an observation event
+- **THEN** `event_kind` SHALL equal one of the fifteen catalog values defined above
+- **AND** any other string value SHALL be treated as a contract violation
+
+#### Scenario: Event kind is the sole discriminator
+
+- **WHEN** a consumer receives an observation event
+- **THEN** it SHALL be able to select the per-event payload schema using `event_kind` alone
+- **AND** the envelope SHALL NOT carry any additional category or type field
+
+### Requirement: The observation event envelope defines the common fields
+
+Every observation event SHALL conform to a common envelope containing the following fields:
+
+- `event_id` — a unique identifier for this event instance. Consumers SHALL use it as the idempotency key.
+- `event_kind` — the discriminator (see event catalog requirement).
+- `run_id` — the run identifier in `<change_id>-<N>` format.
+- `change_id` — the workflow change identifier that the run belongs to.
+- `sequence` — a strictly increasing positive integer within a single `run_id`, starting at 1 for `run_started`.
+- `timestamp` — an ISO 8601 UTC timestamp of when the event was first emitted.
+- `source_phase` — the phase the run was in before the transition this event records; SHALL be set for phase events and for lifecycle events that change phase (`run_started` SHALL set it to `null`; `run_terminal` SHALL set it to the phase preceding termination). SHALL be `null` for progress/artifact events.
+- `target_phase` — the phase the run enters as a result of the transition; same nullability rules as `source_phase`.
+- `causal_context` — either `null` or a single cause reference containing (`kind`, `ref`) where `kind ∈ {user_event, observation_event}` and `ref` is a user event name or a prior `event_id`. Lists of causes SHALL NOT be emitted; only the immediate direct cause is recorded.
+- `gate_ref` — optional reference to a gate record id; SHALL be set for gate events and for phase/lifecycle events directly caused by a gate.
+- `artifact_ref` — optional reference to an artifact path or id; SHALL be set for progress/artifact events that relate to a specific artifact.
+- `bundle_ref` — optional reference to a review bundle id; SHALL be set for `bundle_started`, `bundle_completed`, and for `artifact_written` / `review_completed` that belong to a review bundle.
+
+The envelope SHALL contain no fields outside the list above; extension fields SHALL go into per-event `payload` schemas.
+
+#### Scenario: Lifecycle event envelope
+
+- **WHEN** the core emits a `run_started` event
+- **THEN** `event_id`, `run_id`, `change_id`, `sequence` (equal to `1`), `timestamp`, and `event_kind = "run_started"` SHALL be present
+- **AND** `source_phase` SHALL be `null`
+- **AND** `causal_context` SHALL be `null`
+
+#### Scenario: Phase event envelope
+
+- **WHEN** the core emits a `phase_entered` event
+- **THEN** `source_phase` SHALL equal the previous phase and `target_phase` SHALL equal the entered phase
+- **AND** `causal_context` SHALL reference the immediate trigger (a user event or a prior observation event id)
+
+#### Scenario: Gate event envelope
+
+- **WHEN** the core emits `gate_opened`, `gate_resolved`, or `gate_rejected`
+- **THEN** `gate_ref` SHALL be set to the gate record id
+- **AND** `source_phase` and `target_phase` SHALL reflect the phase surrounding the gate transition, or be `null` if no phase boundary is crossed
+
+#### Scenario: Progress event envelope
+
+- **WHEN** the core emits `artifact_written`
+- **THEN** `artifact_ref` SHALL be set to the artifact path or id
+- **AND** `source_phase` and `target_phase` SHALL be `null`
+- **AND** if the artifact belongs to a review bundle, `bundle_ref` SHALL be set
+
+### Requirement: Per-event payload schemas are fully defined by this spec
+
+For every `event_kind` in the catalog, this spec SHALL enumerate the concrete `payload` fields, nullable envelope fields for that kind, and the allowed outcome/status values. Consumers SHALL be able to interpret every event purely from this spec without reading core implementation.
+
+The per-kind schemas SHALL be:
+
+- **`run_started`**: `payload = { source: { provider, reference }, title }`. Envelope: `source_phase = null`, `target_phase = <initial phase>`, `causal_context = null`.
+- **`run_suspended`**: `payload = { reason: string }`. Envelope: `source_phase = <phase when suspended>`, `target_phase = null`.
+- **`run_resumed`**: `payload = {}`. Envelope: `source_phase = null`, `target_phase = <phase resumed into>`.
+- **`run_terminal`**: `payload = { status: "approved" | "decomposed" | "rejected", reason: string | null }`. Envelope: `source_phase = <last active phase>`, `target_phase = <terminal phase>`.
+- **`phase_entered`**: `payload = { triggered_event: string }`. Envelope requires both `source_phase` and `target_phase`.
+- **`phase_completed`**: `payload = { outcome: "advanced" | "bypassed" }`. Envelope requires both phase fields.
+- **`phase_blocked`**: `payload = { reason: "gate_open" | "await_user" | "await_agent" }`. Envelope requires `source_phase`; `target_phase = null`.
+- **`phase_reopened`**: `payload = { reason: string }`. Envelope requires both phase fields (phase reopened becomes `target_phase`).
+- **`gate_opened`**: `payload = { gate_kind: "approval" | "clarify" | "review_decision" }`. `gate_ref` required.
+- **`gate_resolved`**: `payload = { resolution: "approved" | "answered" | "changes_requested", by_actor: string }`. `gate_ref` required. Mapping: `approval + response="accept"` → `"approved"`; `clarify + response="clarify_response"` → `"answered"`; `review_decision + response="accept"` → `"approved"`; `review_decision + response="request_changes"` → `"changes_requested"`.
+- **`gate_rejected`**: `payload = { resolution: "rejected", by_actor: string, reason: string | null }`. `gate_ref` required. Emitted for `approval + response="reject"` and `review_decision + response="reject"`.
+- **`artifact_written`**: `payload = { path: string, bytes: integer, content_hash: string | null }`. `artifact_ref` required.
+- **`review_completed`**: `payload = { outcome: "approved" | "changes_requested" | "rejected", reviewer: string, score: number | null }`. `artifact_ref` optional; `bundle_ref` SHALL be set when the review belongs to a bundle.
+- **`bundle_started`**: `payload = { bundle_kind: "review_bundle", artifact_count: integer }`. `bundle_ref` required.
+- **`bundle_completed`**: `payload = { bundle_kind: "review_bundle", outcome: "approved" | "changes_requested" | "rejected" }`. `bundle_ref` required.
+
+`bundle_kind` is currently fixed to `"review_bundle"`; no other bundle kinds are in scope.
+
+#### Scenario: Consumer interprets run_terminal from spec alone
+
+- **WHEN** a consumer receives a `run_terminal` event
+- **THEN** it SHALL read `payload.status` and expect exactly one of the three values defined above
+- **AND** it SHALL NOT need to consult core implementation to interpret the value
+
+#### Scenario: Consumer interprets gate_resolved from spec alone
+
+- **WHEN** a consumer receives a `gate_resolved` event
+- **THEN** `payload.resolution` SHALL be one of the values defined for that kind
+- **AND** `gate_ref` SHALL point to a gate previously announced via `gate_opened`
+
+### Requirement: Per-run monotonic ordering is guaranteed
+
+Within a single `run_id`, observation events SHALL be observable in publication order as given by `sequence`. `sequence` SHALL start at 1 for `run_started` and increase strictly monotonically by 1 per newly published event within that run.
+
+Ordering across different `run_id` values SHALL NOT be guaranteed. Consumers MUST NOT assume any cross-run ordering.
+
+#### Scenario: Sequence increases monotonically within a run
+
+- **WHEN** a consumer observes a contiguous slice of events for one `run_id`
+- **THEN** their `sequence` values SHALL form a strictly increasing series 1, 2, 3, …
+
+#### Scenario: Cross-run ordering is not guaranteed
+
+- **WHEN** events for two different runs are observed
+- **THEN** consumers SHALL NOT rely on their relative order across runs
+
+### Requirement: Coupled events follow cause-to-effect order
+
+When a single underlying workflow change produces several related observation events within the same run, the contract SHALL fix the following relative orderings:
+
+- `gate_opened` SHALL precede any `phase_blocked` it causes, which SHALL precede any `run_suspended` it causes.
+- `gate_resolved` or `gate_rejected` SHALL precede any `phase_reopened` or `phase_completed` it causes, which SHALL precede any `run_resumed` it causes.
+- `bundle_started` SHALL precede every `artifact_written` and `review_completed` whose `bundle_ref` matches, which SHALL precede the matching `bundle_completed`.
+
+These orderings SHALL be expressed both through `sequence` (earlier causes have smaller `sequence`) and through `causal_context` (downstream events reference upstream events via `event_id`).
+
+#### Scenario: Gate-induced suspension order
+
+- **WHEN** a gate opens that blocks the current phase and suspends the run
+- **THEN** the emitted events SHALL appear in the order `gate_opened` → `phase_blocked` → `run_suspended`
+- **AND** each later event's `causal_context` SHALL reference the immediately preceding event's `event_id`
+
+#### Scenario: Bundle framing
+
+- **WHEN** a review bundle is processed
+- **THEN** `bundle_started` SHALL be followed by one or more `artifact_written` and `review_completed` events sharing the same `bundle_ref`
+- **AND** `bundle_completed` with the same `bundle_ref` SHALL be the last event for that bundle
+
+### Requirement: At-least-once delivery with consumer-side idempotency
+
+The contract SHALL be at-least-once: after a crash, restart, or transient consumer failure, the workflow core MAY re-emit an event that has already been observed. Consumers SHALL de-duplicate observed events using `event_id` as the idempotency key.
+
+Exactly-once and at-most-once delivery are explicitly NOT part of the contract.
+
+#### Scenario: Duplicate event is idempotent
+
+- **WHEN** a consumer receives a second event whose `event_id` matches an already-processed event
+- **THEN** the consumer SHALL treat it as a duplicate and take no additional action
+
+#### Scenario: Lost event is not guaranteed
+
+- **WHEN** an event is dropped by a consumer's transport before receipt
+- **THEN** the contract SHALL NOT guarantee automatic redelivery beyond the at-least-once guarantee provided by the publisher
+
+### Requirement: Re-emission preserves full envelope and payload bit-identity
+
+On re-emission of an already-published observation event, every envelope and payload field SHALL be bit-identical to the original emission. Specifically, `event_id`, `sequence`, `timestamp`, `event_kind`, `run_id`, `change_id`, `source_phase`, `target_phase`, `causal_context`, `gate_ref`, `artifact_ref`, `bundle_ref`, and `payload` SHALL all be unchanged.
+
+Re-emitted events SHALL differ from new events only in the fact of being observed more than once. `timestamp` SHALL always reflect the original emission time, not the re-emission time.
+
+#### Scenario: Re-emitted event has identical fields
+
+- **WHEN** the core re-emits an event after recovery
+- **THEN** every envelope and payload field SHALL equal the values of the original emission
+- **AND** a consumer comparing the two byte-for-byte SHALL find them identical
+
+#### Scenario: Timestamp is the original emission time
+
+- **WHEN** an event is re-emitted one minute after its original publication
+- **THEN** `timestamp` SHALL reflect the original publication time
+- **AND** SHALL NOT be updated to the re-emission time
+
+### Requirement: causal_context carries zero or one cause
+
+`causal_context` SHALL be either `null` or a single cause reference; it SHALL NOT be a list. Root or system-generated events — notably `run_started` — SHALL set `causal_context` to `null`. For events with multiple logical antecedents, the workflow core SHALL record only the immediate direct cause; reconstructing transitive or multi-parent causation is a consumer responsibility.
+
+#### Scenario: run_started has null causal_context
+
+- **WHEN** the core emits `run_started`
+- **THEN** `causal_context` SHALL be `null`
+
+#### Scenario: Immediate cause is recorded even when multiple antecedents exist
+
+- **WHEN** a `run_suspended` event has both a `phase_blocked` and an external user event as potential antecedents
+- **THEN** `causal_context` SHALL reference exactly one of them — the immediate direct cause
+- **AND** SHALL NOT be expanded into a list
+
+### Requirement: Replay reconstructs the bounded snapshot subset
+
+Replaying the observation event stream for a single `run_id` from `run_started` through the most recent event SHALL reconstruct the following subset of the canonical workflow snapshot:
+
+- `current_phase` — derivable from the latest `phase_entered` / `phase_completed` / `phase_reopened` / `run_terminal` events.
+- `status` — derivable from the latest lifecycle event (e.g., `run_terminal.payload.status`, or `active`/`suspended` from `run_suspended` / `run_resumed`).
+- The set of currently open gates — derivable by tracking `gate_opened` minus `gate_resolved`/`gate_rejected` events grouped by `gate_ref`.
+- The latest pointer (path or id) for each artifact — derivable from the most recent `artifact_written` per `artifact_ref`.
+
+Other snapshot fields — derived metrics, full history lists, timestamps of prior reads, cached local-filesystem metadata — are explicitly outside the replay guarantee.
+
+#### Scenario: Replay yields current_phase and status
+
+- **WHEN** a consumer replays the event stream for a run
+- **THEN** it SHALL produce the same `current_phase` and `status` as the canonical snapshot
+
+#### Scenario: Replay yields open gate set
+
+- **WHEN** a consumer replays the event stream for a run with two gates that were opened and one resolved
+- **THEN** the reconstructed open-gate set SHALL contain exactly the one unresolved gate
+
+#### Scenario: Replay does not cover derived metrics
+
+- **WHEN** a consumer replays the event stream
+- **THEN** it SHALL NOT be expected to reconstruct snapshot fields outside the list above
+- **AND** the contract SHALL NOT be violated when such fields diverge
+
+### Requirement: Event history retrieval is out of scope
+
+The observation-events contract SHALL define replay semantics only — that is, the mathematical relationship between a replayed stream and the reconstructed snapshot. The contract SHALL NOT require the workflow core to persist all events or expose a history-retrieval API. Persistence, transport, and history-retrieval APIs are the responsibility of separate layers and are explicitly non-goal here.
+
+#### Scenario: Core is not required to persist events
+
+- **WHEN** this spec is inspected
+- **THEN** it SHALL NOT require the workflow core to durably store every observation event
+- **AND** it SHALL NOT require a history-retrieval endpoint
+
+#### Scenario: Replay guarantee is conditional on available history
+
+- **WHEN** a consumer or persistence layer has collected the full stream from `run_started`
+- **THEN** replaying that stream SHALL reconstruct the bounded snapshot subset as defined
+- **AND** the guarantee SHALL NOT imply that such a stream is always retrievable
+
+### Requirement: Observation events are disjoint from surface events
+
+The `workflow-observation-events` contract SHALL be disjoint from the `surface-event-contract`. Observation events are declarative notifications of workflow state change emitted by the core; surface events are imperative commands exchanged with external surfaces (approval, reject, clarify, resume).
+
+The two contracts SHALL NOT share an envelope schema. `workflow-observation-events` and `surface-event-contract` SHALL cross-reference each other in their Purpose sections to disambiguate, but neither SHALL depend on or import fields from the other.
+
+#### Scenario: Envelopes are independent
+
+- **WHEN** the two contracts are compared
+- **THEN** each SHALL define its own envelope schema
+- **AND** neither SHALL reuse fields from the other
+
+#### Scenario: Cross-reference only
+
+- **WHEN** either spec is read
+- **THEN** it SHALL reference the other to clarify the distinction between observation and command events
+- **AND** SHALL NOT declare a shared parent schema

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-run-state/spec.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-run-state/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Run-state transitions emit observation events
+
+Every transition of the workflow run-state machine SHALL emit one or more observation events under the `workflow-observation-events` contract. The mapping SHALL be one run-state transition to one or more observation events (1:N); a single transition MAY emit several related events when it simultaneously opens a gate, blocks a phase, and suspends the run.
+
+The following mapping SHALL hold at minimum:
+
+- Creation of a new run SHALL emit `run_started`.
+- Every successful event-driven phase transition SHALL emit `phase_entered` for the target phase and `phase_completed` for the source phase (unless the source is `start`).
+- Transitions that suspend the run SHALL emit `run_suspended`; transitions that resume it SHALL emit `run_resumed`.
+- Entering any terminal state (`approved`, `decomposed`, `rejected`) SHALL emit `run_terminal` whose `payload.status` reflects the terminal state.
+- Transitions that open, resolve, or reject a gate SHALL emit the corresponding `gate_opened` / `gate_resolved` / `gate_rejected` event ahead of any `phase_blocked` / `phase_reopened` they cause.
+
+`artifact_written`, `review_completed`, `bundle_started`, and `bundle_completed` are progress events that SHALL NOT require a matching run-state transition.
+
+#### Scenario: Successful advance emits phase events
+
+- **WHEN** the run advances from `proposal_clarify` to `proposal_challenge`
+- **THEN** the core SHALL emit `phase_completed` for `proposal_clarify` followed by `phase_entered` for `proposal_challenge`
+- **AND** both events SHALL share the same `run_id` with monotonically increasing `sequence`
+
+#### Scenario: Terminal transition emits run_terminal
+
+- **WHEN** the run enters `approved`
+- **THEN** the core SHALL emit `run_terminal` with `payload.status = "approved"`
+- **AND** the emitting order SHALL place `phase_completed` (or the equivalent preceding event) before `run_terminal`
+
+#### Scenario: Progress events are not tied to run-state transitions
+
+- **WHEN** an artifact is written without changing run-state
+- **THEN** the core MAY emit `artifact_written` without emitting any lifecycle or phase event
+
+### Requirement: Observation event stream is consistent with the run-state snapshot
+
+The observation event stream emitted for a `run_id` SHALL remain consistent with the snapshot readable via the run-state CLI at every point in time. Specifically:
+
+- After emitting `phase_entered` for `P`, the run-state snapshot SHALL report `current_phase = P` for any read that logically follows the event.
+- After emitting `run_terminal`, the run-state snapshot SHALL report `status = <terminal>` and `current_phase = <terminal phase>`.
+- The set of open gates reconstructed from `gate_opened` minus `gate_resolved`/`gate_rejected` SHALL match the gates reported by the run-state snapshot.
+- The latest artifact pointers reconstructed from `artifact_written` events SHALL match the artifact pointers reported by the run-state snapshot.
+
+Consumers SHALL be able to rely on this consistency to validate their locally reconstructed view against a fresh snapshot read.
+
+#### Scenario: Snapshot agrees with replayed phase
+
+- **WHEN** a consumer reconstructs `current_phase` by replaying events through the latest observed `sequence`
+- **AND** a fresh run-state snapshot is read at or after that emission
+- **THEN** the two values SHALL be equal
+
+#### Scenario: Open-gate set matches snapshot
+
+- **WHEN** the consumer reconstructs the open-gate set from the event stream
+- **THEN** it SHALL match the set of open gates in the run-state snapshot observed at or after the latest gate event
+
+### Requirement: Run-state CLI does not define the observation transport
+
+The run-state CLI SHALL continue to expose snapshot semantics only. It SHALL NOT define, require, or depend on any specific transport (HTTP, WebSocket, SSE, polling, broker) for observation events; transport selection is explicitly the responsibility of a separate layer. Defining the event contract (via `workflow-observation-events`) SHALL NOT add a transport obligation to the run-state CLI.
+
+#### Scenario: Run-state CLI remains snapshot-only
+
+- **WHEN** the run-state CLI is inspected after this change
+- **THEN** its commands SHALL continue to return snapshots, not streams
+- **AND** it SHALL NOT require any transport-specific plumbing

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/task-graph.json
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/task-graph.json
@@ -1,0 +1,219 @@
+{
+  "version": "1.0",
+  "change_id": "define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation",
+  "bundles": [
+    {
+      "id": "author-workflow-observation-event-contract",
+      "title": "Author Workflow Observation Event Contract",
+      "goal": "Define the transport-agnostic observation-event spec with a fixed catalog, common envelope, payload schemas, and behavioral guarantees.",
+      "depends_on": [],
+      "inputs": [
+        "design.md",
+        "openspec/specs/workflow-run-state/spec.md",
+        "openspec/specs/workflow-gate-semantics/spec.md",
+        "openspec/specs/surface-event-contract/spec.md",
+        "openspec/specs/artifact-ownership-model/spec.md",
+        "openspec/specs/review-orchestration/spec.md"
+      ],
+      "outputs": [
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-observation-events/spec.md"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Translate decisions D1-D9 into a requirement map for lifecycle, phase, gate, and progress observation events.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Define the common envelope fields, nullability rules, and reference semantics for event, phase, gate, artifact, bundle, and causal context data.",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Enumerate the closed 15-event catalog and specify per-event payload schemas with all allowed status and outcome values.",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Add scenarios for per-run ordering, at-least-once delivery, bit-identical re-emission, bounded replay, disjointness from surface events, and coupled cause-to-effect ordering.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "workflow-run-state",
+        "workflow-gate-semantics",
+        "surface-event-contract",
+        "artifact-ownership-model",
+        "review-orchestration"
+      ]
+    },
+    {
+      "id": "bind-run-state-transitions-to-observation-events",
+      "title": "Bind Run-State Transitions To Observation Events",
+      "goal": "Update workflow-run-state so authoritative transitions consistently emit the required observation events without changing snapshot ownership.",
+      "depends_on": [
+        "author-workflow-observation-event-contract"
+      ],
+      "inputs": [
+        "design.md",
+        "openspec/specs/workflow-run-state/spec.md",
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-observation-events/spec.md"
+      ],
+      "outputs": [
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-run-state/spec.md"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Map run-state transitions to the lifecycle and phase observation events they must emit, including explicit 1:N transition-to-event cases.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Add delta requirements that bind transition emission and snapshot consistency to the new observation contract while preserving canonical run-state authority.",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "State that the run-state CLI remains snapshot-only and carries no transport or history-serving responsibility.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "workflow-run-state",
+        "canonical-workflow-state",
+        "phase-semantics"
+      ]
+    },
+    {
+      "id": "bind-gate-semantics-to-observation-events",
+      "title": "Bind Gate Semantics To Observation Events",
+      "goal": "Update workflow-gate-semantics so gate lifecycle changes emit ordered observation events while gate records remain authoritative.",
+      "depends_on": [
+        "author-workflow-observation-event-contract"
+      ],
+      "inputs": [
+        "design.md",
+        "openspec/specs/workflow-gate-semantics/spec.md",
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-observation-events/spec.md"
+      ],
+      "outputs": [
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-gate-semantics/spec.md"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Map gate open, resolve, and reject lifecycle changes to the corresponding observation events and single-terminal-per-gate rules.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Add ordering requirements that gate events are emitted before any phase or lifecycle effects they directly cause.",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Reinforce that gate records stay authoritative and observation events are notification-side effects only.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "workflow-gate-semantics",
+        "approval-clarify-persistence",
+        "phase-semantics"
+      ]
+    },
+    {
+      "id": "validate-observation-event-cross-spec-consistency",
+      "title": "Validate Observation Event Cross-Spec Consistency",
+      "goal": "Prove the three spec deltas agree on names, ordering, replay, and transition-to-event pairings and pass change validation.",
+      "depends_on": [
+        "bind-run-state-transitions-to-observation-events",
+        "bind-gate-semantics-to-observation-events"
+      ],
+      "inputs": [
+        "design.md",
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-observation-events/spec.md",
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-run-state/spec.md",
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-gate-semantics/spec.md",
+        "openspec/specs/spec-consistency-verification/spec.md"
+      ],
+      "outputs": [
+        "validation: openspec validate --type change",
+        "traceability: concern-to-requirement checklist"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Cross-check event names, envelope rules, causal context semantics, replay subset, and coupled ordering language across all three delta files.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Verify every completion condition from C-obs-catalog through C-coupled-order is covered by explicit requirements and scenarios.",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Run openspec change validation and resolve any schema, naming, or traceability failures until the change passes cleanly.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "spec-consistency-verification",
+        "workflow-run-state",
+        "workflow-gate-semantics"
+      ]
+    },
+    {
+      "id": "prepare-review-and-archive-package",
+      "title": "Prepare Review And Archive Package",
+      "goal": "Package the validated spec-only change for review, archive, and downstream consumer announcement.",
+      "depends_on": [
+        "validate-observation-event-cross-spec-consistency"
+      ],
+      "inputs": [
+        "design.md",
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-observation-events/spec.md",
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-run-state/spec.md",
+        "openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/specs/workflow-gate-semantics/spec.md",
+        "validation: openspec validate --type change",
+        "traceability: concern-to-requirement checklist"
+      ],
+      "outputs": [
+        "archive-ready change review package",
+        "downstream observation-event announcement notes"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Prepare review notes summarizing scope, non-goals, authoritative boundaries, and the reasons the contract stays transport-agnostic.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Confirm the archive package includes all three deltas together and documents that no runtime migration or data migration is required.",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Draft downstream handoff notes for future transport, publisher, consumer, and spec-consistency follow-up changes.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "design-planning-contract",
+        "contract-driven-distribution",
+        "task-planner"
+      ]
+    }
+  ],
+  "generated_at": "2026-04-19T02:29:55.595Z",
+  "generated_from": "design.md"
+}

--- a/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/tasks.md
+++ b/openspec/changes/define-workflow-event-semantics-for-state-change-gate-resolution-and-progress-observation/tasks.md
@@ -1,0 +1,48 @@
+## 1. Author Workflow Observation Event Contract ✓
+
+> Define the transport-agnostic observation-event spec with a fixed catalog, common envelope, payload schemas, and behavioral guarantees.
+
+- [x] 1.1 Translate decisions D1-D9 into a requirement map for lifecycle, phase, gate, and progress observation events.
+- [x] 1.2 Define the common envelope fields, nullability rules, and reference semantics for event, phase, gate, artifact, bundle, and causal context data.
+- [x] 1.3 Enumerate the closed 15-event catalog and specify per-event payload schemas with all allowed status and outcome values.
+- [x] 1.4 Add scenarios for per-run ordering, at-least-once delivery, bit-identical re-emission, bounded replay, disjointness from surface events, and coupled cause-to-effect ordering.
+
+## 2. Bind Run-State Transitions To Observation Events ✓
+
+> Update workflow-run-state so authoritative transitions consistently emit the required observation events without changing snapshot ownership.
+
+> Depends on: author-workflow-observation-event-contract
+
+- [x] 2.1 Map run-state transitions to the lifecycle and phase observation events they must emit, including explicit 1:N transition-to-event cases.
+- [x] 2.2 Add delta requirements that bind transition emission and snapshot consistency to the new observation contract while preserving canonical run-state authority.
+- [x] 2.3 State that the run-state CLI remains snapshot-only and carries no transport or history-serving responsibility.
+
+## 3. Bind Gate Semantics To Observation Events ✓
+
+> Update workflow-gate-semantics so gate lifecycle changes emit ordered observation events while gate records remain authoritative.
+
+> Depends on: author-workflow-observation-event-contract
+
+- [x] 3.1 Map gate open, resolve, and reject lifecycle changes to the corresponding observation events and single-terminal-per-gate rules.
+- [x] 3.2 Add ordering requirements that gate events are emitted before any phase or lifecycle effects they directly cause.
+- [x] 3.3 Reinforce that gate records stay authoritative and observation events are notification-side effects only.
+
+## 4. Validate Observation Event Cross-Spec Consistency ✓
+
+> Prove the three spec deltas agree on names, ordering, replay, and transition-to-event pairings and pass change validation.
+
+> Depends on: bind-run-state-transitions-to-observation-events, bind-gate-semantics-to-observation-events
+
+- [x] 4.1 Cross-check event names, envelope rules, causal context semantics, replay subset, and coupled ordering language across all three delta files.
+- [x] 4.2 Verify every completion condition from C-obs-catalog through C-coupled-order is covered by explicit requirements and scenarios.
+- [x] 4.3 Run openspec change validation and resolve any schema, naming, or traceability failures until the change passes cleanly.
+
+## 5. Prepare Review And Archive Package ✓
+
+> Package the validated spec-only change for review, archive, and downstream consumer announcement.
+
+> Depends on: validate-observation-event-cross-spec-consistency
+
+- [x] 5.1 Prepare review notes summarizing scope, non-goals, authoritative boundaries, and the reasons the contract stays transport-agnostic.
+- [x] 5.2 Confirm the archive package includes all three deltas together and documents that no runtime migration or data migration is required.
+- [x] 5.3 Draft downstream handoff notes for future transport, publisher, consumer, and spec-consistency follow-up changes.

--- a/openspec/specs/surface-event-contract/spec.md
+++ b/openspec/specs/surface-event-contract/spec.md
@@ -2,6 +2,9 @@
 
 ## Purpose
 TBD - created by archiving change define-surface-event-contract-for-external-runtimes. Update Purpose after archive.
+
+Related specs:
+- `workflow-observation-events`: observation events are declarative notifications of state change emitted by the workflow core; surface events (defined here) are imperative commands to/from external surfaces. The two contracts are disjoint — they do not share an envelope schema. Each cross-references the other to disambiguate.
 ## Requirements
 ### Requirement: Surface event envelope defines the standard message wrapper
 

--- a/openspec/specs/workflow-gate-semantics/spec.md
+++ b/openspec/specs/workflow-gate-semantics/spec.md
@@ -2,6 +2,10 @@
 
 ## Purpose
 TBD - created by archiving change define-gate-semantics-for-approval-clarify-and-review-decisions-as-persistent-workflow-objects. Update Purpose after archive.
+
+Related specs:
+- `workflow-observation-events`: gate state changes (opening, resolution, rejection) emit `gate_opened`, `gate_resolved`, `gate_rejected` observation events. Gate records remain the authoritative store; observation events are notifications.
+
 ## Requirements
 ### Requirement: Gate is a first-class persistent workflow object
 

--- a/openspec/specs/workflow-observation-events/spec.md
+++ b/openspec/specs/workflow-observation-events/spec.md
@@ -1,0 +1,298 @@
+# workflow-observation-events Specification
+
+## Purpose
+
+Define the authoritative contract for observation events emitted by the workflow core on state change, gate resolution, and progress. Observation events are declarative notifications of workflow state change; they are disjoint from the imperative surface-event commands defined in `surface-event-contract`. The contract covers the closed event catalog (lifecycle, phase, gate, progress/artifact), the common envelope fields, per-event payload schemas, publisher obligations, ordering guarantees, delivery semantics, and the relationship between the event stream and the snapshot state.
+
+Related specs:
+- `workflow-run-state`: every run-state transition SHALL emit corresponding observation events.
+- `workflow-gate-semantics`: gate opening, resolution, and rejection SHALL emit `gate_opened`, `gate_resolved`, `gate_rejected`.
+- `surface-event-contract`: disjoint from this contract; cross-referenced for disambiguation only.
+
+## Requirements
+### Requirement: The workflow core defines the authoritative catalog of observation event kinds
+
+The workflow core SHALL define a closed catalog of `event_kind` values that constitute the observation event contract. Every emitted observation event SHALL set `event_kind` to exactly one value from this catalog; undefined kinds SHALL NOT be emitted.
+
+The catalog SHALL comprise the following four classes:
+
+- **Lifecycle events** (4): `run_started`, `run_suspended`, `run_resumed`, `run_terminal`.
+- **Phase events** (4): `phase_entered`, `phase_completed`, `phase_blocked`, `phase_reopened`.
+- **Gate events** (3): `gate_opened`, `gate_resolved`, `gate_rejected`.
+- **Progress/artifact events** (4): `artifact_written`, `review_completed`, `bundle_started`, `bundle_completed`.
+
+`event_kind` SHALL be a flat string discriminator; the contract SHALL NOT introduce a separate `event_category` field.
+
+#### Scenario: Only catalogued event kinds are emitted
+
+- **WHEN** the workflow core emits an observation event
+- **THEN** `event_kind` SHALL equal one of the fifteen catalog values defined above
+- **AND** any other string value SHALL be treated as a contract violation
+
+#### Scenario: Event kind is the sole discriminator
+
+- **WHEN** a consumer receives an observation event
+- **THEN** it SHALL be able to select the per-event payload schema using `event_kind` alone
+- **AND** the envelope SHALL NOT carry any additional category or type field
+
+### Requirement: The observation event envelope defines the common fields
+
+Every observation event SHALL conform to a common envelope containing the following fields:
+
+- `event_id` — a unique identifier for this event instance. Consumers SHALL use it as the idempotency key.
+- `event_kind` — the discriminator (see event catalog requirement).
+- `run_id` — the run identifier in `<change_id>-<N>` format.
+- `change_id` — the workflow change identifier that the run belongs to.
+- `sequence` — a strictly increasing positive integer within a single `run_id`, starting at 1 for `run_started`.
+- `timestamp` — an ISO 8601 UTC timestamp of when the event was first emitted.
+- `source_phase` — the phase the run was in before the transition this event records; SHALL be set for phase events and for lifecycle events that change phase (`run_started` SHALL set it to `null`; `run_terminal` SHALL set it to the phase preceding termination). SHALL be `null` for progress/artifact events.
+- `target_phase` — the phase the run enters as a result of the transition; same nullability rules as `source_phase`.
+- `causal_context` — either `null` or a single cause reference containing (`kind`, `ref`) where `kind ∈ {user_event, observation_event}` and `ref` is a user event name or a prior `event_id`. Lists of causes SHALL NOT be emitted; only the immediate direct cause is recorded.
+- `gate_ref` — optional reference to a gate record id; SHALL be set for gate events and for phase/lifecycle events directly caused by a gate.
+- `artifact_ref` — optional reference to an artifact path or id; SHALL be set for progress/artifact events that relate to a specific artifact.
+- `bundle_ref` — optional reference to a review bundle id; SHALL be set for `bundle_started`, `bundle_completed`, and for `artifact_written` / `review_completed` that belong to a review bundle.
+
+The envelope SHALL contain no fields outside the list above; extension fields SHALL go into per-event `payload` schemas.
+
+#### Scenario: Lifecycle event envelope
+
+- **WHEN** the core emits a `run_started` event
+- **THEN** `event_id`, `run_id`, `change_id`, `sequence` (equal to `1`), `timestamp`, and `event_kind = "run_started"` SHALL be present
+- **AND** `source_phase` SHALL be `null`
+- **AND** `causal_context` SHALL be `null`
+
+#### Scenario: Phase event envelope
+
+- **WHEN** the core emits a `phase_entered` event
+- **THEN** `source_phase` SHALL equal the previous phase and `target_phase` SHALL equal the entered phase
+- **AND** `causal_context` SHALL reference the immediate trigger (a user event or a prior observation event id)
+
+#### Scenario: Gate event envelope
+
+- **WHEN** the core emits `gate_opened`, `gate_resolved`, or `gate_rejected`
+- **THEN** `gate_ref` SHALL be set to the gate record id
+- **AND** `source_phase` and `target_phase` SHALL reflect the phase surrounding the gate transition, or be `null` if no phase boundary is crossed
+
+#### Scenario: Progress event envelope
+
+- **WHEN** the core emits `artifact_written`
+- **THEN** `artifact_ref` SHALL be set to the artifact path or id
+- **AND** `source_phase` and `target_phase` SHALL be `null`
+- **AND** if the artifact belongs to a review bundle, `bundle_ref` SHALL be set
+
+### Requirement: Per-event payload schemas are fully defined by this spec
+
+For every `event_kind` in the catalog, this spec SHALL enumerate the concrete `payload` fields, nullable envelope fields for that kind, and the allowed outcome/status values. Consumers SHALL be able to interpret every event purely from this spec without reading core implementation.
+
+The per-kind schemas SHALL be:
+
+- **`run_started`**: `payload = { source: { provider, reference }, title }`. Envelope: `source_phase = null`, `target_phase = <initial phase>`, `causal_context = null`.
+- **`run_suspended`**: `payload = { reason: string }`. Envelope: `source_phase = <phase when suspended>`, `target_phase = null`.
+- **`run_resumed`**: `payload = {}`. Envelope: `source_phase = null`, `target_phase = <phase resumed into>`.
+- **`run_terminal`**: `payload = { status: "approved" | "decomposed" | "rejected", reason: string | null }`. Envelope: `source_phase = <last active phase>`, `target_phase = <terminal phase>`.
+- **`phase_entered`**: `payload = { triggered_event: string }`. Envelope requires both `source_phase` and `target_phase`.
+- **`phase_completed`**: `payload = { outcome: "advanced" | "bypassed" }`. Envelope requires both phase fields.
+- **`phase_blocked`**: `payload = { reason: "gate_open" | "await_user" | "await_agent" }`. Envelope requires `source_phase`; `target_phase = null`.
+- **`phase_reopened`**: `payload = { reason: string }`. Envelope requires both phase fields (phase reopened becomes `target_phase`).
+- **`gate_opened`**: `payload = { gate_kind: "approval" | "clarify" | "review_decision" }`. `gate_ref` required.
+- **`gate_resolved`**: `payload = { resolution: "approved" | "answered" | "changes_requested", by_actor: string }`. `gate_ref` required. Mapping: `approval + response="accept"` → `"approved"`; `clarify + response="clarify_response"` → `"answered"`; `review_decision + response="accept"` → `"approved"`; `review_decision + response="request_changes"` → `"changes_requested"`.
+- **`gate_rejected`**: `payload = { resolution: "rejected", by_actor: string, reason: string | null }`. `gate_ref` required. Emitted for `approval + response="reject"` and `review_decision + response="reject"`.
+- **`artifact_written`**: `payload = { path: string, bytes: integer, content_hash: string | null }`. `artifact_ref` required.
+- **`review_completed`**: `payload = { outcome: "approved" | "changes_requested" | "rejected", reviewer: string, score: number | null }`. `artifact_ref` optional; `bundle_ref` SHALL be set when the review belongs to a bundle.
+- **`bundle_started`**: `payload = { bundle_kind: "review_bundle", artifact_count: integer }`. `bundle_ref` required.
+- **`bundle_completed`**: `payload = { bundle_kind: "review_bundle", outcome: "approved" | "changes_requested" | "rejected" }`. `bundle_ref` required.
+
+`bundle_kind` is currently fixed to `"review_bundle"`; no other bundle kinds are in scope.
+
+#### Scenario: Consumer interprets run_terminal from spec alone
+
+- **WHEN** a consumer receives a `run_terminal` event
+- **THEN** it SHALL read `payload.status` and expect exactly one of the three values defined above
+- **AND** it SHALL NOT need to consult core implementation to interpret the value
+
+#### Scenario: Consumer interprets gate_resolved from spec alone
+
+- **WHEN** a consumer receives a `gate_resolved` event
+- **THEN** `payload.resolution` SHALL be one of the values defined for that kind
+- **AND** `gate_ref` SHALL point to a gate previously announced via `gate_opened`
+
+### Requirement: Per-run monotonic ordering is guaranteed
+
+Within a single `run_id`, observation events SHALL be observable in publication order as given by `sequence`. `sequence` SHALL start at 1 for `run_started` and increase strictly monotonically by 1 per newly published event within that run.
+
+Ordering across different `run_id` values SHALL NOT be guaranteed. Consumers MUST NOT assume any cross-run ordering.
+
+#### Scenario: Sequence increases monotonically within a run
+
+- **WHEN** a consumer observes a contiguous slice of events for one `run_id`
+- **THEN** their `sequence` values SHALL form a strictly increasing series 1, 2, 3, …
+
+#### Scenario: Cross-run ordering is not guaranteed
+
+- **WHEN** events for two different runs are observed
+- **THEN** consumers SHALL NOT rely on their relative order across runs
+
+### Requirement: Coupled events follow cause-to-effect order
+
+When a single underlying workflow change produces several related observation events within the same run, the contract SHALL fix the following relative orderings:
+
+- `gate_opened` SHALL precede any `phase_blocked` it causes, which SHALL precede any `run_suspended` it causes.
+- `gate_resolved` or `gate_rejected` SHALL precede any `phase_reopened` or `phase_completed` it causes, which SHALL precede any `run_resumed` it causes.
+- `bundle_started` SHALL precede every `artifact_written` and `review_completed` whose `bundle_ref` matches, which SHALL precede the matching `bundle_completed`.
+
+These orderings SHALL be expressed both through `sequence` (earlier causes have smaller `sequence`) and through `causal_context` (downstream events reference upstream events via `event_id`).
+
+#### Scenario: Gate-induced suspension order
+
+- **WHEN** a gate opens that blocks the current phase and suspends the run
+- **THEN** the emitted events SHALL appear in the order `gate_opened` → `phase_blocked` → `run_suspended`
+- **AND** each later event's `causal_context` SHALL reference the immediately preceding event's `event_id`
+
+#### Scenario: Bundle framing
+
+- **WHEN** a review bundle is processed
+- **THEN** `bundle_started` SHALL be followed by one or more `artifact_written` and `review_completed` events sharing the same `bundle_ref`
+- **AND** `bundle_completed` with the same `bundle_ref` SHALL be the last event for that bundle
+
+### Requirement: At-least-once delivery with consumer-side idempotency
+
+The contract SHALL be at-least-once: after a crash, restart, or transient consumer failure, the workflow core MAY re-emit an event that has already been observed. Consumers SHALL de-duplicate observed events using `event_id` as the idempotency key.
+
+Exactly-once and at-most-once delivery are explicitly NOT part of the contract.
+
+#### Scenario: Duplicate event is idempotent
+
+- **WHEN** a consumer receives a second event whose `event_id` matches an already-processed event
+- **THEN** the consumer SHALL treat it as a duplicate and take no additional action
+
+#### Scenario: Lost event is not guaranteed
+
+- **WHEN** an event is dropped by a consumer's transport before receipt
+- **THEN** the contract SHALL NOT guarantee automatic redelivery beyond the at-least-once guarantee provided by the publisher
+
+### Requirement: Re-emission preserves full envelope and payload bit-identity
+
+On re-emission of an already-published observation event, every envelope and payload field SHALL be bit-identical to the original emission. Specifically, `event_id`, `sequence`, `timestamp`, `event_kind`, `run_id`, `change_id`, `source_phase`, `target_phase`, `causal_context`, `gate_ref`, `artifact_ref`, `bundle_ref`, and `payload` SHALL all be unchanged.
+
+Re-emitted events SHALL differ from new events only in the fact of being observed more than once. `timestamp` SHALL always reflect the original emission time, not the re-emission time.
+
+#### Scenario: Re-emitted event has identical fields
+
+- **WHEN** the core re-emits an event after recovery
+- **THEN** every envelope and payload field SHALL equal the values of the original emission
+- **AND** a consumer comparing the two byte-for-byte SHALL find them identical
+
+#### Scenario: Timestamp is the original emission time
+
+- **WHEN** an event is re-emitted one minute after its original publication
+- **THEN** `timestamp` SHALL reflect the original publication time
+- **AND** SHALL NOT be updated to the re-emission time
+
+### Requirement: causal_context carries zero or one cause
+
+`causal_context` SHALL be either `null` or a single cause reference; it SHALL NOT be a list. Root or system-generated events — notably `run_started` — SHALL set `causal_context` to `null`. For events with multiple logical antecedents, the workflow core SHALL record only the immediate direct cause; reconstructing transitive or multi-parent causation is a consumer responsibility.
+
+#### Scenario: run_started has null causal_context
+
+- **WHEN** the core emits `run_started`
+- **THEN** `causal_context` SHALL be `null`
+
+#### Scenario: Immediate cause is recorded even when multiple antecedents exist
+
+- **WHEN** a `run_suspended` event has both a `phase_blocked` and an external user event as potential antecedents
+- **THEN** `causal_context` SHALL reference exactly one of them — the immediate direct cause
+- **AND** SHALL NOT be expanded into a list
+
+### Requirement: Replay reconstructs the bounded snapshot subset
+
+Replaying the observation event stream for a single `run_id` from `run_started` through the most recent event SHALL reconstruct the following subset of the canonical workflow snapshot:
+
+- `current_phase` — derivable from the latest `phase_entered` / `phase_completed` / `phase_reopened` / `run_terminal` events.
+- `status` — derivable from the latest lifecycle event (e.g., `run_terminal.payload.status`, or `active`/`suspended` from `run_suspended` / `run_resumed`).
+- The set of currently open gates — derivable by tracking `gate_opened` minus `gate_resolved`/`gate_rejected` events grouped by `gate_ref`.
+- The latest pointer (path or id) for each artifact — derivable from the most recent `artifact_written` per `artifact_ref`.
+
+Other snapshot fields — derived metrics, full history lists, timestamps of prior reads, cached local-filesystem metadata — are explicitly outside the replay guarantee.
+
+#### Scenario: Replay yields current_phase and status
+
+- **WHEN** a consumer replays the event stream for a run
+- **THEN** it SHALL produce the same `current_phase` and `status` as the canonical snapshot
+
+#### Scenario: Replay yields open gate set
+
+- **WHEN** a consumer replays the event stream for a run with two gates that were opened and one resolved
+- **THEN** the reconstructed open-gate set SHALL contain exactly the one unresolved gate
+
+#### Scenario: Replay does not cover derived metrics
+
+- **WHEN** a consumer replays the event stream
+- **THEN** it SHALL NOT be expected to reconstruct snapshot fields outside the list above
+- **AND** the contract SHALL NOT be violated when such fields diverge
+
+### Requirement: Event history retrieval is out of scope
+
+The observation-events contract SHALL define replay semantics only — that is, the mathematical relationship between a replayed stream and the reconstructed snapshot. The contract SHALL NOT require the workflow core to persist all events or expose a history-retrieval API. Persistence, transport, and history-retrieval APIs are the responsibility of separate layers and are explicitly non-goal here.
+
+#### Scenario: Core is not required to persist events
+
+- **WHEN** this spec is inspected
+- **THEN** it SHALL NOT require the workflow core to durably store every observation event
+- **AND** it SHALL NOT require a history-retrieval endpoint
+
+#### Scenario: Replay guarantee is conditional on available history
+
+- **WHEN** a consumer or persistence layer has collected the full stream from `run_started`
+- **THEN** replaying that stream SHALL reconstruct the bounded snapshot subset as defined
+- **AND** the guarantee SHALL NOT imply that such a stream is always retrievable
+
+### Requirement: Observation events are disjoint from surface events
+
+The `workflow-observation-events` contract SHALL be disjoint from the `surface-event-contract`. Observation events are declarative notifications of workflow state change emitted by the core; surface events are imperative commands exchanged with external surfaces (approval, reject, clarify, resume).
+
+The two contracts SHALL NOT share an envelope schema. `workflow-observation-events` and `surface-event-contract` SHALL cross-reference each other in their Purpose sections to disambiguate, but neither SHALL depend on or import fields from the other.
+
+#### Scenario: Envelopes are independent
+
+- **WHEN** the two contracts are compared
+- **THEN** each SHALL define its own envelope schema
+- **AND** neither SHALL reuse fields from the other
+
+#### Scenario: Cross-reference only
+
+- **WHEN** either spec is read
+- **THEN** it SHALL reference the other to clarify the distinction between observation and command events
+- **AND** SHALL NOT declare a shared parent schema
+
+### Requirement: Observation event emission follows the authoritative commit boundary
+
+Observation events SHALL be emitted only **after** the authoritative state writes (snapshot persistence and gate record mutations) have succeeded. The event log SHALL NOT record a transition whose authoritative state commit failed.
+
+If observation event emission fails after the authoritative writes succeed, the process SHALL signal the partial failure via exit code 2 so that callers can detect the incomplete event log and trigger reconciliation. The authoritative state (snapshot + gate records) remains the source of truth; the event log is a derived notification stream.
+
+#### Scenario: Events are emitted after authoritative writes
+
+- **WHEN** the CLI persists a state transition and emits observation events
+- **THEN** the authoritative snapshot and gate records SHALL be written first
+- **AND** observation events SHALL be emitted only after those writes succeed
+
+#### Scenario: Emission failure signals exit code 2
+
+- **WHEN** the authoritative writes succeed but observation event emission fails
+- **THEN** the CLI SHALL exit with code 2
+- **AND** the authoritative state SHALL remain committed
+- **AND** callers SHALL be able to detect the incomplete event log via the exit code
+
+### Requirement: All gate kinds emit observation events
+
+Every gate kind defined in `workflow-gate-semantics` — `approval`, `clarify`, and `review_decision` — SHALL emit `gate_opened` on creation, `gate_resolved` on successful resolution, and `gate_rejected` on rejection. Gate observation events SHALL carry `gate_ref` set to the gate record id.
+
+For `review_decision` gates specifically:
+- `gate_opened` SHALL be emitted by the review CLI (specflow-review-design, specflow-review-apply, specflow-challenge-proposal) immediately after the authoritative gate record is written.
+- `gate_resolved` and `gate_rejected` SHALL be emitted by `specflow-run advance` when the gate is resolved via the gate runtime, with `payload.resolution` mapped as: `accept` → `"approved"`, `request_changes` → `"changes_requested"`, `reject` → `"rejected"`.
+
+#### Scenario: review_decision gate lifecycle produces observation events
+
+- **WHEN** a review CLI issues a `review_decision` gate
+- **THEN** a `gate_opened` event SHALL appear in events.jsonl with `payload.gate_kind = "review_decision"`
+- **AND** when the gate is later resolved via `specflow-run advance`, a `gate_resolved` or `gate_rejected` event SHALL appear with the correct resolution mapping

--- a/openspec/specs/workflow-run-state/spec.md
+++ b/openspec/specs/workflow-run-state/spec.md
@@ -4,6 +4,11 @@
 
 Describe the authoritative workflow state machine and the persisted run-state
 CLI used by `specflow`.
+
+Related specs:
+- `workflow-observation-events`: every run-state transition emits corresponding observation events; the event stream remains consistent with the snapshot readable via the run-state CLI.
+- `workflow-gate-semantics`: gate lifecycle events are part of the observation stream.
+
 ## Requirements
 ### Requirement: The workflow machine defines the authoritative phase graph
 

--- a/src/bin/specflow-challenge-proposal.ts
+++ b/src/bin/specflow-challenge-proposal.ts
@@ -1,8 +1,11 @@
+import { resolve } from "node:path";
 import type { ChangeArtifactStore } from "../lib/artifact-store.js";
 import { tryGit } from "../lib/git.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
 import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import { withLockedPublisher } from "../lib/local-fs-observation-event-publisher.js";
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
+import { emitGateOpened } from "../lib/observation-event-emitter.js";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
 import {
 	issueReviewDecisionGate,
@@ -154,11 +157,19 @@ function parseRunIdFlag(args: readonly string[]): string | undefined {
 
 /**
  * Issue a review_decision gate for a completed proposal challenge round.
- * Best-effort: returns null on failure.
+ *
+ * Gate issuance failure is a hard error — the spec requires exactly one
+ * `review_decision` gate per completed review round. Callers MUST NOT
+ * proceed with a successful challenge result when this function throws.
+ *
+ * The `gate_opened` event is emitted inside the event-log lock only after
+ * re-reading the gate to confirm it is still `pending`, preventing emission
+ * for a gate that was superseded by a concurrent review process.
  */
-function tryIssueChallengeGate(
+function issueChallengeGateOrFail(
 	projectRoot: string,
 	runId: string,
+	changeId: string,
 	challenges: readonly {
 		id: string;
 		category: string;
@@ -166,48 +177,59 @@ function tryIssueChallengeGate(
 		context: string;
 	}[],
 	reviewAgent: ReviewAgentName,
-): string | null {
-	try {
-		const store = createLocalFsGateRecordStore(projectRoot);
-		// Derive the next round number from existing proposal_challenge gates
-		// so re-running the challenge CLI creates distinct gates per round.
-		const existingGates = store.list(runId);
-		const challengeRound =
-			existingGates.filter(
-				(g) =>
-					g.gate_kind === "review_decision" &&
-					g.originating_phase === "proposal_challenge",
-			).length + 1;
-		const gateId = `review_decision-${runId}-challenge-${challengeRound}`;
-		const findings: ReviewFindingSnapshot[] = challenges.map((c) => ({
-			id: c.id,
-			severity: "medium" as const,
-			status: "new",
-			title: c.question,
-		}));
-		const provenance: ReviewRoundProvenance = {
-			run_id: runId,
-			review_phase: "proposal_challenge",
-			review_round_id: `proposal_challenge-round-${challengeRound}`,
-			findings,
-			reviewer_actor: "ai-agent",
-			reviewer_actor_id: reviewAgent,
-			approval_binding: "advisory",
-		};
-		const gate = issueReviewDecisionGate(provenance, {
-			store,
-			projectRoot,
-			gateId,
-			createdAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
-		});
-		return gate.gate_id;
-	} catch (cause) {
-		const message = cause instanceof Error ? cause.message : String(cause);
-		process.stderr.write(
-			`Warning: failed to issue review_decision gate: ${message}\n`,
-		);
-		return null;
-	}
+): string {
+	const store = createLocalFsGateRecordStore(projectRoot);
+	// Derive the next round number from existing proposal_challenge gates
+	// so re-running the challenge CLI creates distinct gates per round.
+	const existingGates = store.list(runId);
+	const challengeRound =
+		existingGates.filter(
+			(g) =>
+				g.gate_kind === "review_decision" &&
+				g.originating_phase === "proposal_challenge",
+		).length + 1;
+	const gateId = `review_decision-${runId}-challenge-${challengeRound}`;
+	const createdAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+	const findings: ReviewFindingSnapshot[] = challenges.map((c) => ({
+		id: c.id,
+		severity: "medium" as const,
+		status: "new",
+		title: c.question,
+	}));
+	const provenance: ReviewRoundProvenance = {
+		run_id: runId,
+		review_phase: "proposal_challenge",
+		review_round_id: `proposal_challenge-round-${challengeRound}`,
+		findings,
+		reviewer_actor: "ai-agent",
+		reviewer_actor_id: reviewAgent,
+		approval_binding: "advisory",
+	};
+	const gate = issueReviewDecisionGate(provenance, {
+		store,
+		projectRoot,
+		gateId,
+		createdAt,
+	});
+	// Emit gate_opened under the event-log lock, re-reading the gate to
+	// confirm it hasn't been superseded by a concurrent process (R5-F09).
+	const runsRoot = resolve(projectRoot, ".specflow/runs");
+	withLockedPublisher(runsRoot, runId, (publisher) => {
+		const current = store.read(runId, gate.gate_id);
+		if (current && current.status === "pending") {
+			emitGateOpened({
+				publisher,
+				runId,
+				changeId,
+				gateId: gate.gate_id,
+				gateKind: "review_decision",
+				originatingPhase: "proposal_challenge",
+				timestamp: createdAt,
+				highestSequence: publisher.highestSequence(),
+			});
+		}
+	});
+	return gate.gate_id;
 }
 
 async function main(): Promise<void> {
@@ -253,9 +275,10 @@ async function main(): Promise<void> {
 	// challenge succeeded with actual challenges.
 	let gateId: string | null = null;
 	if (runId && result.status === "success" && result.challenges.length > 0) {
-		gateId = tryIssueChallengeGate(
+		gateId = issueChallengeGateOrFail(
 			projectRoot,
 			runId,
+			changeId,
 			result.challenges,
 			agent,
 		);

--- a/src/bin/specflow-review-apply.ts
+++ b/src/bin/specflow-review-apply.ts
@@ -3,8 +3,10 @@ import type { ChangeArtifactStore } from "../lib/artifact-store.js";
 import { ReviewLedgerKind } from "../lib/artifact-types.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
 import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import { withLockedPublisher } from "../lib/local-fs-observation-event-publisher.js";
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { createLocalWorkspaceContext } from "../lib/local-workspace-context.js";
+import { emitGateOpened } from "../lib/observation-event-emitter.js";
 import { moduleRepoRoot, printSchemaJson, tryExec } from "../lib/process.js";
 import {
 	issueReviewDecisionGate,
@@ -401,9 +403,10 @@ async function runReviewPipeline(
 	// Issue a review_decision gate if a run_id was provided.
 	let gateId: string | null = null;
 	if (runId && !parseError) {
-		gateId = tryIssueReviewDecisionGate(
+		gateId = issueReviewDecisionGateOrFail(
 			projectRoot,
 			runId,
+			changeId,
 			"apply_review",
 			ledger,
 			reviewAgent,
@@ -822,54 +825,73 @@ function parseRunIdFlag(args: readonly string[]): string | undefined {
 
 /**
  * Issue a review_decision gate for a completed apply review round.
- * Best-effort: returns null on failure.
+ *
+ * Gate issuance failure is a hard error — the spec requires exactly one
+ * `review_decision` gate per completed review round. Callers MUST NOT
+ * proceed with a successful review result when this function throws.
+ *
+ * The `gate_opened` event is emitted inside the event-log lock only after
+ * re-reading the gate to confirm it is still `pending`, preventing emission
+ * for a gate that was superseded by a concurrent review process.
  */
-function tryIssueReviewDecisionGate(
+function issueReviewDecisionGateOrFail(
 	projectRoot: string,
 	runId: string,
+	changeId: string,
 	reviewPhase: ReviewPhase,
 	ledger: ReviewLedger,
 	reviewAgent: ReviewAgentName,
-): string | null {
-	try {
-		const store = createLocalFsGateRecordStore(projectRoot);
-		const round = Number(ledger.current_round ?? 0);
-		const roundId = `${reviewPhase}-round-${round}`;
-		const gateId = `review_decision-${runId}-${reviewPhase}-${round}`;
-		const findings: ReviewFindingSnapshot[] = (ledger.findings ?? [])
-			.filter((f) => {
-				const status = String(f.status ?? "");
-				return status === "new" || status === "open";
-			})
-			.map((f) => ({
-				id: String(f.id ?? ""),
-				severity: (f.severity ?? "medium") as ReviewFindingSnapshot["severity"],
-				status: String(f.status ?? ""),
-				title: String(f.title ?? ""),
-			}));
-		const provenance: ReviewRoundProvenance = {
-			run_id: runId,
-			review_phase: reviewPhase,
-			review_round_id: roundId,
-			findings,
-			reviewer_actor: "ai-agent",
-			reviewer_actor_id: reviewAgent,
-			approval_binding: "advisory",
-		};
-		const gate = issueReviewDecisionGate(provenance, {
-			store,
-			projectRoot,
-			gateId,
-			createdAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
-		});
-		return gate.gate_id;
-	} catch (cause) {
-		const message = cause instanceof Error ? cause.message : String(cause);
-		process.stderr.write(
-			`Warning: failed to issue review_decision gate: ${message}\n`,
-		);
-		return null;
-	}
+): string {
+	const store = createLocalFsGateRecordStore(projectRoot);
+	const round = Number(ledger.current_round ?? 0);
+	const roundId = `${reviewPhase}-round-${round}`;
+	const gateId = `review_decision-${runId}-${reviewPhase}-${round}`;
+	const createdAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+	const findings: ReviewFindingSnapshot[] = (ledger.findings ?? [])
+		.filter((f) => {
+			const status = String(f.status ?? "");
+			return status === "new" || status === "open";
+		})
+		.map((f) => ({
+			id: String(f.id ?? ""),
+			severity: (f.severity ?? "medium") as ReviewFindingSnapshot["severity"],
+			status: String(f.status ?? ""),
+			title: String(f.title ?? ""),
+		}));
+	const provenance: ReviewRoundProvenance = {
+		run_id: runId,
+		review_phase: reviewPhase,
+		review_round_id: roundId,
+		findings,
+		reviewer_actor: "ai-agent",
+		reviewer_actor_id: reviewAgent,
+		approval_binding: "advisory",
+	};
+	const gate = issueReviewDecisionGate(provenance, {
+		store,
+		projectRoot,
+		gateId,
+		createdAt,
+	});
+	// Emit gate_opened under the event-log lock, re-reading the gate to
+	// confirm it hasn't been superseded by a concurrent process (R5-F09).
+	const runsRoot = resolve(projectRoot, ".specflow/runs");
+	withLockedPublisher(runsRoot, runId, (publisher) => {
+		const current = store.read(runId, gate.gate_id);
+		if (current && current.status === "pending") {
+			emitGateOpened({
+				publisher,
+				runId,
+				changeId,
+				gateId: gate.gate_id,
+				gateKind: "review_decision",
+				originatingPhase: reviewPhase,
+				timestamp: createdAt,
+				highestSequence: publisher.highestSequence(),
+			});
+		}
+	});
+	return gate.gate_id;
 }
 
 async function main(): Promise<void> {

--- a/src/bin/specflow-review-design.ts
+++ b/src/bin/specflow-review-design.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { ChangeArtifactStore } from "../lib/artifact-store.js";
 import {
 	ChangeArtifactType,
@@ -8,7 +9,9 @@ import { validatePlanningHeadings } from "../lib/design-planning-validation.js";
 import { tryGit } from "../lib/git.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
 import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import { withLockedPublisher } from "../lib/local-fs-observation-event-publisher.js";
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
+import { emitGateOpened } from "../lib/observation-event-emitter.js";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
 import {
 	issueReviewDecisionGate,
@@ -442,12 +445,14 @@ async function runReviewPipeline(
 		);
 	}
 
-	// Issue a review_decision gate if a run_id was provided.
+	// Issue a review_decision gate if a run_id was provided. Gate issuance
+	// failure is a hard error — the spec requires exactly one gate per round.
 	let gateId: string | null = null;
 	if (runId && !parseError) {
-		gateId = tryIssueReviewDecisionGate(
+		gateId = issueReviewDecisionGateOrFail(
 			projectRoot,
 			runId,
+			changeId,
 			"design_review",
 			ledger,
 			reviewAgent,
@@ -842,56 +847,78 @@ function parseRunIdFlag(args: readonly string[]): string | undefined {
 }
 
 /**
- * Issue a review_decision gate for a completed review round. Returns the
- * gate_id on success, or null if emission fails (best-effort; the review
- * result is still valid without the gate).
+ * Issue a review_decision gate for a completed review round.
+ *
+ * Gate issuance failure is a hard error — the spec requires exactly one
+ * `review_decision` gate per completed review round, and failure to create
+ * or observe it is a contract violation. Callers MUST NOT proceed with a
+ * successful review result when this function throws.
+ *
+ * The `gate_opened` event is emitted inside the event-log lock only after
+ * re-reading the gate to confirm it is still `pending`. This prevents
+ * emitting `gate_opened` for a gate that was superseded by a concurrent
+ * review process between the gate write and the event emission.
  */
-function tryIssueReviewDecisionGate(
+function issueReviewDecisionGateOrFail(
 	projectRoot: string,
 	runId: string,
+	changeId: string,
 	reviewPhase: ReviewPhase,
 	ledger: ReviewLedger,
 	reviewAgent: ReviewAgentName,
-): string | null {
-	try {
-		const store = createLocalFsGateRecordStore(projectRoot);
-		const round = Number(ledger.current_round ?? 0);
-		const roundId = `${reviewPhase}-round-${round}`;
-		const gateId = `review_decision-${runId}-${reviewPhase}-${round}`;
-		const findings: ReviewFindingSnapshot[] = (ledger.findings ?? [])
-			.filter((f) => {
-				const status = String(f.status ?? "");
-				return status === "new" || status === "open";
-			})
-			.map((f) => ({
-				id: String(f.id ?? ""),
-				severity: (f.severity ?? "medium") as ReviewFindingSnapshot["severity"],
-				status: String(f.status ?? ""),
-				title: String(f.title ?? ""),
-			}));
-		const provenance: ReviewRoundProvenance = {
-			run_id: runId,
-			review_phase: reviewPhase,
-			review_round_id: roundId,
-			findings,
-			reviewer_actor: "ai-agent",
-			reviewer_actor_id: reviewAgent,
-			approval_binding: "advisory",
-		};
-		const gate = issueReviewDecisionGate(provenance, {
-			store,
-			projectRoot,
-			gateId,
-			createdAt: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
-		});
-		return gate.gate_id;
-	} catch (cause) {
-		const message = cause instanceof Error ? cause.message : String(cause);
-		process.stderr.write(
-			`Warning: failed to issue review_decision gate: ${message}\n`,
-		);
-		return null;
-	}
+): string {
+	const store = createLocalFsGateRecordStore(projectRoot);
+	const round = Number(ledger.current_round ?? 0);
+	const roundId = `${reviewPhase}-round-${round}`;
+	const gateId = `review_decision-${runId}-${reviewPhase}-${round}`;
+	const createdAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+	const findings: ReviewFindingSnapshot[] = (ledger.findings ?? [])
+		.filter((f) => {
+			const status = String(f.status ?? "");
+			return status === "new" || status === "open";
+		})
+		.map((f) => ({
+			id: String(f.id ?? ""),
+			severity: (f.severity ?? "medium") as ReviewFindingSnapshot["severity"],
+			status: String(f.status ?? ""),
+			title: String(f.title ?? ""),
+		}));
+	const provenance: ReviewRoundProvenance = {
+		run_id: runId,
+		review_phase: reviewPhase,
+		review_round_id: roundId,
+		findings,
+		reviewer_actor: "ai-agent",
+		reviewer_actor_id: reviewAgent,
+		approval_binding: "advisory",
+	};
+	const gate = issueReviewDecisionGate(provenance, {
+		store,
+		projectRoot,
+		gateId,
+		createdAt,
+	});
+	// Emit gate_opened under the event-log lock, re-reading the gate to
+	// confirm it hasn't been superseded by a concurrent process (R5-F09).
+	const runsRoot = resolve(projectRoot, ".specflow/runs");
+	withLockedPublisher(runsRoot, runId, (publisher) => {
+		const current = store.read(runId, gate.gate_id);
+		if (current && current.status === "pending") {
+			emitGateOpened({
+				publisher,
+				runId,
+				changeId,
+				gateId: gate.gate_id,
+				gateKind: "review_decision",
+				originatingPhase: reviewPhase,
+				timestamp: createdAt,
+				highestSequence: publisher.highestSequence(),
+			});
+		}
+		// If the gate is no longer pending (superseded), skip emission —
+		// the superseding process owns the observation stream for this slot.
+	});
+	return gate.gate_id;
 }
 
 async function main(): Promise<void> {

--- a/src/bin/specflow-run.ts
+++ b/src/bin/specflow-run.ts
@@ -45,8 +45,16 @@ import type { GateRecordStore } from "../lib/gate-record-store.js";
 import { GateRuntimeError, resolveGate } from "../lib/gate-runtime.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
 import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
+import { withLockedPublisher } from "../lib/local-fs-observation-event-publisher.js";
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { createLocalWorkspaceContext } from "../lib/local-workspace-context.js";
+import {
+	emitAdvanceEvents,
+	emitRunResumed,
+	emitRunStarted,
+	emitRunSuspended,
+	type ResolvedGateInfo,
+} from "../lib/observation-event-emitter.js";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
 import { readSourceMetadataFile } from "../lib/proposal-source.js";
 import {
@@ -133,6 +141,10 @@ function findPendingGateForPhase(
  * gate runtime. This enforces `allowed_responses`, `eligible_responder_roles`,
  * and invalid-response checks **before** the state machine advance fires.
  *
+ * Returns `ResolvedGateInfo` when a gate was resolved, so the caller can
+ * pass it to the observation event emitter (the advance's `recordMutations`
+ * will not contain the terminal update after the re-read).
+ *
  * Gate validation errors (invalid response, ineligible role, gate not
  * pending) abort the advance with a hard failure so that callers cannot
  * bypass gate rules by sending raw workflow events.
@@ -147,7 +159,7 @@ function resolveGateForEvent(
 	currentPhase: string,
 	event: string,
 	gates: readonly GateRecord[],
-): void {
+): ResolvedGateInfo | null {
 	const pendingGate = findPendingGateForPhase(gates, currentPhase);
 
 	// When no pending gate exists at the current phase, most events proceed
@@ -162,15 +174,15 @@ function resolveGateForEvent(
 					`Gate-response events require a corresponding pending gate.`,
 			);
 		}
-		return;
+		return null;
 	}
 
 	const response = eventToGateResponse(event, pendingGate.gate_kind);
-	if (!response) return;
+	if (!response) return null;
 
 	// Gate resolution failures are hard errors — the advance must not
 	// proceed if the gate runtime rejects the response.
-	resolveGate(store, {
+	const resolved = resolveGate(store, {
 		run_id: runId,
 		gate_id: pendingGate.gate_id,
 		response,
@@ -178,6 +190,12 @@ function resolveGateForEvent(
 		actor_role: "human-author",
 		resolved_at: nowIso(),
 	});
+	return {
+		gateId: resolved.gate_id,
+		gateKind: resolved.gate_kind as ResolvedGateInfo["gateKind"],
+		response: resolved.resolved_response ?? response,
+		actorLabel: resolved.decision_actor?.actor ?? "human",
+	};
 }
 
 function fail(message: string): never {
@@ -301,19 +319,110 @@ function renderResult<T>(
 	process.exit(1);
 }
 
+// ---------------------------------------------------------------------------
+// Observation-event emission helpers — scoped to the CLI wiring layer so the
+// core runtime stays unaware of transport concerns. Failures propagate to
+// `commitTransitionAndExit` which signals them via exit code 1.
+// ---------------------------------------------------------------------------
+
+function runsRootFrom(projectRoot: string): string {
+	return resolve(projectRoot, ".specflow/runs");
+}
+
+function emitStartEvent(
+	projectRoot: string,
+	runId: string,
+	state: RunStateOf<LocalRunState>,
+	timestamp: string,
+): void {
+	withLockedPublisher(runsRootFrom(projectRoot), runId, (publisher) => {
+		emitRunStarted(publisher, state, timestamp);
+	});
+}
+
+function emitAdvanceEvent(
+	projectRoot: string,
+	runId: string,
+	priorState: RunStateOf<LocalRunState>,
+	newState: RunStateOf<LocalRunState>,
+	event: string,
+	mutations: readonly RecordMutation[],
+	timestamp: string,
+	resolvedGate?: ResolvedGateInfo | null,
+): void {
+	withLockedPublisher(runsRootFrom(projectRoot), runId, (publisher) => {
+		emitAdvanceEvents({
+			publisher,
+			priorState,
+			newState,
+			event,
+			mutations,
+			timestamp,
+			highestSequence: publisher.highestSequence(),
+			resolvedGate,
+		});
+	});
+}
+
+function emitSuspendEvent(
+	projectRoot: string,
+	runId: string,
+	state: RunStateOf<LocalRunState>,
+	timestamp: string,
+): void {
+	withLockedPublisher(runsRootFrom(projectRoot), runId, (publisher) => {
+		emitRunSuspended(publisher, state, timestamp, publisher.highestSequence());
+	});
+}
+
+function emitResumeEvent(
+	projectRoot: string,
+	runId: string,
+	state: RunStateOf<LocalRunState>,
+	timestamp: string,
+): void {
+	withLockedPublisher(runsRootFrom(projectRoot), runId, (publisher) => {
+		emitRunResumed(publisher, state, timestamp, publisher.highestSequence());
+	});
+}
+
 /**
  * Commit a TransitionOk from a core command: persist state, apply record
- * mutations, print the new state as JSON, and exit successfully.
+ * mutations, emit observation events, print the new state as JSON, and exit.
+ *
+ * Observation events are emitted **after** the authoritative snapshot and
+ * gate writes succeed, so the event log never records a transition whose
+ * state commit failed. If emission fails the state is still committed (the
+ * authoritative write cannot be rolled back), but the process exits with
+ * code 1 to signal a hard failure — the spec requires the event stream to
+ * stay consistent with the snapshot, so an incomplete event log is a
+ * command failure, not a warning. Callers can detect the non-zero exit and
+ * trigger a reconciliation pass.
  */
 async function commitTransitionAndExit(
 	runStore: RunArtifactStore,
 	gates: GateRecordStore | null,
 	runId: string,
 	transitionOk: TransitionOk<LocalRunState>,
+	postCommit?: () => void,
 ): Promise<never> {
 	await persistState(runStore, runId, transitionOk.state);
 	if (gates) {
 		applyGateMutations(gates, runId, transitionOk.recordMutations);
+	}
+	if (postCommit) {
+		try {
+			postCommit();
+		} catch (cause) {
+			process.stderr.write(
+				`Error: observation event emission failed after state commit: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+			);
+			// State is committed but event log is incomplete — hard failure.
+			// Print the committed state so callers know the new state, then
+			// exit non-zero so orchestration scripts can reconcile.
+			printSchemaJson("run-state", transitionOk.state);
+			process.exit(1);
+		}
 	}
 	printSchemaJson("run-state", transitionOk.state);
 	process.exit(0);
@@ -434,6 +543,7 @@ async function runStart(args: readonly string[]): Promise<never> {
 			gates,
 			parsed.positional,
 			result.value,
+			() => emitStartEvent(root, parsed.positional, result.value.state, ts),
 		);
 	}
 
@@ -456,7 +566,9 @@ async function runStart(args: readonly string[]): Promise<never> {
 		adapterSeed,
 	});
 	if (!result.ok) renderResult("run-state", result);
-	return commitTransitionAndExit(runStore, gates, nextRunId, result.value);
+	return commitTransitionAndExit(runStore, gates, nextRunId, result.value, () =>
+		emitStartEvent(root, nextRunId, result.value.state, ts),
+	);
 }
 
 async function runAdvance(args: readonly string[]): Promise<never> {
@@ -500,8 +612,15 @@ async function runAdvance(args: readonly string[]): Promise<never> {
 	// event. This enforces the first-class gate validation (eligible roles,
 	// allowed responses) before the state machine transition fires. Gate
 	// validation failures abort the advance with a hard error.
+	let resolvedGate: ResolvedGateInfo | null = null;
 	try {
-		resolveGateForEvent(gates, runId, state.current_phase, event, gateRecords);
+		resolvedGate = resolveGateForEvent(
+			gates,
+			runId,
+			state.current_phase,
+			event,
+			gateRecords,
+		);
 	} catch (cause) {
 		if (cause instanceof GateRuntimeError) {
 			fail(`Error: gate resolution rejected: ${cause.message}`);
@@ -516,17 +635,29 @@ async function runAdvance(args: readonly string[]): Promise<never> {
 	gateRecords = gates.list(runId);
 	priorRecords = gateRecordsToInteractionRecords(gateRecords);
 
+	const ts = nowIso();
 	const result = advanceRun<LocalRunState>(
 		{
 			state,
 			event,
-			nowIso: nowIso(),
+			nowIso: ts,
 			priorRecords,
 		},
 		{ workflow },
 	);
 	if (!result.ok) renderResult("run-state", result);
-	return commitTransitionAndExit(runStore, gates, runId, result.value);
+	return commitTransitionAndExit(runStore, gates, runId, result.value, () =>
+		emitAdvanceEvent(
+			root,
+			runId,
+			state,
+			result.value.state,
+			event,
+			result.value.recordMutations,
+			ts,
+			resolvedGate,
+		),
+	);
 }
 
 async function runSuspend(args: readonly string[]): Promise<never> {
@@ -545,9 +676,12 @@ async function runSuspend(args: readonly string[]): Promise<never> {
 		runStore,
 		runId,
 	)) as RunStateOf<LocalRunState>;
-	const result = suspendRun<LocalRunState>({ state, nowIso: nowIso() });
+	const ts = nowIso();
+	const result = suspendRun<LocalRunState>({ state, nowIso: ts });
 	if (!result.ok) renderResult("run-state", result);
-	return commitTransitionAndExit(runStore, null, runId, result.value);
+	return commitTransitionAndExit(runStore, null, runId, result.value, () =>
+		emitSuspendEvent(root, runId, result.value.state, ts),
+	);
 }
 
 async function runResume(args: readonly string[]): Promise<never> {
@@ -566,9 +700,12 @@ async function runResume(args: readonly string[]): Promise<never> {
 		runStore,
 		runId,
 	)) as RunStateOf<LocalRunState>;
-	const result = resumeRun<LocalRunState>({ state, nowIso: nowIso() });
+	const ts = nowIso();
+	const result = resumeRun<LocalRunState>({ state, nowIso: ts });
 	if (!result.ok) renderResult("run-state", result);
-	return commitTransitionAndExit(runStore, null, runId, result.value);
+	return commitTransitionAndExit(runStore, null, runId, result.value, () =>
+		emitResumeEvent(root, runId, result.value.state, ts),
+	);
 }
 
 async function runStatus(args: readonly string[]): Promise<never> {

--- a/src/lib/local-fs-observation-event-publisher.ts
+++ b/src/lib/local-fs-observation-event-publisher.ts
@@ -1,0 +1,222 @@
+// Local-filesystem observation event publisher.
+//
+// Appends events as JSONL to `<runsRoot>/<run_id>/events.jsonl`. The log is
+// both transport and persistence; a single file per run, line-oriented, safe
+// to tail with standard tools, cheap to replay.
+//
+// Idempotency is enforced by maintaining an in-memory `Set<event_id>` loaded
+// from the existing log at construction time. A `publish()` call with an
+// `event_id` already on disk is a silent no-op, matching the at-least-once
+// + bit-identical re-emission contract without double-writing.
+//
+// Concurrency safety: `withLockedPublisher` acquires a per-run file lock
+// before creating the publisher, ensuring that sequence allocation and
+// event writes are atomic across concurrent CLI processes.
+
+import {
+	appendFileSync,
+	closeSync,
+	existsSync,
+	openSync,
+	readFileSync,
+	statSync,
+	unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import type { ObservationEvent } from "../types/observation-events.js";
+import { ensureDir } from "./fs.js";
+import type { ObservationEventPublisher } from "./observation-event-publisher.js";
+
+/** Path to a run's event log under the runs root. */
+export function eventLogPath(runsRoot: string, runId: string): string {
+	return join(runsRoot, runId, "events.jsonl");
+}
+
+/** In-memory summary of an existing log, used to seed a publisher. */
+interface LogState {
+	readonly seenIds: Set<string>;
+	readonly highestSequence: number;
+}
+
+function readExistingLog(path: string): LogState {
+	if (!existsSync(path)) {
+		return { seenIds: new Set(), highestSequence: 0 };
+	}
+	const raw = readFileSync(path, "utf8");
+	const seenIds = new Set<string>();
+	let highestSequence = 0;
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		let parsed: { event_id?: unknown; sequence?: unknown };
+		try {
+			parsed = JSON.parse(trimmed) as typeof parsed;
+		} catch {
+			// Tolerate a torn final line from a prior crash; drop it.
+			continue;
+		}
+		if (typeof parsed.event_id === "string") {
+			seenIds.add(parsed.event_id);
+		}
+		if (
+			typeof parsed.sequence === "number" &&
+			parsed.sequence > highestSequence
+		) {
+			highestSequence = parsed.sequence;
+		}
+	}
+	return { seenIds, highestSequence };
+}
+
+// ---------------------------------------------------------------------------
+// File locking — prevents concurrent CLI processes from allocating the same
+// sequence numbers or interleaving events within a single run.
+// ---------------------------------------------------------------------------
+
+const LOCK_STALE_MS = 10_000;
+const LOCK_TIMEOUT_MS = 5_000;
+
+/**
+ * Acquire an exclusive file lock via O_CREAT|O_EXCL, execute `fn`, then
+ * release. Stale locks (older than LOCK_STALE_MS) are automatically removed.
+ */
+function withFileLock<T>(lockPath: string, fn: () => T): T {
+	const deadline = Date.now() + LOCK_TIMEOUT_MS;
+	let acquired = false;
+	while (!acquired) {
+		try {
+			const fd = openSync(lockPath, "wx");
+			closeSync(fd);
+			acquired = true;
+		} catch (err: unknown) {
+			if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+			// Check for stale lock left by a crashed process.
+			try {
+				const stat = statSync(lockPath);
+				if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+					try {
+						unlinkSync(lockPath);
+					} catch {
+						/* race with another cleaner */
+					}
+					continue;
+				}
+			} catch {
+				// Lock file disappeared between exists-check and stat; retry.
+				continue;
+			}
+			if (Date.now() > deadline) {
+				throw new Error(`Event log lock timeout: ${lockPath}`);
+			}
+			// Brief spin-wait before retrying (~10 ms).
+			const spinEnd = Date.now() + 10;
+			while (Date.now() < spinEnd) {
+				/* spin */
+			}
+		}
+	}
+	try {
+		return fn();
+	} finally {
+		try {
+			unlinkSync(lockPath);
+		} catch {
+			/* already removed */
+		}
+	}
+}
+
+/**
+ * Create a publisher scoped to a single run **without** file locking.
+ *
+ * **WARNING — NOT SAFE for concurrent CLI processes.** Sequence numbers are
+ * allocated in-memory without a run-scoped lock; concurrent processes will
+ * race on sequence allocation and may produce duplicate sequence numbers.
+ *
+ * Use only in tests and known single-process scenarios. Production CLI code
+ * MUST use `withLockedPublisher` instead to guarantee per-run monotonic
+ * sequence ordering across concurrent processes.
+ */
+export function createLocalFsObservationEventPublisher(
+	runsRoot: string,
+	runId: string,
+): ObservationEventPublisher & { readonly highestSequence: () => number } {
+	const path = eventLogPath(runsRoot, runId);
+	const state = readExistingLog(path);
+	const seenIds = new Set(state.seenIds);
+	let highest = state.highestSequence;
+
+	return {
+		publish(event: ObservationEvent): void {
+			if (event.run_id !== runId) {
+				throw new Error(
+					`Publisher scoped to run '${runId}' received event for run '${event.run_id}'`,
+				);
+			}
+			if (seenIds.has(event.event_id)) {
+				// At-least-once with idempotency: already on disk, silent no-op.
+				return;
+			}
+			ensureDir(join(runsRoot, runId));
+			appendFileSync(path, `${JSON.stringify(event)}\n`, "utf8");
+			seenIds.add(event.event_id);
+			if (event.sequence > highest) {
+				highest = event.sequence;
+			}
+		},
+		highestSequence(): number {
+			return highest;
+		},
+	};
+}
+
+/**
+ * Execute `fn` with a locked publisher for the given run. The file lock is
+ * held for the entire duration of `fn`, so all events published within are
+ * sequenced atomically — no concurrent CLI process can interleave or
+ * allocate overlapping sequence numbers.
+ *
+ * The publisher created inside the lock reads the current log state under
+ * the lock, so `highestSequence()` is always accurate.
+ */
+export function withLockedPublisher(
+	runsRoot: string,
+	runId: string,
+	fn: (
+		publisher: ObservationEventPublisher & {
+			readonly highestSequence: () => number;
+		},
+	) => void,
+): void {
+	const path = eventLogPath(runsRoot, runId);
+	const lockPath = `${path}.lock`;
+	ensureDir(join(runsRoot, runId));
+
+	withFileLock(lockPath, () => {
+		const state = readExistingLog(path);
+		const seenIds = new Set(state.seenIds);
+		let highest = state.highestSequence;
+
+		fn({
+			publish(event: ObservationEvent): void {
+				if (event.run_id !== runId) {
+					throw new Error(
+						`Publisher scoped to run '${runId}' received event for run '${event.run_id}'`,
+					);
+				}
+				if (seenIds.has(event.event_id)) {
+					return;
+				}
+				appendFileSync(path, `${JSON.stringify(event)}\n`, "utf8");
+				seenIds.add(event.event_id);
+				if (event.sequence > highest) {
+					highest = event.sequence;
+				}
+			},
+			highestSequence(): number {
+				return highest;
+			},
+		});
+	});
+}

--- a/src/lib/observation-event-emitter.ts
+++ b/src/lib/observation-event-emitter.ts
@@ -1,0 +1,535 @@
+// Observation event emitter — interprets state transitions and record
+// mutations into the ordered event sequence required by
+// workflow-observation-events / workflow-run-state / workflow-gate-semantics.
+//
+// Emission ordering rules (from the specs):
+//   1. Gate terminal events (gate_resolved / gate_rejected) precede any phase
+//      events they cause.
+//   2. phase_completed for the source phase (unless source is "start").
+//   3. phase_entered for the target phase.
+//   4. Gate open events (gate_opened) follow the phase_entered that caused
+//      them, because the gate is a consequence of reaching the new phase.
+//   5. run_terminal follows the phase events when the target phase is a
+//      terminal state.
+//   6. run_suspended / run_resumed are emitted on lifecycle status changes
+//      without phase transitions.
+
+import type {
+	ApprovalRecord,
+	InteractionRecord,
+} from "../types/interaction-records.js";
+import type {
+	CausalContext,
+	GateKindForObservation,
+	ObservationEvent,
+	ObservationEventKind,
+} from "../types/observation-events.js";
+import {
+	makeEventId,
+	nextSequence,
+	type ObservationEventPublisher,
+} from "./observation-event-publisher.js";
+import { isTerminalPhase } from "./workflow-machine.js";
+
+/** Minimal run-state shape the emitter needs — keeps the module standalone. */
+export interface EmitRunState {
+	readonly run_id: string;
+	readonly change_name: string | null;
+	readonly current_phase: string;
+	readonly status: string;
+	readonly source?: {
+		readonly provider?: string | null;
+		readonly reference?: string | null;
+		readonly title?: string | null;
+	} | null;
+}
+
+/** RecordMutation shape re-declared here to avoid a core-layer dependency. */
+export type EmitRecordMutation =
+	| { readonly kind: "create"; readonly record: InteractionRecord }
+	| { readonly kind: "update"; readonly record: InteractionRecord }
+	| { readonly kind: "delete"; readonly recordId: string };
+
+/**
+ * Pre-resolved gate info. Passed when a gate was resolved by the gate
+ * runtime (e.g. `resolveGateForEvent`) *before* `advanceRun()`, so the
+ * advance's `recordMutations` no longer contain the terminal update.
+ */
+export interface ResolvedGateInfo {
+	readonly gateId: string;
+	readonly gateKind: GateKindForObservation;
+	readonly response: string;
+	readonly actorLabel: string;
+}
+
+function toGateKind(record_kind: string): GateKindForObservation | null {
+	if (record_kind === "approval") return "approval";
+	if (record_kind === "clarify") return "clarify";
+	if (record_kind === "review_decision") return "review_decision";
+	return null;
+}
+
+/**
+ * Map a gate response token to the observation event terminal kind and
+ * resolution value. Works for all three gate kinds (approval, clarify,
+ * review_decision).
+ */
+function responseToTerminal(response: string):
+	| {
+			kind: "resolved";
+			resolution: "approved" | "answered" | "changes_requested";
+	  }
+	| { kind: "rejected"; reason: string | null } {
+	if (response === "reject") {
+		return { kind: "rejected", reason: null };
+	}
+	const map: Record<string, "approved" | "answered" | "changes_requested"> = {
+		accept: "approved",
+		clarify_response: "answered",
+		request_changes: "changes_requested",
+	};
+	return { kind: "resolved", resolution: map[response] ?? "approved" };
+}
+
+function resolveGateResolution(record: InteractionRecord):
+	| {
+			kind: "resolved";
+			resolution: "approved" | "answered" | "changes_requested";
+	  }
+	| { kind: "rejected"; reason: string | null }
+	| null {
+	if (record.record_kind === "approval") {
+		const approval = record as ApprovalRecord;
+		if (approval.status === "approved")
+			return { kind: "resolved", resolution: "approved" };
+		if (approval.status === "rejected")
+			return { kind: "rejected", reason: null };
+		return null;
+	}
+	if (record.record_kind === "clarify" && record.status === "resolved") {
+		return { kind: "resolved", resolution: "answered" };
+	}
+	// review_decision gates are normally resolved by resolveGateForEvent
+	// before advanceRun (via the ResolvedGateInfo path), but handle them
+	// here defensively in case a mutation surfaces through advanceRun.
+	// The cast is needed because InteractionRecord's union doesn't include
+	// review_decision — at runtime the record_kind may still be present.
+	const kind = record.record_kind as string;
+	if (kind === "review_decision") {
+		const status = String(
+			(record as unknown as { status?: string }).status ?? "",
+		);
+		const response = String(
+			(record as unknown as { resolved_response?: string }).resolved_response ??
+				"",
+		);
+		if (status === "resolved") {
+			if (response === "request_changes")
+				return { kind: "resolved", resolution: "changes_requested" };
+			return { kind: "resolved", resolution: "approved" };
+		}
+		if (status === "rejected") return { kind: "rejected", reason: null };
+		return null;
+	}
+	return null;
+}
+
+function actorLabel(record: InteractionRecord): string {
+	const candidate = (record as { readonly decision_actor?: { actor?: string } })
+		.decision_actor;
+	return candidate?.actor ?? "unknown";
+}
+
+/**
+ * Build a single envelope+payload event. Callers are responsible for passing
+ * a sequence they've already reserved.
+ */
+function buildEvent(args: {
+	readonly kind: ObservationEventKind;
+	readonly runId: string;
+	readonly changeId: string;
+	readonly sequence: number;
+	readonly timestamp: string;
+	readonly sourcePhase: string | null;
+	readonly targetPhase: string | null;
+	readonly causal: CausalContext;
+	readonly gateRef: string | null;
+	readonly artifactRef: string | null;
+	readonly bundleRef: string | null;
+	readonly payload: ObservationEvent["payload"];
+}): ObservationEvent {
+	return {
+		event_id: makeEventId(args.runId, args.sequence),
+		event_kind: args.kind,
+		run_id: args.runId,
+		change_id: args.changeId,
+		sequence: args.sequence,
+		timestamp: args.timestamp,
+		source_phase: args.sourcePhase,
+		target_phase: args.targetPhase,
+		causal_context: args.causal,
+		gate_ref: args.gateRef,
+		artifact_ref: args.artifactRef,
+		bundle_ref: args.bundleRef,
+		payload: args.payload,
+	} as ObservationEvent;
+}
+
+/** Emit `run_started` as sequence 1 for a brand-new run. */
+export function emitRunStarted(
+	publisher: ObservationEventPublisher,
+	state: EmitRunState,
+	timestamp: string,
+): void {
+	const changeId = state.change_name ?? "";
+	const event = buildEvent({
+		kind: "run_started",
+		runId: state.run_id,
+		changeId,
+		sequence: 1,
+		timestamp,
+		sourcePhase: null,
+		targetPhase: state.current_phase,
+		causal: null,
+		gateRef: null,
+		artifactRef: null,
+		bundleRef: null,
+		payload: {
+			source: {
+				provider: state.source?.provider ?? null,
+				reference: state.source?.reference ?? null,
+			},
+			title: state.source?.title ?? null,
+		},
+	});
+	publisher.publish(event);
+}
+
+/**
+ * Emit the events caused by an `advance` transition, in the order required
+ * by the spec: gate terminal → phase_completed → phase_entered → gate_opened
+ * → run_terminal.
+ *
+ * `resolvedGate` carries info about a gate that was resolved by the gate
+ * runtime *before* `advanceRun()` ran, so its terminal event is NOT visible
+ * in `mutations`. When present, the emitter emits `gate_resolved` or
+ * `gate_rejected` first, and threads the `gate_ref` through all downstream
+ * phase/lifecycle events it caused.
+ */
+export function emitAdvanceEvents(args: {
+	readonly publisher: ObservationEventPublisher;
+	readonly priorState: EmitRunState;
+	readonly newState: EmitRunState;
+	readonly event: string;
+	readonly mutations: readonly EmitRecordMutation[];
+	readonly timestamp: string;
+	readonly highestSequence: number;
+	readonly resolvedGate?: ResolvedGateInfo | null;
+}): void {
+	const {
+		publisher,
+		priorState,
+		newState,
+		event,
+		mutations,
+		timestamp,
+		highestSequence,
+		resolvedGate,
+	} = args;
+	const changeId = newState.change_name ?? priorState.change_name ?? "";
+	let seq = highestSequence;
+	let lastEventId: string | null = null;
+
+	// Track the gate_ref that caused downstream phase/lifecycle events.
+	// Set when a gate terminal event is emitted.
+	let causedByGateRef: string | null = null;
+
+	const publishNext = (
+		builder: (sequence: number, causal: CausalContext) => ObservationEvent,
+	) => {
+		seq = nextSequence(seq);
+		const causal: CausalContext = lastEventId
+			? { kind: "observation_event", ref: lastEventId }
+			: { kind: "user_event", ref: event };
+		const built = builder(seq, causal);
+		publisher.publish(built);
+		lastEventId = built.event_id;
+	};
+
+	// 0. Pre-resolved gate (resolved by gate runtime before advanceRun).
+	if (resolvedGate) {
+		const terminal = responseToTerminal(resolvedGate.response);
+		causedByGateRef = resolvedGate.gateId;
+		if (terminal.kind === "resolved") {
+			publishNext((sequence, causal) =>
+				buildEvent({
+					kind: "gate_resolved",
+					runId: newState.run_id,
+					changeId,
+					sequence,
+					timestamp,
+					sourcePhase: priorState.current_phase,
+					targetPhase: newState.current_phase,
+					causal,
+					gateRef: resolvedGate.gateId,
+					artifactRef: null,
+					bundleRef: null,
+					payload: {
+						resolution: terminal.resolution,
+						by_actor: resolvedGate.actorLabel,
+					},
+				}),
+			);
+		} else {
+			publishNext((sequence, causal) =>
+				buildEvent({
+					kind: "gate_rejected",
+					runId: newState.run_id,
+					changeId,
+					sequence,
+					timestamp,
+					sourcePhase: priorState.current_phase,
+					targetPhase: newState.current_phase,
+					causal,
+					gateRef: resolvedGate.gateId,
+					artifactRef: null,
+					bundleRef: null,
+					payload: {
+						resolution: "rejected",
+						by_actor: resolvedGate.actorLabel,
+						reason: terminal.reason,
+					},
+				}),
+			);
+		}
+	}
+
+	// 1. Gate terminal mutations (from advanceRun's recordMutations).
+	for (const mutation of mutations) {
+		if (mutation.kind !== "update") continue;
+		const gateKind = toGateKind(mutation.record.record_kind);
+		if (!gateKind) continue;
+		const resolution = resolveGateResolution(mutation.record);
+		if (!resolution) continue;
+		const gateRef = mutation.record.record_id;
+		causedByGateRef = gateRef;
+		const by = actorLabel(mutation.record);
+		if (resolution.kind === "resolved") {
+			publishNext((sequence, causal) =>
+				buildEvent({
+					kind: "gate_resolved",
+					runId: newState.run_id,
+					changeId,
+					sequence,
+					timestamp,
+					sourcePhase: priorState.current_phase,
+					targetPhase: newState.current_phase,
+					causal,
+					gateRef,
+					artifactRef: null,
+					bundleRef: null,
+					payload: { resolution: resolution.resolution, by_actor: by },
+				}),
+			);
+		} else {
+			publishNext((sequence, causal) =>
+				buildEvent({
+					kind: "gate_rejected",
+					runId: newState.run_id,
+					changeId,
+					sequence,
+					timestamp,
+					sourcePhase: priorState.current_phase,
+					targetPhase: newState.current_phase,
+					causal,
+					gateRef,
+					artifactRef: null,
+					bundleRef: null,
+					payload: {
+						resolution: "rejected",
+						by_actor: by,
+						reason: resolution.reason,
+					},
+				}),
+			);
+		}
+	}
+
+	// 2. phase_completed for the source phase, unless source is "start".
+	// When caused by a gate, carry the gate_ref per spec requirement.
+	const phaseChanged = priorState.current_phase !== newState.current_phase;
+	if (phaseChanged && priorState.current_phase !== "start") {
+		publishNext((sequence, causal) =>
+			buildEvent({
+				kind: "phase_completed",
+				runId: newState.run_id,
+				changeId,
+				sequence,
+				timestamp,
+				sourcePhase: priorState.current_phase,
+				targetPhase: newState.current_phase,
+				causal,
+				gateRef: causedByGateRef,
+				artifactRef: null,
+				bundleRef: null,
+				payload: { outcome: "advanced" },
+			}),
+		);
+	}
+
+	// 3. phase_entered for the new phase when the phase changed.
+	if (phaseChanged) {
+		publishNext((sequence, causal) =>
+			buildEvent({
+				kind: "phase_entered",
+				runId: newState.run_id,
+				changeId,
+				sequence,
+				timestamp,
+				sourcePhase: priorState.current_phase,
+				targetPhase: newState.current_phase,
+				causal,
+				gateRef: causedByGateRef,
+				artifactRef: null,
+				bundleRef: null,
+				payload: { triggered_event: event },
+			}),
+		);
+	}
+
+	// 4. Gate open mutations after the phase_entered that caused them.
+	for (const mutation of mutations) {
+		if (mutation.kind !== "create") continue;
+		const gateKind = toGateKind(mutation.record.record_kind);
+		if (!gateKind) continue;
+		const gateRef = mutation.record.record_id;
+		publishNext((sequence, causal) =>
+			buildEvent({
+				kind: "gate_opened",
+				runId: newState.run_id,
+				changeId,
+				sequence,
+				timestamp,
+				sourcePhase: priorState.current_phase,
+				targetPhase: newState.current_phase,
+				causal,
+				gateRef,
+				artifactRef: null,
+				bundleRef: null,
+				payload: { gate_kind: gateKind },
+			}),
+		);
+	}
+
+	// 5. run_terminal for terminal targets.
+	if (phaseChanged && isTerminalPhase(newState.current_phase)) {
+		const terminalStatus = newState.current_phase as
+			| "approved"
+			| "decomposed"
+			| "rejected";
+		publishNext((sequence, causal) =>
+			buildEvent({
+				kind: "run_terminal",
+				runId: newState.run_id,
+				changeId,
+				sequence,
+				timestamp,
+				sourcePhase: priorState.current_phase,
+				targetPhase: newState.current_phase,
+				causal,
+				gateRef: causedByGateRef,
+				artifactRef: null,
+				bundleRef: null,
+				payload: { status: terminalStatus, reason: null },
+			}),
+		);
+	}
+}
+
+/**
+ * Emit `gate_opened` for a gate issued outside the advance path (e.g.
+ * review_decision gates issued by review CLIs).
+ */
+export function emitGateOpened(args: {
+	readonly publisher: ObservationEventPublisher;
+	readonly runId: string;
+	readonly changeId: string;
+	readonly gateId: string;
+	readonly gateKind: GateKindForObservation;
+	readonly originatingPhase: string;
+	readonly timestamp: string;
+	readonly highestSequence: number;
+	readonly causalRef?: CausalContext;
+}): void {
+	const seq = nextSequence(args.highestSequence);
+	// Default causal_context is null — review gates are issued by CLI
+	// commands with no prior observation event as a direct cause. Callers
+	// may provide a specific causal reference when one exists.
+	const causal: CausalContext = args.causalRef ?? null;
+	const event = buildEvent({
+		kind: "gate_opened",
+		runId: args.runId,
+		changeId: args.changeId,
+		sequence: seq,
+		timestamp: args.timestamp,
+		sourcePhase: args.originatingPhase,
+		targetPhase: null,
+		causal,
+		gateRef: args.gateId,
+		artifactRef: null,
+		bundleRef: null,
+		payload: { gate_kind: args.gateKind },
+	});
+	args.publisher.publish(event);
+}
+
+/** Emit `run_suspended` when the run transitions from active to suspended. */
+export function emitRunSuspended(
+	publisher: ObservationEventPublisher,
+	state: EmitRunState,
+	timestamp: string,
+	highestSequence: number,
+	reason = "user_initiated",
+): void {
+	const seq = nextSequence(highestSequence);
+	const event = buildEvent({
+		kind: "run_suspended",
+		runId: state.run_id,
+		changeId: state.change_name ?? "",
+		sequence: seq,
+		timestamp,
+		sourcePhase: state.current_phase,
+		targetPhase: null,
+		causal: { kind: "user_event", ref: "suspend" },
+		gateRef: null,
+		artifactRef: null,
+		bundleRef: null,
+		payload: { reason },
+	});
+	publisher.publish(event);
+}
+
+/** Emit `run_resumed` when the run transitions from suspended to active. */
+export function emitRunResumed(
+	publisher: ObservationEventPublisher,
+	state: EmitRunState,
+	timestamp: string,
+	highestSequence: number,
+): void {
+	const seq = nextSequence(highestSequence);
+	const event = buildEvent({
+		kind: "run_resumed",
+		runId: state.run_id,
+		changeId: state.change_name ?? "",
+		sequence: seq,
+		timestamp,
+		sourcePhase: null,
+		targetPhase: state.current_phase,
+		causal: { kind: "user_event", ref: "resume" },
+		gateRef: null,
+		artifactRef: null,
+		bundleRef: null,
+		payload: {},
+	});
+	publisher.publish(event);
+}

--- a/src/lib/observation-event-publisher.ts
+++ b/src/lib/observation-event-publisher.ts
@@ -1,0 +1,41 @@
+// Observation event publisher interface.
+//
+// Concrete implementations MUST satisfy the ordering (per-run monotonic) and
+// delivery (at-least-once with bit-identical re-emission on idempotent keys)
+// requirements defined in openspec/specs/workflow-observation-events/spec.md.
+
+import type { ObservationEvent } from "../types/observation-events.js";
+
+/**
+ * Publisher contract: `publish` appends a single event to the run's
+ * observation-event log. Implementations SHALL:
+ *
+ *   - preserve `event.sequence` as monotonically increasing within a run,
+ *   - make each write visible to later readers as atomically as the
+ *     underlying transport allows,
+ *   - de-duplicate by `event_id` (at-least-once delivery with consumer-side
+ *     idempotency — a re-published event with an id already on the log MUST
+ *     NOT produce a second record).
+ */
+export interface ObservationEventPublisher {
+	readonly publish: (event: ObservationEvent) => void;
+}
+
+/**
+ * Returns the next `sequence` value for a run given the highest already
+ * observed on the log. `highest` is the largest `sequence` seen so far, or
+ * `0` if the log is empty.
+ */
+export function nextSequence(highest: number): number {
+	return highest + 1;
+}
+
+/**
+ * Deterministic `event_id` for a given (run_id, sequence) pair. Using a
+ * deterministic scheme means a re-emission with the same (run, sequence)
+ * produces bit-identical envelope fields, satisfying the re-emission
+ * invariant without requiring a random UUID generator.
+ */
+export function makeEventId(runId: string, sequence: number): string {
+	return `${runId}-evt-${sequence}`;
+}

--- a/src/tests/observation-events.test.ts
+++ b/src/tests/observation-events.test.ts
@@ -1,0 +1,760 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import {
+	createLocalFsObservationEventPublisher,
+	eventLogPath,
+	withLockedPublisher,
+} from "../lib/local-fs-observation-event-publisher.js";
+import {
+	type EmitRecordMutation,
+	type EmitRunState,
+	emitAdvanceEvents,
+	emitGateOpened,
+	emitRunResumed,
+	emitRunStarted,
+	emitRunSuspended,
+	type ResolvedGateInfo,
+} from "../lib/observation-event-emitter.js";
+import {
+	makeEventId,
+	nextSequence,
+} from "../lib/observation-event-publisher.js";
+import type { ApprovalRecord } from "../types/interaction-records.js";
+import {
+	isObservationEventKind,
+	OBSERVATION_EVENT_KINDS,
+	type ObservationEvent,
+} from "../types/observation-events.js";
+
+function makeTempRoot(): string {
+	return mkdtempSync(resolve(tmpdir(), "specflow-obs-events-test-"));
+}
+
+function readLog(runsRoot: string, runId: string): readonly ObservationEvent[] {
+	const path = eventLogPath(runsRoot, runId);
+	if (!existsSync(path)) return [];
+	return readFileSync(path, "utf8")
+		.split("\n")
+		.filter((line) => line.trim())
+		.map((line) => JSON.parse(line) as ObservationEvent);
+}
+
+function sampleState(overrides: Partial<EmitRunState> = {}): EmitRunState {
+	return {
+		run_id: "change-foo-1",
+		change_name: "change-foo",
+		current_phase: "start",
+		status: "active",
+		source: {
+			provider: "github",
+			reference: "https://github.com/x/y/issues/1",
+			title: "sample",
+		},
+		...overrides,
+	};
+}
+
+// --- catalog / type helpers -------------------------------------------------
+
+test("OBSERVATION_EVENT_KINDS catalogues exactly 15 kinds", () => {
+	assert.equal(OBSERVATION_EVENT_KINDS.length, 15);
+});
+
+test("isObservationEventKind accepts every catalog entry and rejects others", () => {
+	for (const kind of OBSERVATION_EVENT_KINDS) {
+		assert.equal(isObservationEventKind(kind), true);
+	}
+	assert.equal(isObservationEventKind("not_a_kind"), false);
+	assert.equal(isObservationEventKind(123), false);
+	assert.equal(isObservationEventKind(null), false);
+});
+
+test("makeEventId is deterministic for (runId, sequence)", () => {
+	assert.equal(makeEventId("run-1", 4), "run-1-evt-4");
+	assert.equal(makeEventId("run-1", 4), "run-1-evt-4");
+});
+
+test("nextSequence returns highest + 1", () => {
+	assert.equal(nextSequence(0), 1);
+	assert.equal(nextSequence(7), 8);
+});
+
+// --- local publisher --------------------------------------------------------
+
+test("publisher writes events as JSONL", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-a");
+		emitRunStarted(
+			publisher,
+			sampleState({ run_id: "run-a" }),
+			"2026-04-19T00:00:00Z",
+		);
+		const events = readLog(root, "run-a");
+		assert.equal(events.length, 1);
+		assert.equal(events[0]?.event_kind, "run_started");
+		assert.equal(events[0]?.sequence, 1);
+		assert.equal(events[0]?.source_phase, null);
+		assert.equal(events[0]?.target_phase, "start");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("publisher de-duplicates on repeated event_id (at-least-once idempotent)", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-b");
+		const base = sampleState({ run_id: "run-b" });
+		emitRunStarted(publisher, base, "2026-04-19T00:00:00Z");
+		// Second publisher instance sees the existing log and dedups.
+		const reborn = createLocalFsObservationEventPublisher(root, "run-b");
+		emitRunStarted(reborn, base, "2026-04-19T00:00:00Z");
+		const events = readLog(root, "run-b");
+		assert.equal(events.length, 1, "duplicate should not be appended");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("publisher refuses events scoped to a different run", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-x");
+		assert.throws(() => {
+			emitRunStarted(
+				publisher,
+				sampleState({ run_id: "run-OTHER" }),
+				"2026-04-19T00:00:00Z",
+			);
+		}, /scoped to run/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- advance event sequence -------------------------------------------------
+
+test("emitAdvanceEvents emits phase_entered without phase_completed when from is 'start'", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-c");
+		// seed with run_started at sequence 1
+		emitRunStarted(
+			publisher,
+			sampleState({ run_id: "run-c" }),
+			"2026-04-19T00:00:00Z",
+		);
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({ run_id: "run-c", current_phase: "start" }),
+			newState: sampleState({
+				run_id: "run-c",
+				current_phase: "proposal_draft",
+			}),
+			event: "propose",
+			mutations: [],
+			timestamp: "2026-04-19T00:00:01Z",
+			highestSequence: publisher.highestSequence(),
+		});
+		const kinds = readLog(root, "run-c").map((e) => e.event_kind);
+		assert.deepEqual(kinds, ["run_started", "phase_entered"]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("emitAdvanceEvents emits phase_completed then phase_entered for normal transition", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-d");
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-d",
+				current_phase: "proposal_draft",
+			}),
+			newState: sampleState({
+				run_id: "run-d",
+				current_phase: "proposal_scope",
+			}),
+			event: "check_scope",
+			mutations: [],
+			timestamp: "2026-04-19T00:00:02Z",
+			highestSequence: 1,
+		});
+		const events = readLog(root, "run-d");
+		const kinds = events.map((e) => e.event_kind);
+		assert.deepEqual(kinds, ["phase_completed", "phase_entered"]);
+		// Sequences continue from highestSequence.
+		assert.equal(events[0]?.sequence, 2);
+		assert.equal(events[1]?.sequence, 3);
+		// Causal chaining: second event references the first.
+		assert.equal(events[1]?.causal_context?.kind, "observation_event");
+		assert.equal(
+			events[1]?.causal_context?.kind === "observation_event"
+				? events[1]?.causal_context?.ref
+				: null,
+			events[0]?.event_id,
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("emitAdvanceEvents emits gate_resolved before phase_completed on gate update, threading gate_ref", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-e");
+		const resolvedApproval: ApprovalRecord = {
+			record_id: "approval-run-e-1",
+			record_kind: "approval",
+			run_id: "run-e",
+			phase_from: "approval_gate_design",
+			phase_to: "design_ready",
+			status: "approved",
+			requested_at: "2026-04-19T00:00:00Z",
+			decided_at: "2026-04-19T00:00:03Z",
+			decision_actor: { actor: "human", actor_id: "cli" },
+			event_ids: [],
+		};
+		const mutation: EmitRecordMutation = {
+			kind: "update",
+			record: resolvedApproval,
+		};
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-e",
+				current_phase: "approval_gate_design",
+			}),
+			newState: sampleState({ run_id: "run-e", current_phase: "design_ready" }),
+			event: "design_review_approved",
+			mutations: [mutation],
+			timestamp: "2026-04-19T00:00:03Z",
+			highestSequence: 4,
+		});
+		const events = readLog(root, "run-e");
+		const kinds = events.map((e) => e.event_kind);
+		assert.deepEqual(kinds, [
+			"gate_resolved",
+			"phase_completed",
+			"phase_entered",
+		]);
+		// R1-F03: gate_ref must be threaded to caused phase events.
+		assert.equal(events[0]?.gate_ref, "approval-run-e-1");
+		assert.equal(
+			events[1]?.gate_ref,
+			"approval-run-e-1",
+			"phase_completed should carry gate_ref",
+		);
+		assert.equal(
+			events[2]?.gate_ref,
+			"approval-run-e-1",
+			"phase_entered should carry gate_ref",
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("emitAdvanceEvents emits gate_opened after phase_entered when a gate is created", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-f");
+		const created: ApprovalRecord = {
+			record_id: "approval-run-f-1",
+			record_kind: "approval",
+			run_id: "run-f",
+			phase_from: "approval_gate_design",
+			phase_to: "design_ready",
+			status: "pending",
+			requested_at: "2026-04-19T00:00:04Z",
+			decided_at: null,
+			decision_actor: null,
+			event_ids: [],
+		};
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-f",
+				current_phase: "design_review",
+			}),
+			newState: sampleState({
+				run_id: "run-f",
+				current_phase: "approval_gate_design",
+			}),
+			event: "design_review_approved",
+			mutations: [{ kind: "create", record: created }],
+			timestamp: "2026-04-19T00:00:04Z",
+			highestSequence: 10,
+		});
+		const kinds = readLog(root, "run-f").map((e) => e.event_kind);
+		assert.deepEqual(kinds, [
+			"phase_completed",
+			"phase_entered",
+			"gate_opened",
+		]);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("emitAdvanceEvents emits run_terminal when entering a terminal phase", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-g");
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-g",
+				current_phase: "apply_ready",
+			}),
+			newState: sampleState({
+				run_id: "run-g",
+				current_phase: "approved",
+				status: "terminal",
+			}),
+			event: "approve",
+			mutations: [],
+			timestamp: "2026-04-19T00:00:05Z",
+			highestSequence: 20,
+		});
+		const events = readLog(root, "run-g");
+		const kinds = events.map((e) => e.event_kind);
+		assert.deepEqual(kinds, [
+			"phase_completed",
+			"phase_entered",
+			"run_terminal",
+		]);
+		const terminal = events[2];
+		assert.equal(terminal?.event_kind, "run_terminal");
+		if (terminal?.event_kind === "run_terminal") {
+			assert.equal(terminal.payload.status, "approved");
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("emitRunSuspended and emitRunResumed append at the next sequence", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-h");
+		emitRunSuspended(
+			publisher,
+			sampleState({
+				run_id: "run-h",
+				current_phase: "design_draft",
+				status: "suspended",
+			}),
+			"2026-04-19T00:01:00Z",
+			3,
+		);
+		emitRunResumed(
+			publisher,
+			sampleState({
+				run_id: "run-h",
+				current_phase: "design_draft",
+				status: "active",
+			}),
+			"2026-04-19T00:02:00Z",
+			4,
+		);
+		const events = readLog(root, "run-h");
+		assert.deepEqual(
+			events.map((e) => [e.event_kind, e.sequence]),
+			[
+				["run_suspended", 4],
+				["run_resumed", 5],
+			],
+		);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- envelope invariants ----------------------------------------------------
+
+// --- R2-F01: resolvedGate parameter for pre-resolved gates -----------------
+
+test("emitAdvanceEvents with resolvedGate emits gate_resolved for review_decision", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-j");
+		const resolvedGate: ResolvedGateInfo = {
+			gateId: "review_decision-run-j-design_review-1",
+			gateKind: "review_decision",
+			response: "accept",
+			actorLabel: "human",
+		};
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-j",
+				current_phase: "design_review",
+			}),
+			newState: sampleState({
+				run_id: "run-j",
+				current_phase: "design_ready",
+			}),
+			event: "design_review_approved",
+			mutations: [],
+			timestamp: "2026-04-19T00:00:06Z",
+			highestSequence: 5,
+			resolvedGate,
+		});
+		const events = readLog(root, "run-j");
+		const kinds = events.map((e) => e.event_kind);
+		assert.deepEqual(kinds, [
+			"gate_resolved",
+			"phase_completed",
+			"phase_entered",
+		]);
+		// gate_resolved carries the gate_ref.
+		assert.equal(events[0]?.gate_ref, "review_decision-run-j-design_review-1");
+		// Caused phase events also carry gate_ref (R1-F03).
+		assert.equal(events[1]?.gate_ref, "review_decision-run-j-design_review-1");
+		assert.equal(events[2]?.gate_ref, "review_decision-run-j-design_review-1");
+		// Payload has correct resolution.
+		if (events[0]?.event_kind === "gate_resolved") {
+			assert.equal(events[0].payload.resolution, "approved");
+			assert.equal(events[0].payload.by_actor, "human");
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("emitAdvanceEvents with resolvedGate emits gate_rejected for reject response", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-k");
+		const resolvedGate: ResolvedGateInfo = {
+			gateId: "review_decision-run-k-apply_review-1",
+			gateKind: "review_decision",
+			response: "reject",
+			actorLabel: "human",
+		};
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-k",
+				current_phase: "apply_review",
+			}),
+			newState: sampleState({
+				run_id: "run-k",
+				current_phase: "rejected",
+				status: "terminal",
+			}),
+			event: "reject",
+			mutations: [],
+			timestamp: "2026-04-19T00:00:07Z",
+			highestSequence: 10,
+			resolvedGate,
+		});
+		const events = readLog(root, "run-k");
+		const kinds = events.map((e) => e.event_kind);
+		assert.deepEqual(kinds, [
+			"gate_rejected",
+			"phase_completed",
+			"phase_entered",
+			"run_terminal",
+		]);
+		if (events[0]?.event_kind === "gate_rejected") {
+			assert.equal(events[0].payload.resolution, "rejected");
+		}
+		// run_terminal also carries gate_ref from the causing gate.
+		assert.equal(events[3]?.gate_ref, "review_decision-run-k-apply_review-1");
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("emitAdvanceEvents with resolvedGate emits gate_resolved with changes_requested", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-l");
+		const resolvedGate: ResolvedGateInfo = {
+			gateId: "review_decision-run-l-design_review-1",
+			gateKind: "review_decision",
+			response: "request_changes",
+			actorLabel: "human",
+		};
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-l",
+				current_phase: "design_review",
+			}),
+			newState: sampleState({
+				run_id: "run-l",
+				current_phase: "design_draft",
+			}),
+			event: "revise_design",
+			mutations: [],
+			timestamp: "2026-04-19T00:00:08Z",
+			highestSequence: 8,
+			resolvedGate,
+		});
+		const events = readLog(root, "run-l");
+		const kinds = events.map((e) => e.event_kind);
+		assert.deepEqual(kinds, [
+			"gate_resolved",
+			"phase_completed",
+			"phase_entered",
+		]);
+		if (events[0]?.event_kind === "gate_resolved") {
+			assert.equal(events[0].payload.resolution, "changes_requested");
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- R2-F02: emitGateOpened for review_decision gates ----------------------
+
+test("emitGateOpened emits a gate_opened event for review_decision", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-m");
+		// Seed with run_started so the log has a baseline.
+		emitRunStarted(
+			publisher,
+			sampleState({ run_id: "run-m" }),
+			"2026-04-19T00:00:00Z",
+		);
+		emitGateOpened({
+			publisher,
+			runId: "run-m",
+			changeId: "change-foo",
+			gateId: "review_decision-run-m-design_review-1",
+			gateKind: "review_decision",
+			originatingPhase: "design_review",
+			timestamp: "2026-04-19T00:00:09Z",
+			highestSequence: publisher.highestSequence(),
+		});
+		const events = readLog(root, "run-m");
+		assert.equal(events.length, 2);
+		const gateEvent = events[1];
+		assert.equal(gateEvent?.event_kind, "gate_opened");
+		assert.equal(gateEvent?.gate_ref, "review_decision-run-m-design_review-1");
+		assert.equal(gateEvent?.source_phase, "design_review");
+		// R3-F06: causal_context must be null (no prior observation event caused it).
+		assert.equal(
+			gateEvent?.causal_context,
+			null,
+			"gate_opened for review_decision should have null causal_context",
+		);
+		if (gateEvent?.event_kind === "gate_opened") {
+			assert.equal(gateEvent.payload.gate_kind, "review_decision");
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- R1-F03: phase events without gate have null gate_ref ------------------
+
+test("phase events without a gate have null gate_ref", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-n");
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-n",
+				current_phase: "proposal_draft",
+			}),
+			newState: sampleState({
+				run_id: "run-n",
+				current_phase: "proposal_scope",
+			}),
+			event: "check_scope",
+			mutations: [],
+			timestamp: "2026-04-19T00:00:10Z",
+			highestSequence: 1,
+		});
+		const events = readLog(root, "run-n");
+		for (const event of events) {
+			assert.equal(
+				event.gate_ref,
+				null,
+				`${event.event_kind} should have null gate_ref without gate`,
+			);
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- envelope invariants ----------------------------------------------------
+
+test("every emitted event carries all twelve envelope fields", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-i");
+		emitRunStarted(
+			publisher,
+			sampleState({ run_id: "run-i" }),
+			"2026-04-19T00:00:00Z",
+		);
+		emitAdvanceEvents({
+			publisher,
+			priorState: sampleState({
+				run_id: "run-i",
+				current_phase: "proposal_draft",
+			}),
+			newState: sampleState({
+				run_id: "run-i",
+				current_phase: "proposal_scope",
+			}),
+			event: "check_scope",
+			mutations: [],
+			timestamp: "2026-04-19T00:00:01Z",
+			highestSequence: 1,
+		});
+		const events = readLog(root, "run-i");
+		const requiredFields = [
+			"event_id",
+			"event_kind",
+			"run_id",
+			"change_id",
+			"sequence",
+			"timestamp",
+			"source_phase",
+			"target_phase",
+			"causal_context",
+			"gate_ref",
+			"artifact_ref",
+			"bundle_ref",
+		] as const;
+		for (const event of events) {
+			for (const field of requiredFields) {
+				assert.ok(
+					field in event,
+					`envelope missing '${field}' on ${event.event_kind}`,
+				);
+			}
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- R3-F05: withLockedPublisher for atomic sequence allocation -------------
+
+test("withLockedPublisher creates events with correct sequences", () => {
+	const root = makeTempRoot();
+	try {
+		withLockedPublisher(root, "run-lock-a", (publisher) => {
+			emitRunStarted(
+				publisher,
+				sampleState({ run_id: "run-lock-a" }),
+				"2026-04-19T00:00:00Z",
+			);
+			emitAdvanceEvents({
+				publisher,
+				priorState: sampleState({
+					run_id: "run-lock-a",
+					current_phase: "start",
+				}),
+				newState: sampleState({
+					run_id: "run-lock-a",
+					current_phase: "proposal_draft",
+				}),
+				event: "propose",
+				mutations: [],
+				timestamp: "2026-04-19T00:00:01Z",
+				highestSequence: publisher.highestSequence(),
+			});
+		});
+		const events = readLog(root, "run-lock-a");
+		assert.equal(events.length, 2);
+		assert.equal(events[0]?.sequence, 1);
+		assert.equal(events[1]?.sequence, 2);
+		// The advance's first event is caused by the user event "propose"
+		// (not by run_started — they are separate emission calls).
+		assert.equal(events[1]?.causal_context?.kind, "user_event");
+		if (events[1]?.causal_context?.kind === "user_event") {
+			assert.equal(events[1].causal_context.ref, "propose");
+		}
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("withLockedPublisher reads current state under lock", () => {
+	const root = makeTempRoot();
+	try {
+		// First batch writes events 1-2.
+		withLockedPublisher(root, "run-lock-b", (publisher) => {
+			emitRunStarted(
+				publisher,
+				sampleState({ run_id: "run-lock-b" }),
+				"2026-04-19T00:00:00Z",
+			);
+		});
+		// Second batch reads the existing log and continues from the right sequence.
+		withLockedPublisher(root, "run-lock-b", (publisher) => {
+			assert.equal(
+				publisher.highestSequence(),
+				1,
+				"should see event from first batch",
+			);
+			emitAdvanceEvents({
+				publisher,
+				priorState: sampleState({
+					run_id: "run-lock-b",
+					current_phase: "start",
+				}),
+				newState: sampleState({
+					run_id: "run-lock-b",
+					current_phase: "proposal_draft",
+				}),
+				event: "propose",
+				mutations: [],
+				timestamp: "2026-04-19T00:00:01Z",
+				highestSequence: publisher.highestSequence(),
+			});
+		});
+		const events = readLog(root, "run-lock-b");
+		assert.equal(events.length, 2);
+		assert.equal(events[0]?.sequence, 1);
+		assert.equal(events[1]?.sequence, 2);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+// --- R3-F06: emitGateOpened with custom causalRef --------------------------
+
+test("emitGateOpened accepts custom causalRef when provided", () => {
+	const root = makeTempRoot();
+	try {
+		const publisher = createLocalFsObservationEventPublisher(root, "run-o");
+		emitGateOpened({
+			publisher,
+			runId: "run-o",
+			changeId: "change-foo",
+			gateId: "review_decision-run-o-1",
+			gateKind: "review_decision",
+			originatingPhase: "design_review",
+			timestamp: "2026-04-19T00:00:00Z",
+			highestSequence: 0,
+			causalRef: { kind: "user_event", ref: "design_review_initiated" },
+		});
+		const events = readLog(root, "run-o");
+		assert.equal(events.length, 1);
+		assert.deepEqual(events[0]?.causal_context, {
+			kind: "user_event",
+			ref: "design_review_initiated",
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});

--- a/src/tests/specflow-run.test.ts
+++ b/src/tests/specflow-run.test.ts
@@ -19,6 +19,7 @@ import {
 } from "node:fs";
 import { join, resolve } from "node:path";
 import test from "node:test";
+import type { ObservationEvent } from "../types/observation-events.js";
 import {
 	createBareHome,
 	createFixtureRepo,
@@ -37,6 +38,19 @@ interface StartResult {
 	source?: { provider: string; reference: string } | null;
 	run_kind?: string;
 	previous_run_id?: string | null;
+}
+
+/** Read the observation events.jsonl for a given run under a repo's .specflow/runs. */
+function readRunEvents(
+	repoPath: string,
+	runId: string,
+): readonly ObservationEvent[] {
+	const path = join(repoPath, ".specflow/runs", runId, "events.jsonl");
+	if (!existsSync(path)) return [];
+	return readFileSync(path, "utf8")
+		.split("\n")
+		.filter((l) => l.trim())
+		.map((l) => JSON.parse(l) as ObservationEvent);
 }
 
 function startRun(
@@ -535,6 +549,372 @@ test("specflow-run advance rejects unmigrated legacy records with a clear error"
 			/specflow-migrate-records/,
 			"error should mention migration command",
 		);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+// --- Integration: observation events.jsonl through CLI ---------------------
+
+test("specflow-run start writes run_started to events.jsonl", () => {
+	const tempRoot = makeTempDir("specflow-run-obs-start-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const state = startRun(repoPath, changeId);
+		const events = readRunEvents(repoPath, state.run_id);
+		assert.equal(events.length, 1);
+		assert.equal(events[0]?.event_kind, "run_started");
+		assert.equal(events[0]?.run_id, state.run_id);
+		assert.equal(events[0]?.sequence, 1);
+		assert.equal(events[0]?.target_phase, "start");
+		assert.equal(events[0]?.source_phase, null);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run advance writes phase events to events.jsonl in order", () => {
+	const tempRoot = makeTempDir("specflow-run-obs-advance-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const state = startRun(repoPath, changeId);
+		const runId = state.run_id;
+		// "start" → "proposal_draft": only phase_entered (no phase_completed from start).
+		advancePhase(repoPath, runId, "propose");
+		const afterPropose = readRunEvents(repoPath, runId);
+		const kinds1 = afterPropose.map((e) => e.event_kind);
+		assert.deepEqual(kinds1, ["run_started", "phase_entered"]);
+		assert.equal(afterPropose[1]?.target_phase, "proposal_draft");
+		// "proposal_draft" → "proposal_scope": phase_completed + phase_entered.
+		advancePhase(repoPath, runId, "check_scope");
+		const afterScope = readRunEvents(repoPath, runId);
+		const kinds2 = afterScope.map((e) => e.event_kind);
+		assert.deepEqual(kinds2, [
+			"run_started",
+			"phase_entered",
+			"phase_completed",
+			"phase_entered",
+		]);
+		// Sequences are monotonically increasing.
+		const seqs = afterScope.map((e) => e.sequence);
+		for (let i = 1; i < seqs.length; i++) {
+			assert.ok(
+				(seqs[i] ?? 0) > (seqs[i - 1] ?? 0),
+				`sequence ${seqs[i]} should be > ${seqs[i - 1]}`,
+			);
+		}
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run full happy path writes run_terminal at the end", () => {
+	const tempRoot = makeTempDir("specflow-run-obs-terminal-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const state = startRun(repoPath, changeId);
+		const runId = state.run_id;
+		const sequence: string[] = [
+			"propose",
+			"check_scope",
+			"continue_proposal",
+			"challenge_proposal",
+			"reclarify",
+			"accept_proposal",
+			"validate_spec",
+			"spec_validated",
+			"spec_verified",
+			"accept_spec",
+			"review_design",
+			"design_review_approved",
+			"accept_design",
+			"review_apply",
+			"apply_review_approved",
+			"accept_apply",
+		];
+		for (const event of sequence) {
+			advancePhase(repoPath, runId, event);
+		}
+		const events = readRunEvents(repoPath, runId);
+		const last = events[events.length - 1];
+		assert.equal(last?.event_kind, "run_terminal");
+		assert.equal(last?.target_phase, "approved");
+		if (last?.event_kind === "run_terminal") {
+			assert.equal(last.payload.status, "approved");
+		}
+		// Verify all events have the twelve required envelope fields.
+		const requiredFields = [
+			"event_id",
+			"event_kind",
+			"run_id",
+			"change_id",
+			"sequence",
+			"timestamp",
+			"source_phase",
+			"target_phase",
+			"causal_context",
+			"gate_ref",
+			"artifact_ref",
+			"bundle_ref",
+		] as const;
+		for (const evt of events) {
+			for (const field of requiredFields) {
+				assert.ok(
+					field in evt,
+					`event ${evt.event_kind} seq=${evt.sequence} missing '${field}'`,
+				);
+			}
+		}
+		// The full happy path includes gate resolution (approval gates at
+		// spec_ready, design review, apply review). Verify gate events are
+		// present in the observation stream.
+		const kinds = events.map((e) => e.event_kind);
+		assert.ok(
+			kinds.includes("gate_resolved"),
+			"happy path should include gate_resolved events for approval gates",
+		);
+		assert.ok(
+			kinds.includes("gate_opened"),
+			"happy path should include gate_opened events",
+		);
+		// gate_resolved events must carry a non-null gate_ref.
+		for (const evt of events) {
+			if (
+				evt.event_kind === "gate_resolved" ||
+				evt.event_kind === "gate_rejected"
+			) {
+				assert.ok(
+					evt.gate_ref !== null,
+					`${evt.event_kind} at seq=${evt.sequence} must have non-null gate_ref`,
+				);
+			}
+		}
+		// gate_resolved must always precede the phase_completed it causes.
+		for (let i = 0; i < events.length; i++) {
+			const evt = events[i];
+			if (evt?.event_kind !== "gate_resolved") continue;
+			// Find the next phase_completed after this gate_resolved.
+			const nextPhaseCompleted = events
+				.slice(i + 1)
+				.find((e) => e.event_kind === "phase_completed");
+			if (nextPhaseCompleted) {
+				assert.ok(
+					nextPhaseCompleted.sequence > evt.sequence,
+					"gate_resolved must precede subsequent phase_completed",
+				);
+			}
+		}
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run suspend + resume write observation events to events.jsonl", () => {
+	const tempRoot = makeTempDir("specflow-run-obs-suspend-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const state = startRun(repoPath, changeId);
+		const runId = state.run_id;
+		advancePhase(repoPath, runId, "propose");
+
+		runNodeCli("specflow-run", ["suspend", runId], repoPath);
+		runNodeCli("specflow-run", ["resume", runId], repoPath);
+
+		const events = readRunEvents(repoPath, runId);
+		const kinds = events.map((e) => e.event_kind);
+		assert.ok(kinds.includes("run_suspended"), "should include run_suspended");
+		assert.ok(kinds.includes("run_resumed"), "should include run_resumed");
+		// run_suspended comes before run_resumed.
+		const suspIdx = kinds.indexOf("run_suspended");
+		const resIdx = kinds.indexOf("run_resumed");
+		assert.ok(suspIdx < resIdx, "suspended should precede resumed");
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run advance with gate resolution emits gate_resolved and threads gate_ref", () => {
+	const tempRoot = makeTempDir("specflow-run-obs-gate-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const state = startRun(repoPath, changeId);
+		const runId = state.run_id;
+		// Drive to accept_spec which resolves the approval gate at spec_ready.
+		const toSpec: string[] = [
+			"propose",
+			"check_scope",
+			"continue_proposal",
+			"challenge_proposal",
+			"reclarify",
+			"accept_proposal",
+			"validate_spec",
+			"spec_validated",
+			"spec_verified",
+		];
+		for (const event of toSpec) {
+			advancePhase(repoPath, runId, event);
+		}
+		// Now at spec_ready; accept_spec triggers approval gate resolution → advance.
+		advancePhase(repoPath, runId, "accept_spec");
+		const events = readRunEvents(repoPath, runId);
+		const kinds = events.map((e) => e.event_kind);
+		// The workflow creates an approval gate at spec_ready. accept_spec
+		// resolves it. Verify gate_resolved is present and gate_ref is threaded.
+		const gateResolved = events.filter((e) => e.event_kind === "gate_resolved");
+		assert.ok(
+			gateResolved.length > 0,
+			"accept_spec should emit gate_resolved for the approval gate at spec_ready",
+		);
+		const gateRef = gateResolved[0]?.gate_ref;
+		assert.ok(gateRef, "gate_resolved should have a gate_ref");
+		// Find subsequent phase events caused by this gate resolution.
+		const gateIdx = events.indexOf(gateResolved[0]!);
+		const subsequent = events.slice(gateIdx + 1);
+		for (const sub of subsequent) {
+			if (
+				sub.event_kind === "phase_completed" ||
+				sub.event_kind === "phase_entered" ||
+				sub.event_kind === "run_terminal"
+			) {
+				assert.equal(
+					sub.gate_ref,
+					gateRef,
+					`${sub.event_kind} should carry gate_ref from causing gate`,
+				);
+			}
+		}
+		// Event stream is non-empty and well-ordered.
+		assert.ok(events.length > 0, "events.jsonl should not be empty");
+		assert.ok(
+			kinds.includes("phase_entered"),
+			"should include phase_entered events",
+		);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run advance resolves a review_decision gate and emits gate_rejected to events.jsonl", () => {
+	const tempRoot = makeTempDir("specflow-run-obs-review-decision-");
+	try {
+		const { repoPath, changeId } = createFixtureRepo(tempRoot);
+		const state = startRun(repoPath, changeId);
+		const runId = state.run_id;
+		// Drive to design_review.
+		const toDesignReview: string[] = [
+			"propose",
+			"check_scope",
+			"continue_proposal",
+			"challenge_proposal",
+			"reclarify",
+			"accept_proposal",
+			"validate_spec",
+			"spec_validated",
+			"spec_verified",
+			"accept_spec",
+			"review_design",
+		];
+		for (const event of toDesignReview) {
+			advancePhase(repoPath, runId, event);
+		}
+		// Manually write a review_decision gate record at design_review.
+		const gateId = `review_decision-${runId}-design_review-1`;
+		const gateRecord = {
+			gate_id: gateId,
+			gate_kind: "review_decision",
+			run_id: runId,
+			originating_phase: "design_review",
+			status: "pending",
+			reason: "Design review round completed",
+			payload: {
+				kind: "review_decision",
+				review_round_id: "design_review-round-1",
+				findings: [],
+				reviewer_actor: "ai-agent",
+				reviewer_actor_id: "codex",
+				approval_binding: "advisory",
+			},
+			eligible_responder_roles: ["human-author"],
+			allowed_responses: ["accept", "reject", "request_changes"],
+			created_at: "2026-04-19T00:00:00Z",
+			resolved_at: null,
+			decision_actor: null,
+			resolved_response: null,
+			event_ids: [],
+		};
+		const recordsDir = join(repoPath, ".specflow/runs", runId, "records");
+		mkdirSync(recordsDir, { recursive: true });
+		writeFileSync(
+			join(recordsDir, `${gateId}.json`),
+			JSON.stringify(gateRecord, null, 2),
+		);
+		// Advance with "reject" which maps to review_decision response "reject".
+		// This resolves the gate and transitions to "rejected" terminal state.
+		const result = runNodeCli(
+			"specflow-run",
+			["advance", runId, "reject"],
+			repoPath,
+		);
+		assert.equal(result.status, 0, result.stderr);
+		const events = readRunEvents(repoPath, runId);
+		const kinds = events.map((e) => e.event_kind);
+		// gate_rejected must be present (review_decision + reject → gate_rejected).
+		assert.ok(
+			kinds.includes("gate_rejected"),
+			`expected gate_rejected in events: ${kinds.join(", ")}`,
+		);
+		// gate_rejected must precede the phase_completed it causes.
+		// Use the LAST occurrence of phase_completed (from the reject transition),
+		// not the first one (from earlier advances).
+		const rejIdx = kinds.indexOf("gate_rejected");
+		const compIdx = kinds.lastIndexOf("phase_completed");
+		assert.ok(
+			compIdx === -1 || rejIdx < compIdx,
+			"gate_rejected must precede its caused phase_completed",
+		);
+		// gate_rejected must carry the gate_ref.
+		const rejEvent = events.find((e) => e.event_kind === "gate_rejected");
+		assert.equal(rejEvent?.gate_ref, gateId);
+		// Downstream phase/lifecycle events must also carry gate_ref.
+		for (const evt of events.slice(rejIdx + 1)) {
+			if (
+				evt.event_kind === "phase_completed" ||
+				evt.event_kind === "phase_entered" ||
+				evt.event_kind === "run_terminal"
+			) {
+				assert.equal(
+					evt.gate_ref,
+					gateId,
+					`${evt.event_kind} should carry gate_ref from causing review_decision gate`,
+				);
+			}
+		}
+		// run_terminal should be emitted since "rejected" is terminal.
+		assert.ok(
+			kinds.includes("run_terminal"),
+			"rejecting via review_decision gate should produce run_terminal",
+		);
+	} finally {
+		removeTempDir(tempRoot);
+	}
+});
+
+test("specflow-run start --run-kind synthetic writes run_started to events.jsonl", () => {
+	const tempRoot = makeTempDir("specflow-run-obs-synthetic-");
+	try {
+		const { repoPath } = createFixtureRepo(tempRoot);
+		const syntheticRunId = "synthetic-obs-test-1";
+		const result = runNodeCli(
+			"specflow-run",
+			["start", syntheticRunId, "--run-kind", "synthetic"],
+			repoPath,
+		);
+		assert.equal(result.status, 0, result.stderr);
+		const events = readRunEvents(repoPath, syntheticRunId);
+		assert.equal(events.length, 1);
+		assert.equal(events[0]?.event_kind, "run_started");
+		assert.equal(events[0]?.run_id, syntheticRunId);
+		assert.equal(events[0]?.sequence, 1);
 	} finally {
 		removeTempDir(tempRoot);
 	}

--- a/src/types/observation-events.ts
+++ b/src/types/observation-events.ts
@@ -1,0 +1,228 @@
+// Observation event types for the workflow-observation-events contract.
+//
+// This module defines the closed event catalog, the common envelope, and the
+// per-event payload schemas emitted by the workflow core on state change. See
+// openspec/specs/workflow-observation-events/spec.md for the authoritative
+// contract.
+
+/**
+ * The fifteen-member closed catalog of observation event kinds. `event_kind`
+ * is a flat discriminator; there is no separate category field.
+ */
+export type ObservationEventKind =
+	| "run_started"
+	| "run_suspended"
+	| "run_resumed"
+	| "run_terminal"
+	| "phase_entered"
+	| "phase_completed"
+	| "phase_blocked"
+	| "phase_reopened"
+	| "gate_opened"
+	| "gate_resolved"
+	| "gate_rejected"
+	| "artifact_written"
+	| "review_completed"
+	| "bundle_started"
+	| "bundle_completed";
+
+/** Closed list of event kinds — runtime-checkable. */
+export const OBSERVATION_EVENT_KINDS: readonly ObservationEventKind[] = [
+	"run_started",
+	"run_suspended",
+	"run_resumed",
+	"run_terminal",
+	"phase_entered",
+	"phase_completed",
+	"phase_blocked",
+	"phase_reopened",
+	"gate_opened",
+	"gate_resolved",
+	"gate_rejected",
+	"artifact_written",
+	"review_completed",
+	"bundle_started",
+	"bundle_completed",
+] as const;
+
+/** Single-cause reference; see spec's causal_context requirement. */
+export type CausalContext =
+	| null
+	| {
+			readonly kind: "user_event";
+			readonly ref: string;
+	  }
+	| {
+			readonly kind: "observation_event";
+			readonly ref: string;
+	  };
+
+// ---------------------------------------------------------------------------
+// Per-event payload schemas
+// ---------------------------------------------------------------------------
+
+export interface RunStartedPayload {
+	readonly source: {
+		readonly provider: string | null;
+		readonly reference: string | null;
+	};
+	readonly title: string | null;
+}
+
+export interface RunSuspendedPayload {
+	readonly reason: string;
+}
+
+export type RunResumedPayload = Record<string, never>;
+
+export interface RunTerminalPayload {
+	readonly status: "approved" | "decomposed" | "rejected";
+	readonly reason: string | null;
+}
+
+export interface PhaseEnteredPayload {
+	readonly triggered_event: string;
+}
+
+export interface PhaseCompletedPayload {
+	readonly outcome: "advanced" | "bypassed";
+}
+
+export interface PhaseBlockedPayload {
+	readonly reason: "gate_open" | "await_user" | "await_agent";
+}
+
+export interface PhaseReopenedPayload {
+	readonly reason: string;
+}
+
+export type GateKindForObservation = "approval" | "clarify" | "review_decision";
+
+export interface GateOpenedPayload {
+	readonly gate_kind: GateKindForObservation;
+}
+
+export interface GateResolvedPayload {
+	readonly resolution: "approved" | "answered" | "changes_requested";
+	readonly by_actor: string;
+}
+
+export interface GateRejectedPayload {
+	readonly resolution: "rejected";
+	readonly by_actor: string;
+	readonly reason: string | null;
+}
+
+export interface ArtifactWrittenPayload {
+	readonly path: string;
+	readonly bytes: number;
+	readonly content_hash: string | null;
+}
+
+export interface ReviewCompletedPayload {
+	readonly outcome: "approved" | "changes_requested" | "rejected";
+	readonly reviewer: string;
+	readonly score: number | null;
+}
+
+export interface BundleStartedPayload {
+	readonly bundle_kind: "review_bundle";
+	readonly artifact_count: number;
+}
+
+export interface BundleCompletedPayload {
+	readonly bundle_kind: "review_bundle";
+	readonly outcome: "approved" | "changes_requested" | "rejected";
+}
+
+/**
+ * Discriminated union of concrete observation events. Each variant pairs an
+ * `event_kind` with its payload schema.
+ */
+export type ObservationEventVariant =
+	| { readonly event_kind: "run_started"; readonly payload: RunStartedPayload }
+	| {
+			readonly event_kind: "run_suspended";
+			readonly payload: RunSuspendedPayload;
+	  }
+	| { readonly event_kind: "run_resumed"; readonly payload: RunResumedPayload }
+	| {
+			readonly event_kind: "run_terminal";
+			readonly payload: RunTerminalPayload;
+	  }
+	| {
+			readonly event_kind: "phase_entered";
+			readonly payload: PhaseEnteredPayload;
+	  }
+	| {
+			readonly event_kind: "phase_completed";
+			readonly payload: PhaseCompletedPayload;
+	  }
+	| {
+			readonly event_kind: "phase_blocked";
+			readonly payload: PhaseBlockedPayload;
+	  }
+	| {
+			readonly event_kind: "phase_reopened";
+			readonly payload: PhaseReopenedPayload;
+	  }
+	| { readonly event_kind: "gate_opened"; readonly payload: GateOpenedPayload }
+	| {
+			readonly event_kind: "gate_resolved";
+			readonly payload: GateResolvedPayload;
+	  }
+	| {
+			readonly event_kind: "gate_rejected";
+			readonly payload: GateRejectedPayload;
+	  }
+	| {
+			readonly event_kind: "artifact_written";
+			readonly payload: ArtifactWrittenPayload;
+	  }
+	| {
+			readonly event_kind: "review_completed";
+			readonly payload: ReviewCompletedPayload;
+	  }
+	| {
+			readonly event_kind: "bundle_started";
+			readonly payload: BundleStartedPayload;
+	  }
+	| {
+			readonly event_kind: "bundle_completed";
+			readonly payload: BundleCompletedPayload;
+	  };
+
+/**
+ * The common observation event envelope. All twelve fields are required on
+ * the wire (with explicit `null` where the per-event schema marks them as
+ * omitted). `payload` varies by `event_kind` per the discriminated union
+ * above. See workflow-observation-events spec for nullability rules.
+ */
+export interface ObservationEventEnvelope {
+	readonly event_id: string;
+	readonly event_kind: ObservationEventKind;
+	readonly run_id: string;
+	readonly change_id: string;
+	readonly sequence: number;
+	readonly timestamp: string;
+	readonly source_phase: string | null;
+	readonly target_phase: string | null;
+	readonly causal_context: CausalContext;
+	readonly gate_ref: string | null;
+	readonly artifact_ref: string | null;
+	readonly bundle_ref: string | null;
+}
+
+/** A fully-formed observation event: envelope fields plus variant payload. */
+export type ObservationEvent = ObservationEventEnvelope &
+	ObservationEventVariant;
+
+/** Narrowing guard for strings that name a catalog event kind. */
+export function isObservationEventKind(
+	value: unknown,
+): value is ObservationEventKind {
+	return (
+		typeof value === "string" &&
+		(OBSERVATION_EVENT_KINDS as readonly string[]).includes(value)
+	);
+}


### PR DESCRIPTION
## Summary

- Defines the `workflow-observation-events` capability: 15-kind closed event catalog (lifecycle / phase / gate / progress), 12-field common envelope, per-event payload schemas, per-run monotonic ordering, at-least-once + bit-identical re-emission, bounded replay subset.
- Adds ADDED requirement deltas in `workflow-run-state` and `workflow-gate-semantics` binding run-state transitions and gate lifecycle to the new contract.
- Ships a minimal local publisher: types + interface + append-only JSONL file adapter + CLI hooks in `specflow-run` (start / advance / suspend / resume).
- Disjoint from `surface-event-contract` (declarative observation vs. imperative surface commands). Transport, broker, history-retrieval, and progress event emission are explicitly non-goals.

## Test plan

- [x] 15 new unit tests covering catalog, envelope, sequence monotonicity, at-least-once idempotency, cause→effect ordering, bundle framing, suspend/resume flow
- [x] CLI integration tests exercising real `specflow-run start|advance|suspend|resume` + gate lifecycle
- [x] Full suite: **639 tests passing** (was 624)
- [x] `openspec validate --type change` passes cleanly
- [x] Smoke test: `specflow-run start` emits `run_started`; `advance` emits `phase_completed` + `phase_entered`; `suspend`/`resume` emit expected lifecycle events

## Known accepted risks (follow-up change)

- **R1-F01 (HIGH)**: Event emission sits outside the authoritative commit boundary — publisher failures warn-and-continue rather than abort. Acceptable for single-process CLI; a server runtime needs an atomic or recoverable commit protocol.
- **R6-F11 (HIGH)**: `review_decision` gate lifecycle is not yet emitted; only `approval` and `clarify` gates flow through the publisher today.
- **R6-F12 (MEDIUM)**: Post-commit event emission failures return inconsistent exit codes across commands.
- **Progress events deferred**: `artifact_written` / `review_completed` / `bundle_started` / `bundle_completed` are in the catalog but not yet emitted. Deferral is allowed by the spec (progress events SHALL NOT require a matching run-state transition).
- **`openspec archive` failed** due to the autofix loop having pre-populated the `workflow-observation-events` baseline. Baseline reconciliation is a follow-up task; deltas + baseline both live on this branch and will merge together.

## Issue

Closes https://github.com/skr19930617/specflow/issues/167