### PR TITLE
feat: present mainline terminal handoffs via AskUserQuestion blocks (#171)

### DIFF
--- a/assets/commands/specflow.apply.md.tmpl
+++ b/assets/commands/specflow.apply.md.tmpl
@@ -101,7 +101,36 @@ Report: `Step 1 complete — implementation completed in apply_draft`
    ```bash
    specflow-run advance "<RUN_ID>" apply_review_approved
    ```
-5. Only from `apply_ready`, offer `/specflow.approve`.
+5. Only from `apply_ready`, offer `/specflow.approve` using the AskUserQuestion block below:
+
+   **テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+   ```
+   ✅ Apply review approved — run is in `apply_ready`.
+
+   次のアクションを選択してください（テキスト入力またはボタンで回答）:
+   - **Approve に進む** → `/specflow.approve`
+   - **Fix ループへ** → `/specflow.fix_apply`
+   - **中止** → `/specflow.reject`
+   ```
+
+   **AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
+   ```
+   AskUserQuestion:
+     question: "Apply review 承認済み。次のアクションを選択してください"
+     options:
+       - label: "Approve に進む"
+         description: "/specflow.approve で archive・commit・push・PR 作成に進む"
+       - label: "Fix ループへ"
+         description: "/specflow.fix_apply で追加修正してから再レビュー"
+       - label: "中止"
+         description: "/specflow.reject で全変更を破棄して終了"
+   ```
+
+   **入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
+   - 「Approve に進む」 → `Skill(skill: "specflow.approve")`
+   - 「Fix ループへ」 → `Skill(skill: "specflow.fix_apply")`
+   - 「中止」 → `Skill(skill: "specflow.reject")`
 
 If the configured round cap is reached and findings remain, stop in place without an approve bypass.
 

--- a/assets/commands/specflow.design.md.tmpl
+++ b/assets/commands/specflow.design.md.tmpl
@@ -118,7 +118,32 @@ If any are incomplete, report which artifacts are missing and ask the user how t
    ```bash
    specflow-run advance "<RUN_ID>" design_review_approved
    ```
-5. Only from `design_ready`, offer `/specflow.apply`.
+5. Only from `design_ready`, offer `/specflow.apply` using the AskUserQuestion block below:
+
+   **テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+   ```
+   ✅ Design review approved — run is in `design_ready`.
+
+   次のアクションを選択してください（テキスト入力またはボタンで回答）:
+   - **Apply に進む** → `/specflow.apply`
+   - **中止** → `/specflow.reject`
+   ```
+
+   **AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
+   ```
+   AskUserQuestion:
+     question: "Design review 承認済み。次のアクションを選択してください"
+     options:
+       - label: "Apply に進む"
+         description: "/specflow.apply で実装を開始し、apply review ゲートに進む"
+       - label: "中止"
+         description: "/specflow.reject で全変更を破棄して終了"
+   ```
+
+   **入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
+   - 「Apply に進む」 → `Skill(skill: "specflow.apply")`
+   - 「中止」 → `Skill(skill: "specflow.reject")`
 
 Remove any path that allows `/specflow.apply` while findings remain.
 

--- a/assets/commands/specflow.md.tmpl
+++ b/assets/commands/specflow.md.tmpl
@@ -286,9 +286,30 @@ Strict gate rules:
 
 Only when the run is in `spec_ready`, offer the next action.
 
-Recommended handoff:
+**テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+```
+✅ Spec phase complete — run is in `spec_ready`.
+
+次のアクションを選択してください（テキスト入力またはボタンで回答）:
 - **Design に進む** → `/specflow.design`
 - **中止** → `/specflow.reject`
+```
+
+**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
+```
+AskUserQuestion:
+  question: "Spec phase 完了。次のアクションを選択してください"
+  options:
+    - label: "Design に進む"
+      description: "/specflow.design で design.md / tasks.md を生成し、review ゲートに進む"
+    - label: "中止"
+      description: "/specflow.reject で全変更を破棄して終了"
+```
+
+**入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
+- 「Design に進む」 → `Skill(skill: "specflow.design")`
+- 「中止」 → `Skill(skill: "specflow.reject")`
 
 Do not offer `/specflow.design` from `proposal_clarify`, `proposal_challenge`, `proposal_reclarify`, `spec_draft`, `spec_validate`, or `spec_verify`.
 

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/approval-summary.md
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/approval-summary.md
@@ -1,0 +1,79 @@
+# Approval Summary: ensure-askquestion-coverage-for-all-phase-transitions
+
+**Generated**: 2026-04-19T12:46:12Z
+**Branch**: ensure-askquestion-coverage-for-all-phase-transitions
+**Status**: ⚠️ 1 unresolved high (accepted_risk)
+
+## What Changed
+
+```
+ assets/commands/specflow.apply.md.tmpl          | 31 +++++++++-
+ assets/commands/specflow.design.md.tmpl         | 27 +++++++-
+ assets/commands/specflow.md.tmpl                | 23 ++++++-
+ src/tests/__snapshots__/specflow.apply.md.snap  | 31 +++++++++-
+ src/tests/__snapshots__/specflow.design.md.snap | 27 +++++++-
+ src/tests/__snapshots__/specflow.md.snap        | 23 ++++++-
+ src/tests/command-order.test.ts                 | 82 ++++++++++++++++++++++++-
+ 7 files changed, 237 insertions(+), 7 deletions(-)
+```
+
+## Files Touched
+
+- assets/commands/specflow.apply.md.tmpl
+- assets/commands/specflow.design.md.tmpl
+- assets/commands/specflow.md.tmpl
+- src/tests/__snapshots__/specflow.apply.md.snap
+- src/tests/__snapshots__/specflow.design.md.snap
+- src/tests/__snapshots__/specflow.md.snap
+- src/tests/command-order.test.ts
+
+## Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 0     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+### Impl Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 0     |
+| Unresolved high    | 0     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+(Both findings reclassified to `accepted_risk`: the spec delta and tasks entry exist in `openspec/changes/<id>/` which is untracked at review time, and `openspec archive` will promote them into baseline `openspec/specs/` and `openspec/archive/` at commit time.)
+
+## Proposal Coverage
+
+Spec deltas for this change define three scenarios plus a MODIFIED requirement. Mapping to changed files:
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | `specflow.md` spec_ready handoff presents `AskUserQuestion` block referencing `/specflow.design` and `/specflow.reject` | Yes | assets/commands/specflow.md.tmpl, src/tests/__snapshots__/specflow.md.snap, src/tests/command-order.test.ts |
+| 2 | `specflow.design.md` design_ready handoff presents `AskUserQuestion` block referencing `/specflow.apply` and `/specflow.reject` | Yes | assets/commands/specflow.design.md.tmpl, src/tests/__snapshots__/specflow.design.md.snap, src/tests/command-order.test.ts |
+| 3 | `specflow.apply.md` apply_ready handoff presents `AskUserQuestion` block referencing `/specflow.approve`, `/specflow.fix_apply`, `/specflow.reject` | Yes | assets/commands/specflow.apply.md.tmpl, src/tests/__snapshots__/specflow.apply.md.snap, src/tests/command-order.test.ts |
+| 4 | Utility and review-loop guides exempt (no regression) | Yes | (existing snapshots unchanged) |
+| 5 | MODIFIED `Mainline workflow guides encode strict phase gates` preserves every baseline scenario verbatim while requiring `AskUserQuestion` for terminal handoffs | Yes | openspec/changes/.../specs/slash-command-guides/spec.md (archive-time) |
+
+**Coverage Rate**: 5/5 (100%)
+
+## Remaining Risks
+
+- ⚠️ R1-F01: Normative OpenSpec delta is missing from the reviewed diff (severity: high, status: accepted_risk — resolved at archive time)
+- ⚠️ R1-F02: Required manual Claude Code UI verification is not captured (severity: medium, status: accepted_risk — already tracked in task-graph bundle `run-end-to-end-verification` task 3)
+- ⚠️ Manual Claude Code UI verification is not runnable from CI: operator must observe buttons at `spec_ready`, `design_ready`, and `apply_ready` in a fresh Claude Code session after the new `dist/` is installed.
+
+## Human Checkpoints
+
+- [ ] Run the install step (`specflow-install` or equivalent) so the updated `dist/package/global/commands/*.md` files reach your global Claude Code command directory, then verify buttons render at `spec_ready`, `design_ready`, and `apply_ready` in a new session.
+- [ ] Spot-check that existing review-loop guides (`/specflow.review_design`, `/specflow.review_apply`) still render their `_with_findings` and `_no_findings` options unchanged (no regression).
+- [ ] Confirm that `openspec archive` promoted the spec delta into baseline `openspec/specs/slash-command-guides/spec.md` and that the MODIFIED scenarios survived verbatim.
+- [ ] Review the commit for any unintended inclusion of untracked files (the approval flow stages everything with `git add -A`).

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/current-phase.md
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/current-phase.md
@@ -1,0 +1,13 @@
+# Current Phase: ensure-askquestion-coverage-for-all-phase-transitions
+
+- Phase: impl-review
+- Round: 1
+- Status: has_open_high
+- Open High/Critical Findings: 1 件 — "Normative OpenSpec delta is missing from the reviewed diff"
+- Actionable Findings: 2
+- Accepted Risks: none
+- Latest Changes:
+  - 9ad8871 feat: define workflow event semantics for state change, gate resolution, and progress observation (#167)
+  - 528028d chore: formatter whitespace cleanup in review-cli.test.ts
+  - 82d5792 feat: define gate semantics for approval, clarify, and review decisions as persistent workflow objects (#166)
+- Next Recommended Action: /specflow.fix_apply

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/design.md
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/design.md
@@ -1,0 +1,196 @@
+## Context
+
+specflow slash-commands are Markdown guides that Claude Code reads at runtime. When a guide wants Claude Code to present the operator with a clickable choice, it must embed a pseudo-block of the form `AskUserQuestion:` + YAML-like options. At runtime the agent interprets that block and calls the real `AskUserQuestion` tool, which renders buttons in the Claude Code UI.
+
+The three mainline workflow commands currently end their terminal phase with prose-only handoff text:
+
+- `assets/commands/specflow.md.tmpl` Step 9 "Design Handoff" (`spec_ready` → `/specflow.design`) — lines 285–293.
+- `assets/commands/specflow.design.md.tmpl` Step 4 (`design_ready` → `/specflow.apply`) — line 121.
+- `assets/commands/specflow.apply.md.tmpl` Step 2 (`apply_ready` → `/specflow.approve`) — line 104.
+
+Because no `AskUserQuestion:` block is emitted, the UI shows no button and the operator must type the next slash command by hand. GitHub issue #171 reports this at `spec_ready`. The same gap exists at `design_ready` and `apply_ready`.
+
+Review-loop and utility commands already use `AskUserQuestion:` blocks correctly (`specflow.review_design.md.tmpl`, `specflow.review_apply.md.tmpl`, `specflow.decompose.md.tmpl`, `specflow.spec.md.tmpl`, etc.) and are out of scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Claude Code renders clickable buttons at the three mainline terminal-handoff transitions without requiring the operator to type slash commands by hand.
+- The `slash-command-guides` spec encodes the presence of the `AskUserQuestion` block and the required set of slash-command targets at those transitions, so future regressions are caught by existing structural tests.
+- Manual UI verification is documented in `tasks.md` so the fix is observed, not just asserted structurally.
+- Changes preserve every existing scenario in the `slash-command-guides` spec (only additions and one tightening).
+
+**Non-Goals:**
+
+- Do NOT change the workflow state machine (`canonical-workflow-state`), phase-contract registries, or run-state CLI semantics.
+- Do NOT modify review-loop command guides that already emit `AskUserQuestion:` blocks.
+- Do NOT prescribe exact button labels or option ordering in the spec; those are intentionally left to templates so copy can evolve without spec churn.
+- Do NOT add cross-tool compatibility constraints (Cursor, Codex CLI, etc.); Claude Code UI is the only validated consumer.
+- Do NOT introduce a new `terminalHandoff` metadata field on `commandContracts` — the runtime is template-driven and the renderer passes `AskUserQuestion:` blocks through verbatim, so TS-side changes are not required (see Decisions).
+
+## Decisions
+
+### Decision 1: Fix is a pure template change; no renderer changes required
+
+**Decision:** Add `AskUserQuestion:` blocks directly inside the existing terminal-step sections of the three `.md.tmpl` files. Do not modify TypeScript renderer / template-resolver code.
+
+**Rationale:** `src/contracts/template-resolver.ts` replaces only `{{insert|contract|render:}}` tags and splits on `## headings`; all other prose (including `AskUserQuestion:` pseudo-blocks) is copied through verbatim into `dist/package/global/commands/*.md`. The review-loop templates already rely on this behavior, so the mechanism is proven.
+
+**Alternatives considered:**
+
+- *Add a `terminalHandoff` field to `commandContracts` and have the renderer inject the block automatically.* Rejected: (a) increases blast radius across `src/contracts/`, `src/build.ts`, and test snapshots; (b) option wording is currently Japanese, which templates capture more naturally than contracts; (c) the existing review-loop commands prove the template-level approach works.
+- *Delete the prose and put the block in a new `Skill`-invoked flow.* Rejected: Step 9 in `/specflow` intentionally closes the command there and hands off; injecting an extra skill would change control flow for no UI benefit.
+
+### Decision 2: `AskUserQuestion:` block format matches the review-loop convention
+
+**Decision:** Use the existing block syntax already used in `specflow.review_design.md.tmpl` and `specflow.review_apply.md.tmpl`:
+
+```
+AskUserQuestion:
+  question: "<prompt>"
+  options:
+    - label: "<label>"
+      description: "<short description>"
+```
+
+Blocks SHALL continue to be written in Japanese, matching existing templates, until/unless a broader i18n pass is proposed separately.
+
+**Rationale:** Keeps a single idiom across all specflow guides and avoids one-off stylistic variation.
+
+### Decision 3: Include and exclude sets for the new requirement
+
+**Decision:** The new `slash-command-guides` requirement applies only to mainline terminal-handoff phases (`spec_ready`, `design_ready`, `apply_ready`). Utility commands (`specflow.reject`, `specflow.dashboard`, `specflow.setup`, `specflow.explore`, `specflow.spec`, `specflow.license`, `specflow.readme`) and review-loop commands (`specflow.review_*`, `specflow.fix_*`) are explicitly exempt in the spec text.
+
+**Rationale:** The reported defect is about transitions where the operator must pick the next mainline slash command. Review-loop commands already satisfy the behavior via their own per-state handoff blocks. Utility commands don't participate in the mainline flow.
+
+**Alternatives considered:**
+
+- *Require `AskUserQuestion` at every transition, including internal ones.* Rejected: would turn internal phase advances (e.g., `proposal_clarify → proposal_challenge`) into interactive gates and break auto-driven flows.
+
+### Decision 4: Spec asserts block presence + slash-command targets; not wording
+
+**Decision:** The new scenario set in `slash-command-guides` asserts (a) that an `AskUserQuestion:` block exists in the relevant generated file near the terminal phase, and (b) that the `options` array contains slash-command references to the expected targets (e.g., `/specflow.design`, `/specflow.reject`). It does NOT fix exact labels, ordering, or descriptions.
+
+**Rationale:** Labels may evolve (translation, copy polish, adding severity suffixes). Locking wording in the spec would cause spec churn. The set-of-targets contract is the behavior-relevant invariant; labels are UX polish.
+
+**Alternatives considered:**
+
+- *Full-text scenarios with exact strings.* Rejected: too brittle for a copy-heavy Markdown file.
+- *Presence-only scenarios.* Rejected: would allow a regression that swaps `/specflow.design` for some unrelated target without detection.
+
+### Decision 5: Structural tests live in existing `command-order.test.ts`
+
+**Decision:** Extend `src/tests/command-order.test.ts` to add fragments like `AskUserQuestion:`, `/specflow.design`, `/specflow.reject` into the ordered-fragment lists for the three generated files. No new test file is required.
+
+**Rationale:** The existing test harness already reads each generated `.md` and asserts ordered fragments; adding a few more strings is the smallest-diff path. The `command-order.test.ts` file is where analogous contracts (archive order, approve-gate fragments) are already enforced.
+
+### Decision 6: Manual UI verification recorded in tasks.md
+
+**Decision:** `tasks.md` includes a terminal manual-verification task with three checks — open a Claude Code session, drive each of the three transitions, and visually confirm buttons render. This task is marked explicitly non-automated.
+
+**Rationale:** Structural tests cannot detect UI rendering regressions in Claude Code itself (e.g., a Claude Code change that ignored our block syntax). A one-time manual check gives confidence that the user-visible behavior is correct before closing the change.
+
+## Risks / Trade-offs
+
+- **Risk:** A future refactor renames the `AskUserQuestion:` pseudo-block syntax or the agent stops recognizing it. → **Mitigation:** The review-loop templates use the same syntax and have visible UI integration; a syntax-level break would surface immediately there. Adding the three new call sites doesn't increase this risk beyond the existing baseline.
+
+- **Risk:** Labels drift from the contract captured in the spec (e.g., someone renames `/specflow.design` or `/specflow.reject`). → **Mitigation:** The new scenarios assert slash-command targets explicitly, and the regeneration + ordered-fragments test will fail.
+
+- **Risk:** Some operators rely on the current prose-only list as a reference (they read the guide as documentation). → **Mitigation:** Decision 1 keeps prose alongside the block; the spec only forbids prose-only handoffs, not prose as a supplement.
+
+- **Risk:** Snapshot tests (`src/tests/__snapshots__/specflow.md.snap`, etc.) will need regeneration after the template change. → **Mitigation:** Run `npm test -- -u` or the project's snapshot-update command as part of the apply phase; include a task for it.
+
+- **Trade-off:** The spec intentionally does not pin exact wording or option order, so the UX can evolve without spec churn but the spec gives weaker protection against label regressions. Accepted — label regressions are detectable by structural tests anyway.
+
+## Migration Plan
+
+1. Update the three `.md.tmpl` files under `assets/commands/` to add `AskUserQuestion:` blocks at the terminal-handoff steps.
+2. Run the build pipeline so `dist/package/global/commands/specflow.md`, `specflow.design.md`, and `specflow.apply.md` are regenerated.
+3. Update `src/tests/command-order.test.ts` with the new required fragments.
+4. Update any affected snapshot files under `src/tests/__snapshots__/` (re-record if needed).
+5. Run the full test suite and verify green.
+6. Manually verify in a Claude Code session: drive one end-to-end run (or three mini-runs) and confirm buttons appear at `spec_ready`, `design_ready`, `apply_ready`.
+7. Archive the change via `/specflow.approve`.
+
+Rollback: revert the template edits. The change is additive, so reverting does not leave artifacts in an inconsistent state.
+
+## Open Questions
+
+- None. The reclarify phase resolved the scope, contract, renderer-in-scope, validation-depth, and consumer-compatibility questions.
+
+## Concerns
+
+Each concern below is a user-facing slice that maps to a handoff transition affected by issue #171:
+
+1. **spec_ready handoff button** — after `/specflow` completes the spec phase, the operator sees no button to proceed to design.
+2. **design_ready handoff button** — after `/specflow.design` completes design + review, the operator sees no button to proceed to apply.
+3. **apply_ready handoff button** — after `/specflow.apply` completes implementation + review, the operator sees no button to proceed to approve / fix / reject.
+4. **spec-level regression protection** — without a spec requirement, future template edits could silently drop the blocks again.
+5. **manual UI observation** — the automated tests assert structure, not UI rendering; an operator must actually see the buttons at least once.
+
+## State / Lifecycle
+
+**Canonical state:** The run-state `current_phase` (persisted by `specflow-run`) is the authoritative signal for when a handoff is reachable. No new run-state transitions or phases are introduced.
+
+**Derived state:** The Claude Code UI "has a button available" state is derived solely from the agent calling `AskUserQuestion` — which is triggered by the agent reading the `AskUserQuestion:` pseudo-block in the guide. There is no other derived state.
+
+**Lifecycle boundaries:** Each handoff block lives inside the terminal step of its command guide and is reached exactly once per command invocation. On operator selection, control passes to the next command (`/specflow.design`, `/specflow.apply`, `/specflow.approve`, `/specflow.fix_apply`, or `/specflow.reject`), which starts its own lifecycle.
+
+**Persistence-sensitive state:** None. The handoff is a UI choice; operator selection causes a new slash-command invocation which then advances `current_phase` via its own `specflow-run advance` calls.
+
+## Contracts / Interfaces
+
+**ui (Claude Code):** The generated `.md` files are the interface. Claude Code reads a guide, encounters `AskUserQuestion:`, and calls the `AskUserQuestion` tool. The contract is the pseudo-block syntax already used by review-loop commands.
+
+**api / persistence:** None newly defined. `specflow-run` CLI and `canonical-workflow-state` spec are unchanged.
+
+**renderer:** `src/contracts/template-resolver.ts` passes all non-tagged content through verbatim, including `AskUserQuestion:` blocks. This contract is already in effect; no renderer-side interface change.
+
+**external services:** None.
+
+Inputs that other bundles depend on:
+
+- The `.md.tmpl` templates are inputs to the build pipeline (`src/build.ts`).
+- The generated `.md` files are inputs to the `command-order.test.ts` and snapshot tests.
+
+## Persistence / Ownership
+
+- `assets/commands/*.md.tmpl` — owned by the templates bundle; edited directly in this change.
+- `dist/package/global/commands/*.md` — owned by the build pipeline; regenerated from templates.
+- `openspec/specs/slash-command-guides/spec.md` — owned by the spec bundle; modified via delta in `openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/specs/slash-command-guides/spec.md`.
+- `src/tests/command-order.test.ts` — owned by the tests bundle; extended with new fragment assertions.
+- `src/tests/__snapshots__/specflow.md.snap`, `specflow.design.md.snap`, `specflow.apply.md.snap` — regenerated from templates.
+
+No data ownership boundaries are crossed or redefined.
+
+## Integration Points
+
+- **Build pipeline (`src/build.ts`):** Regenerates `dist/package/global/commands/*.md` from the edited templates. Triggered by the standard build command.
+- **Test suite (`src/tests/command-order.test.ts`, snapshot tests):** Asserts generated-file structure after build.
+- **Claude Code UI:** Interprets `AskUserQuestion:` blocks at runtime; integration verified manually.
+
+No retry, save/restore, or regeneration boundaries are affected.
+
+## Ordering / Dependency Notes
+
+1. Template edits (`specflow.md.tmpl`, `specflow.design.md.tmpl`, `specflow.apply.md.tmpl`) — independent of each other; can be done in parallel.
+2. Spec delta update — already completed in the spec phase; this change only extends the delta when the design moves into implementation.
+3. Regenerate `dist/` — depends on templates being edited.
+4. Test updates (`command-order.test.ts`) — depends on knowing final block structure; safe to write alongside template edits.
+5. Snapshot regeneration — depends on `dist/` and tests being ready.
+6. Manual UI verification — depends on all of the above being merged / available locally.
+
+Foundational: template edits. Parallelizable: the three template edits. Sequential: regenerate → tests → snapshots → UI check.
+
+## Completion Conditions
+
+The change is complete when **all** of the following hold:
+
+- The three `.md.tmpl` templates contain `AskUserQuestion:` blocks at the terminal-handoff steps with option sets referencing the required slash-command targets.
+- `dist/package/global/commands/specflow.md`, `specflow.design.md`, `specflow.apply.md` contain the corresponding blocks after a clean build.
+- `src/tests/command-order.test.ts` passes with the new fragments and asserts presence of `AskUserQuestion:` + each required slash-command target in each file.
+- All snapshot tests pass.
+- `openspec validate ensure-askquestion-coverage-for-all-phase-transitions --type change` returns valid.
+- A manual Claude Code run observes buttons at `spec_ready`, `design_ready`, and `apply_ready`.
+- `tasks.md` marks each task as `done` (or `skipped` with justification for the N/A tasks, if any).

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/proposal.md
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Several mainline specflow slash-command guides end their terminal phase in prose ("recommended handoff: design に進む / 中止") instead of presenting the next-step options through an `AskUserQuestion` block. Because no structured question is emitted, the Claude Code UI does not render clickable buttons for the handoff choice, so users must type the slash command manually. The reported failure mode is at `spec_ready` — after `/specflow` finishes, no button to run `/specflow.design` appears (GitHub issue #171). The same gap exists at the end of `/specflow.design` (`design_ready` → `/specflow.apply`) and `/specflow.apply` (`apply_ready` → `/specflow.approve`).
+
+Source: https://github.com/skr19930617/specflow/issues/171
+
+## Definitions
+
+**Mainline terminal-handoff phase**: A terminal gate phase in the mainline workflow's run-state machine (defined by the `canonical-workflow-state` spec) where the run halts and the operator must choose the next slash-command to run. The authoritative set for this change is:
+
+- `spec_ready` — handed off by `/specflow`
+- `design_ready` — handed off by `/specflow.design`
+- `apply_ready` — handed off by `/specflow.apply`
+
+Review-loop intermediate states (`review_with_findings`, `loop_with_findings`, etc.) are outside this definition because they are already handled by `/specflow.review_*` guides with explicit `AskUserQuestion` blocks.
+
+## What Changes
+
+- Require each mainline command guide that leaves the run in a terminal-handoff phase (as defined above) to present its next-step options via an `AskUserQuestion` block, not prose-only text.
+- Apply this rule to the three broken guides and their templates:
+  - `/specflow` at `spec_ready` → options include `/specflow.design` (proceed) and `/specflow.reject` (abort)
+  - `/specflow.design` at `design_ready` → options include `/specflow.apply` (proceed) and `/specflow.reject` (abort)
+  - `/specflow.apply` at `apply_ready` → options include `/specflow.approve` (proceed), `/specflow.fix_apply` (fix loop), and `/specflow.reject` (abort)
+- Extend the `slash-command-guides` spec with a requirement covering mainline terminal-handoff phases. The spec SHALL assert the **presence of an `AskUserQuestion` block** and the **set of slash-command targets** referenced by its options. Exact wording and option order are left to the templates (not normative in the spec) so they can evolve without spec churn.
+- Allow explanatory prose to coexist with the `AskUserQuestion` block (useful for the "読み物として読まれた場合" fallback and for template maintainers) — the spec only forbids prose-only handoffs.
+- Update TypeScript-side template-merge / renderer logic in `src/` if and only if experimentation during design shows that current rendering drops or rewrites `AskUserQuestion` blocks. Confirmed in scope for this proposal.
+- Accept Claude Code UI as the only validated consumer of the generated guides. No cross-tool compatibility constraints are added.
+- Validation for this change: (a) automated structural tests assert the `AskUserQuestion` block and target slash-commands in the three generated files; (b) a manual UI-verification checklist item is added to `tasks.md` — run each transition in a Claude Code session and visually confirm that buttons appear.
+
+Out of scope: review-loop guides (`/specflow.review_design`, `/specflow.review_apply`, `/specflow.fix_design`, `/specflow.fix_apply`) already present `AskUserQuestion` blocks and remain unchanged. Utility/cleanup guides (`/specflow.reject`, `/specflow.dashboard`, `/specflow.setup`, `/specflow.explore`, `/specflow.spec`, `/specflow.license`, `/specflow.readme`) do not reach a mainline terminal-handoff phase and remain exempt.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `slash-command-guides`: Add the contract that each mainline terminal-handoff phase (`spec_ready`, `design_ready`, `apply_ready`) is presented via an `AskUserQuestion` block in its generated guide, with scenarios asserting that the required set of slash-command targets appears in the options. Update the per-command handoff scenarios for `specflow`, `specflow.design`, and `specflow.apply` to replace the prose-only handoff text with the structured block.
+
+## Impact
+
+- Source templates updated: `assets/commands/specflow.md.tmpl`, `assets/commands/specflow.design.md.tmpl`, `assets/commands/specflow.apply.md.tmpl`.
+- Generated outputs regenerated: `dist/package/global/commands/specflow.md`, `specflow.design.md`, `specflow.apply.md`.
+- TypeScript-side rendering code in `src/` (template merge, `renderPhaseMarkdown`, or equivalents) may be adjusted to preserve `AskUserQuestion` blocks verbatim; confirmed in scope and finalized in `design.md`.
+- Structural tests under the `slash-command-guides` suite extended to assert the `AskUserQuestion` block and target slash-commands in the three generated files.
+- `tasks.md` includes a manual UI-verification task for the three transitions in Claude Code.
+- No changes to workflow state machine semantics, run-state CLI contracts, or phase-contract registries.

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/review-ledger-design.json
@@ -1,0 +1,19 @@
+{
+  "feature_id": "ensure-askquestion-coverage-for-all-phase-transitions",
+  "phase": "design",
+  "current_round": 1,
+  "status": "all_resolved",
+  "max_finding_id": 0,
+  "findings": [],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 0,
+      "open": 0,
+      "new": 0,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {}
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/review-ledger.json
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/review-ledger.json
@@ -1,0 +1,51 @@
+{
+  "feature_id": "ensure-askquestion-coverage-for-all-phase-transitions",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 2,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/specs/slash-command-guides/spec.md",
+      "title": "Normative OpenSpec delta is missing from the reviewed diff",
+      "detail": "The proposal requires extending `slash-command-guides` so the `AskUserQuestion` requirement for the `spec_ready`, `design_ready`, and `apply_ready` handoffs is part of the spec contract. The current diff only updates templates, snapshots, and tests; it does not include the change-spec file, so the implementation is not complete against the accepted proposal. Add the OpenSpec delta to the committed change.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "accepted_risk",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "Accepted-risk by operator: the spec delta file exists at openspec/changes/.../specs/slash-command-guides/spec.md but is untracked. /specflow.approve will run openspec archive which promotes the delta into baseline openspec/specs/slash-command-guides/spec.md and commits that change. Reviewer only saw tracked-file git diff, hence the false-positive observation."
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "testing",
+      "file": "openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/tasks.md",
+      "title": "Required manual Claude Code UI verification is not captured",
+      "detail": "The proposal’s validation section explicitly requires a `tasks.md` checklist item to manually verify that Claude Code renders buttons at `spec_ready`, `design_ready`, and `apply_ready`. The diff adds automated structural tests, but it does not include the corresponding task-tracking update, so part of the acceptance plan is missing from the implementation artifacts.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "accepted_risk",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "Accepted-risk by operator: task-graph.json bundle 'run-end-to-end-verification' task id 3 already captures 'Manually drive spec_ready, design_ready, and apply_ready in Claude Code and confirm clickable buttons appear at each handoff' and is tracked in tasks.md via the regenerated rendering. File is untracked so reviewer did not observe it."
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/specs/slash-command-guides/spec.md
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/specs/slash-command-guides/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: Mainline terminal-handoff phases SHALL present next-step options via AskUserQuestion
+
+Generated slash-command guides for the mainline workflow SHALL, whenever a command's flow leaves the run in a mainline terminal-handoff phase, present the next-step choice to the operator through an `AskUserQuestion` block rather than prose-only text.
+
+The mainline terminal-handoff phases for this requirement are exactly:
+
+- `spec_ready` — terminal phase of `/specflow`
+- `design_ready` — terminal phase of `/specflow.design`
+- `apply_ready` — terminal phase of `/specflow.apply`
+
+For each of those phases, the `AskUserQuestion` block in the corresponding generated guide SHALL reference the following slash-command targets in its option set (labels and option order are not normative):
+
+- `spec_ready` in `specflow.md` SHALL reference `/specflow.design` and `/specflow.reject`.
+- `design_ready` in `specflow.design.md` SHALL reference `/specflow.apply` and `/specflow.reject`.
+- `apply_ready` in `specflow.apply.md` SHALL reference `/specflow.approve`, `/specflow.fix_apply`, and `/specflow.reject`.
+
+Explanatory prose MAY coexist with the `AskUserQuestion` block, but prose-only handoffs SHALL NOT satisfy this requirement.
+
+Review-loop guides (`specflow.review_design.md`, `specflow.review_apply.md`, `specflow.fix_design.md`, `specflow.fix_apply.md`) are NOT governed by this requirement; they remain governed by the existing review-loop handoff requirements.
+
+#### Scenario: Proposal guide presents spec_ready handoff via AskUserQuestion
+
+- **WHEN** generated `specflow.md` is read
+- **THEN** the section that offers the next step after the run reaches `spec_ready` SHALL contain an `AskUserQuestion` block
+- **AND** that block's options SHALL reference both `/specflow.design` and `/specflow.reject`
+- **AND** the section SHALL NOT describe the handoff using prose-only text (for example, a bullet list of "recommended handoffs") in place of the `AskUserQuestion` block
+
+#### Scenario: Design guide presents design_ready handoff via AskUserQuestion
+
+- **WHEN** generated `specflow.design.md` is read
+- **THEN** the section that offers the next step after the run reaches `design_ready` SHALL contain an `AskUserQuestion` block
+- **AND** that block's options SHALL reference both `/specflow.apply` and `/specflow.reject`
+- **AND** the section SHALL NOT describe the handoff using prose-only text in place of the `AskUserQuestion` block
+
+#### Scenario: Apply guide presents apply_ready handoff via AskUserQuestion
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** the section that offers the next step after the run reaches `apply_ready` SHALL contain an `AskUserQuestion` block
+- **AND** that block's options SHALL reference `/specflow.approve`, `/specflow.fix_apply`, and `/specflow.reject`
+- **AND** the section SHALL NOT describe the handoff using prose-only text in place of the `AskUserQuestion` block
+
+#### Scenario: Utility and review-loop guides are exempt
+
+- **WHEN** generated `specflow.reject.md`, `specflow.dashboard.md`, `specflow.setup.md`, `specflow.explore.md`, `specflow.spec.md`, `specflow.license.md`, `specflow.readme.md`, `specflow.review_design.md`, `specflow.review_apply.md`, `specflow.fix_design.md`, or `specflow.fix_apply.md` is read
+- **THEN** this requirement SHALL NOT be evaluated against them
+- **AND** those guides SHALL continue to be governed only by the existing requirements that apply to them
+
+## MODIFIED Requirements
+
+### Requirement: Mainline workflow guides encode strict phase gates
+
+The generated guides for the main slash-command workflow SHALL encode the
+current phase order and SHALL not document bypasses around the implemented
+gates. Guides SHALL present mainline terminal-handoff options via
+`AskUserQuestion` blocks rather than prose-only text per the
+"Mainline terminal-handoff phases SHALL present next-step options via
+AskUserQuestion" requirement.
+
+#### Scenario: Proposal guide materializes local proposal artifacts before run start
+
+- **WHEN** generated `specflow.md` is read
+- **THEN** it SHALL include
+  `specflow-prepare-change [<CHANGE_ID>] <raw-input>`
+- **AND** it SHALL NOT require the caller to write a temp file before invoking
+  `specflow-prepare-change`
+- **AND** it SHALL document writing `openspec/changes/<CHANGE_ID>/proposal.md`
+  before `specflow-run start`
+- **AND** it SHALL include `specflow-run advance "<RUN_ID>" propose`
+
+#### Scenario: Proposal guide drafts and validates spec deltas before design
+
+- **WHEN** generated `specflow.md` is read
+- **THEN** it SHALL place `openspec instructions specs --change "<CHANGE_ID>" --json`
+  before `openspec validate "<CHANGE_ID>" --type change --json`
+- **AND** it SHALL include `specflow-run advance "<RUN_ID>" validate_spec`
+- **AND** it SHALL include a distinct step that runs after `spec_validated`
+  and before `spec_ready`, driven by `specflow-spec-verify` and advanced via
+  `specflow-run advance "<RUN_ID>" spec_verified`
+- **AND** it SHALL not offer `/specflow.design` before the run reaches
+  `spec_ready`
+
+#### Scenario: Design starts from spec_ready and enters review directly
+
+- **WHEN** generated `specflow.design.md` is read
+- **THEN** it SHALL describe `spec_ready` as the entry phase
+- **AND** it SHALL enter the design review gate with
+  `specflow-run advance "<RUN_ID>" review_design`
+- **AND** it SHALL not document `openspec validate "<CHANGE_ID>" --type change --json`
+
+#### Scenario: Apply gates approval behind apply_ready
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** it SHALL enter the apply review gate with
+  `specflow-run advance "<RUN_ID>" review_apply`
+- **AND** it SHALL only offer `/specflow.approve` after
+  `specflow-run advance "<RUN_ID>" apply_review_approved`
+- **AND** the gate to issue `apply_review_approved` SHALL depend solely on the
+  HIGH+ severity gate (i.e., zero findings whose `severity ∈ {critical, high}`
+  and `status ∈ {new, open}`); LOW / MEDIUM findings alone SHALL NOT block
+  `apply_review_approved`
+
+#### Scenario: Approve keeps archive before commit
+
+- **WHEN** generated `specflow.approve.md` is read
+- **THEN** it SHALL order the `Archive`, `Commit`, and `Push & Pull Request`
+  sections in that sequence

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/task-graph.json
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/task-graph.json
@@ -1,0 +1,217 @@
+{
+  "version": "1.0",
+  "change_id": "ensure-askquestion-coverage-for-all-phase-transitions",
+  "bundles": [
+    {
+      "id": "add-mainline-handoff-question-blocks",
+      "title": "Add Mainline Handoff Question Blocks",
+      "goal": "Add AskUserQuestion blocks to the three mainline terminal handoffs while preserving the existing prose guidance.",
+      "depends_on": [],
+      "inputs": [
+        "design.md",
+        "assets/commands/specflow.md.tmpl",
+        "assets/commands/specflow.design.md.tmpl",
+        "assets/commands/specflow.apply.md.tmpl",
+        "assets/commands/specflow.review_design.md.tmpl",
+        "assets/commands/specflow.review_apply.md.tmpl"
+      ],
+      "outputs": [
+        "assets/commands/specflow.md.tmpl",
+        "assets/commands/specflow.design.md.tmpl",
+        "assets/commands/specflow.apply.md.tmpl"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Add an AskUserQuestion block to specflow step 9 for the spec_ready handoff with /specflow.design and /specflow.reject targets.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Add an AskUserQuestion block to specflow.design step 4 for the design_ready handoff with /specflow.apply and /specflow.reject targets.",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Add an AskUserQuestion block to specflow.apply step 2 for the apply_ready handoff with /specflow.approve, /specflow.fix_apply, and /specflow.reject targets.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "slash-command-guides",
+        "command-template-authoring"
+      ]
+    },
+    {
+      "id": "align-openspec-change-artifacts",
+      "title": "Align OpenSpec Change Artifacts",
+      "goal": "Ensure the change spec and task checklist encode the new handoff contract and required manual verification steps.",
+      "depends_on": [],
+      "inputs": [
+        "design.md",
+        "openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/specs/slash-command-guides/spec.md",
+        "openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/tasks.md"
+      ],
+      "outputs": [
+        "openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/specs/slash-command-guides/spec.md",
+        "openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/tasks.md"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Tighten the slash-command-guides change delta so mainline terminal handoffs require AskUserQuestion blocks and the correct slash-command target sets, with review-loop and utility exemptions preserved.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Update tasks.md to track build, structural test, snapshot, openspec validation, and non-automated Claude Code UI verification work for this change.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "slash-command-guides",
+        "task-planner",
+        "spec-consistency-verification"
+      ]
+    },
+    {
+      "id": "regenerate-distributed-command-guides",
+      "title": "Regenerate Distributed Command Guides",
+      "goal": "Rebuild the generated slash-command guides so the distributed artifacts include the new handoff blocks.",
+      "depends_on": [
+        "add-mainline-handoff-question-blocks"
+      ],
+      "inputs": [
+        "assets/commands/specflow.md.tmpl",
+        "assets/commands/specflow.design.md.tmpl",
+        "assets/commands/specflow.apply.md.tmpl",
+        "src/build.ts"
+      ],
+      "outputs": [
+        "dist/package/global/commands/specflow.md",
+        "dist/package/global/commands/specflow.design.md",
+        "dist/package/global/commands/specflow.apply.md"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Run the standard build pipeline to regenerate the three distributed command guides from the updated templates.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Inspect the regenerated guides to confirm each terminal handoff contains an AskUserQuestion block with the expected slash-command targets.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "command-template-authoring",
+        "contract-driven-distribution"
+      ]
+    },
+    {
+      "id": "extend-structural-regression-coverage",
+      "title": "Extend Structural Regression Coverage",
+      "goal": "Update structural tests and snapshots so regressions in mainline handoff question blocks are caught automatically.",
+      "depends_on": [
+        "add-mainline-handoff-question-blocks",
+        "regenerate-distributed-command-guides",
+        "align-openspec-change-artifacts"
+      ],
+      "inputs": [
+        "design.md",
+        "dist/package/global/commands/specflow.md",
+        "dist/package/global/commands/specflow.design.md",
+        "dist/package/global/commands/specflow.apply.md",
+        "src/tests/command-order.test.ts",
+        "src/tests/__snapshots__/specflow.md.snap",
+        "src/tests/__snapshots__/specflow.design.md.snap",
+        "src/tests/__snapshots__/specflow.apply.md.snap"
+      ],
+      "outputs": [
+        "src/tests/command-order.test.ts",
+        "src/tests/__snapshots__/specflow.md.snap",
+        "src/tests/__snapshots__/specflow.design.md.snap",
+        "src/tests/__snapshots__/specflow.apply.md.snap"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Extend command-order.test.ts with ordered fragments for AskUserQuestion and each required slash-command target in the three generated guides.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Regenerate the affected snapshot files for specflow.md, specflow.design.md, and specflow.apply.md.",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Run the relevant structural and snapshot tests to verify the new coverage passes against the regenerated output.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "slash-command-guides",
+        "spec-consistency-verification"
+      ]
+    },
+    {
+      "id": "run-end-to-end-verification",
+      "title": "Run End-to-End Verification",
+      "goal": "Validate the change, observe the Claude Code UI behavior directly, and close out the change checklist.",
+      "depends_on": [
+        "align-openspec-change-artifacts",
+        "regenerate-distributed-command-guides",
+        "extend-structural-regression-coverage"
+      ],
+      "inputs": [
+        "openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/tasks.md",
+        "dist/package/global/commands/specflow.md",
+        "dist/package/global/commands/specflow.design.md",
+        "dist/package/global/commands/specflow.apply.md",
+        "src/tests/command-order.test.ts"
+      ],
+      "outputs": [
+        "openspec/changes/ensure-askquestion-coverage-for-all-phase-transitions/tasks.md",
+        "validation: openspec validate ensure-askquestion-coverage-for-all-phase-transitions --type change",
+        "verification: full test suite green",
+        "verification: Claude Code buttons observed at spec_ready, design_ready, and apply_ready"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Run openspec validate ensure-askquestion-coverage-for-all-phase-transitions --type change and resolve any remaining contract drift.",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Run the full test suite and confirm the change is green end-to-end.",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Manually drive spec_ready, design_ready, and apply_ready in Claude Code and confirm clickable buttons appear at each handoff.",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Mark the change tasks complete in tasks.md, including the manual verification outcome.",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "slash-command-guides",
+        "spec-consistency-verification",
+        "task-planner"
+      ]
+    }
+  ],
+  "generated_at": "2026-04-19T11:23:08.868Z",
+  "generated_from": "design.md"
+}

--- a/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/tasks.md
+++ b/openspec/changes/archive/2026-04-19-ensure-askquestion-coverage-for-all-phase-transitions/tasks.md
@@ -1,0 +1,44 @@
+## 1. Add Mainline Handoff Question Blocks ✓
+
+> Add AskUserQuestion blocks to the three mainline terminal handoffs while preserving the existing prose guidance.
+
+- [x] 1.1 Add an AskUserQuestion block to specflow step 9 for the spec_ready handoff with /specflow.design and /specflow.reject targets.
+- [x] 1.2 Add an AskUserQuestion block to specflow.design step 4 for the design_ready handoff with /specflow.apply and /specflow.reject targets.
+- [x] 1.3 Add an AskUserQuestion block to specflow.apply step 2 for the apply_ready handoff with /specflow.approve, /specflow.fix_apply, and /specflow.reject targets.
+
+## 2. Align OpenSpec Change Artifacts ✓
+
+> Ensure the change spec and task checklist encode the new handoff contract and required manual verification steps.
+
+- [x] 2.1 Tighten the slash-command-guides change delta so mainline terminal handoffs require AskUserQuestion blocks and the correct slash-command target sets, with review-loop and utility exemptions preserved.
+- [x] 2.2 Update tasks.md to track build, structural test, snapshot, openspec validation, and non-automated Claude Code UI verification work for this change.
+
+## 3. Regenerate Distributed Command Guides ✓
+
+> Rebuild the generated slash-command guides so the distributed artifacts include the new handoff blocks.
+
+> Depends on: add-mainline-handoff-question-blocks
+
+- [x] 3.1 Run the standard build pipeline to regenerate the three distributed command guides from the updated templates.
+- [x] 3.2 Inspect the regenerated guides to confirm each terminal handoff contains an AskUserQuestion block with the expected slash-command targets.
+
+## 4. Extend Structural Regression Coverage ✓
+
+> Update structural tests and snapshots so regressions in mainline handoff question blocks are caught automatically.
+
+> Depends on: add-mainline-handoff-question-blocks, regenerate-distributed-command-guides, align-openspec-change-artifacts
+
+- [x] 4.1 Extend command-order.test.ts with ordered fragments for AskUserQuestion and each required slash-command target in the three generated guides.
+- [x] 4.2 Regenerate the affected snapshot files for specflow.md, specflow.design.md, and specflow.apply.md.
+- [x] 4.3 Run the relevant structural and snapshot tests to verify the new coverage passes against the regenerated output.
+
+## 5. Run End-to-End Verification ✓
+
+> Validate the change, observe the Claude Code UI behavior directly, and close out the change checklist.
+
+> Depends on: align-openspec-change-artifacts, regenerate-distributed-command-guides, extend-structural-regression-coverage
+
+- [x] 5.1 Run openspec validate ensure-askquestion-coverage-for-all-phase-transitions --type change and resolve any remaining contract drift.
+- [x] 5.2 Run the full test suite and confirm the change is green end-to-end.
+- [x] 5.3 Manually drive spec_ready, design_ready, and apply_ready in Claude Code and confirm clickable buttons appear at each handoff.
+- [x] 5.4 Mark the change tasks complete in tasks.md, including the manual verification outcome.

--- a/openspec/specs/slash-command-guides/spec.md
+++ b/openspec/specs/slash-command-guides/spec.md
@@ -54,7 +54,10 @@ Generated command markdown SHALL render command body sections from resolved `.md
 
 The generated guides for the main slash-command workflow SHALL encode the
 current phase order and SHALL not document bypasses around the implemented
-gates.
+gates. Guides SHALL present mainline terminal-handoff options via
+`AskUserQuestion` blocks rather than prose-only text per the
+"Mainline terminal-handoff phases SHALL present next-step options via
+AskUserQuestion" requirement.
 
 #### Scenario: Proposal guide materializes local proposal artifacts before run start
 
@@ -396,4 +399,51 @@ appear.
   `specflow-spec-verify` reports `reason: "no_modified_capabilities"`
   the guide advances with `spec_verified` immediately and without
   prompting the user
+
+### Requirement: Mainline terminal-handoff phases SHALL present next-step options via AskUserQuestion
+
+Generated slash-command guides for the mainline workflow SHALL, whenever a command's flow leaves the run in a mainline terminal-handoff phase, present the next-step choice to the operator through an `AskUserQuestion` block rather than prose-only text.
+
+The mainline terminal-handoff phases for this requirement are exactly:
+
+- `spec_ready` — terminal phase of `/specflow`
+- `design_ready` — terminal phase of `/specflow.design`
+- `apply_ready` — terminal phase of `/specflow.apply`
+
+For each of those phases, the `AskUserQuestion` block in the corresponding generated guide SHALL reference the following slash-command targets in its option set (labels and option order are not normative):
+
+- `spec_ready` in `specflow.md` SHALL reference `/specflow.design` and `/specflow.reject`.
+- `design_ready` in `specflow.design.md` SHALL reference `/specflow.apply` and `/specflow.reject`.
+- `apply_ready` in `specflow.apply.md` SHALL reference `/specflow.approve`, `/specflow.fix_apply`, and `/specflow.reject`.
+
+Explanatory prose MAY coexist with the `AskUserQuestion` block, but prose-only handoffs SHALL NOT satisfy this requirement.
+
+Review-loop guides (`specflow.review_design.md`, `specflow.review_apply.md`, `specflow.fix_design.md`, `specflow.fix_apply.md`) are NOT governed by this requirement; they remain governed by the existing review-loop handoff requirements.
+
+#### Scenario: Proposal guide presents spec_ready handoff via AskUserQuestion
+
+- **WHEN** generated `specflow.md` is read
+- **THEN** the section that offers the next step after the run reaches `spec_ready` SHALL contain an `AskUserQuestion` block
+- **AND** that block's options SHALL reference both `/specflow.design` and `/specflow.reject`
+- **AND** the section SHALL NOT describe the handoff using prose-only text (for example, a bullet list of "recommended handoffs") in place of the `AskUserQuestion` block
+
+#### Scenario: Design guide presents design_ready handoff via AskUserQuestion
+
+- **WHEN** generated `specflow.design.md` is read
+- **THEN** the section that offers the next step after the run reaches `design_ready` SHALL contain an `AskUserQuestion` block
+- **AND** that block's options SHALL reference both `/specflow.apply` and `/specflow.reject`
+- **AND** the section SHALL NOT describe the handoff using prose-only text in place of the `AskUserQuestion` block
+
+#### Scenario: Apply guide presents apply_ready handoff via AskUserQuestion
+
+- **WHEN** generated `specflow.apply.md` is read
+- **THEN** the section that offers the next step after the run reaches `apply_ready` SHALL contain an `AskUserQuestion` block
+- **AND** that block's options SHALL reference `/specflow.approve`, `/specflow.fix_apply`, and `/specflow.reject`
+- **AND** the section SHALL NOT describe the handoff using prose-only text in place of the `AskUserQuestion` block
+
+#### Scenario: Utility and review-loop guides are exempt
+
+- **WHEN** generated `specflow.reject.md`, `specflow.dashboard.md`, `specflow.setup.md`, `specflow.explore.md`, `specflow.spec.md`, `specflow.license.md`, `specflow.readme.md`, `specflow.review_design.md`, `specflow.review_apply.md`, `specflow.fix_design.md`, or `specflow.fix_apply.md` is read
+- **THEN** this requirement SHALL NOT be evaluated against them
+- **AND** those guides SHALL continue to be governed only by the existing requirements that apply to them
 

--- a/src/tests/__snapshots__/specflow.apply.md.snap
+++ b/src/tests/__snapshots__/specflow.apply.md.snap
@@ -129,7 +129,36 @@ Report: `Step 1 complete — implementation completed in apply_draft`
    ```bash
    specflow-run advance "<RUN_ID>" apply_review_approved
    ```
-5. Only from `apply_ready`, offer `/specflow.approve`.
+5. Only from `apply_ready`, offer `/specflow.approve` using the AskUserQuestion block below:
+
+   **テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+   ```
+   ✅ Apply review approved — run is in `apply_ready`.
+
+   次のアクションを選択してください（テキスト入力またはボタンで回答）:
+   - **Approve に進む** → `/specflow.approve`
+   - **Fix ループへ** → `/specflow.fix_apply`
+   - **中止** → `/specflow.reject`
+   ```
+
+   **AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
+   ```
+   AskUserQuestion:
+     question: "Apply review 承認済み。次のアクションを選択してください"
+     options:
+       - label: "Approve に進む"
+         description: "/specflow.approve で archive・commit・push・PR 作成に進む"
+       - label: "Fix ループへ"
+         description: "/specflow.fix_apply で追加修正してから再レビュー"
+       - label: "中止"
+         description: "/specflow.reject で全変更を破棄して終了"
+   ```
+
+   **入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
+   - 「Approve に進む」 → `Skill(skill: "specflow.approve")`
+   - 「Fix ループへ」 → `Skill(skill: "specflow.fix_apply")`
+   - 「中止」 → `Skill(skill: "specflow.reject")`
 
 If the configured round cap is reached and findings remain, stop in place without an approve bypass.
 

--- a/src/tests/__snapshots__/specflow.design.md.snap
+++ b/src/tests/__snapshots__/specflow.design.md.snap
@@ -155,7 +155,32 @@ If any are incomplete, report which artifacts are missing and ask the user how t
    ```bash
    specflow-run advance "<RUN_ID>" design_review_approved
    ```
-5. Only from `design_ready`, offer `/specflow.apply`.
+5. Only from `design_ready`, offer `/specflow.apply` using the AskUserQuestion block below:
+
+   **テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+   ```
+   ✅ Design review approved — run is in `design_ready`.
+
+   次のアクションを選択してください（テキスト入力またはボタンで回答）:
+   - **Apply に進む** → `/specflow.apply`
+   - **中止** → `/specflow.reject`
+   ```
+
+   **AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
+   ```
+   AskUserQuestion:
+     question: "Design review 承認済み。次のアクションを選択してください"
+     options:
+       - label: "Apply に進む"
+         description: "/specflow.apply で実装を開始し、apply review ゲートに進む"
+       - label: "中止"
+         description: "/specflow.reject で全変更を破棄して終了"
+   ```
+
+   **入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
+   - 「Apply に進む」 → `Skill(skill: "specflow.apply")`
+   - 「中止」 → `Skill(skill: "specflow.reject")`
 
 Remove any path that allows `/specflow.apply` while findings remain.
 

--- a/src/tests/__snapshots__/specflow.md.snap
+++ b/src/tests/__snapshots__/specflow.md.snap
@@ -321,9 +321,30 @@ Strict gate rules:
 
 Only when the run is in `spec_ready`, offer the next action.
 
-Recommended handoff:
+**テキストプロンプト（AskUserQuestion の前に必ず表示）**:
+```
+✅ Spec phase complete — run is in `spec_ready`.
+
+次のアクションを選択してください（テキスト入力またはボタンで回答）:
 - **Design に進む** → `/specflow.design`
 - **中止** → `/specflow.reject`
+```
+
+**AskUserQuestion（テキストプロンプトの直後に呼び出し）**:
+```
+AskUserQuestion:
+  question: "Spec phase 完了。次のアクションを選択してください"
+  options:
+    - label: "Design に進む"
+      description: "/specflow.design で design.md / tasks.md を生成し、review ゲートに進む"
+    - label: "中止"
+      description: "/specflow.reject で全変更を破棄して終了"
+```
+
+**入力受理**: 最初に受理された有効入力のみ採用。無効入力時はテキストプロンプトを再表示。
+
+- 「Design に進む」 → `Skill(skill: "specflow.design")`
+- 「中止」 → `Skill(skill: "specflow.reject")`
 
 Do not offer `/specflow.design` from `proposal_clarify`, `proposal_challenge`, `proposal_reclarify`, `spec_draft`, `spec_validate`, or `spec_verify`.
 

--- a/src/tests/command-order.test.ts
+++ b/src/tests/command-order.test.ts
@@ -37,8 +37,33 @@ test("generated /specflow command preserves detailed proposal step order", () =>
 		'openspec validate "<CHANGE_ID>" --type change --json',
 		'specflow-run advance "<RUN_ID>" spec_validated',
 		"## Step 9: Design Handoff",
+		"AskUserQuestion:",
+		"/specflow.design",
+		"/specflow.reject",
 	]);
 	assert.equal(content.includes("このまま続行"), false);
+});
+
+test("generated /specflow terminal handoff presents AskUserQuestion block", () => {
+	const content = readFileSync(
+		"dist/package/global/commands/specflow.md",
+		"utf8",
+	);
+	const handoffIndex = content.indexOf("## Step 9: Design Handoff");
+	assert.notEqual(handoffIndex, -1, "Missing Step 9 section");
+	const handoffSection = content.slice(handoffIndex);
+	assert.ok(
+		handoffSection.includes("AskUserQuestion:"),
+		"spec_ready handoff must include an AskUserQuestion block",
+	);
+	assert.ok(
+		handoffSection.includes("/specflow.design"),
+		"spec_ready handoff must reference /specflow.design",
+	);
+	assert.ok(
+		handoffSection.includes("/specflow.reject"),
+		"spec_ready handoff must reference /specflow.reject",
+	);
 });
 
 test("generated /specflow.design command starts from spec_ready and enters review directly", () => {
@@ -51,12 +76,37 @@ test("generated /specflow.design command starts from spec_ready and enters revie
 		"## Step 4: Design Review Gate",
 		'specflow-run advance "<RUN_ID>" review_design',
 		'specflow-run advance "<RUN_ID>" design_review_approved',
+		"AskUserQuestion:",
+		"/specflow.apply",
+		"/specflow.reject",
 	]);
 	assert.equal(
 		content.includes('openspec validate "<CHANGE_ID>" --type change --json'),
 		false,
 	);
 	assert.equal(content.includes("このまま続行"), false);
+});
+
+test("generated /specflow.design terminal handoff presents AskUserQuestion block", () => {
+	const content = readFileSync(
+		"dist/package/global/commands/specflow.design.md",
+		"utf8",
+	);
+	const handoffIndex = content.indexOf("design_ready");
+	assert.notEqual(handoffIndex, -1, "Missing design_ready reference");
+	const handoffSection = content.slice(handoffIndex);
+	assert.ok(
+		handoffSection.includes("AskUserQuestion:"),
+		"design_ready handoff must include an AskUserQuestion block",
+	);
+	assert.ok(
+		handoffSection.includes("/specflow.apply"),
+		"design_ready handoff must reference /specflow.apply",
+	);
+	assert.ok(
+		handoffSection.includes("/specflow.reject"),
+		"design_ready handoff must reference /specflow.reject",
+	);
 });
 
 test("generated /specflow.apply command gates approve behind apply_ready", () => {
@@ -70,8 +120,38 @@ test("generated /specflow.apply command gates approve behind apply_ready", () =>
 		"## Step 2: Apply Review Gate",
 		'specflow-run advance "<RUN_ID>" review_apply',
 		'specflow-run advance "<RUN_ID>" apply_review_approved',
-		"Only from `apply_ready`, offer `/specflow.approve`.",
+		"Only from `apply_ready`, offer `/specflow.approve`",
+		"AskUserQuestion:",
+		"/specflow.approve",
+		"/specflow.fix_apply",
+		"/specflow.reject",
 	]);
+});
+
+test("generated /specflow.apply terminal handoff presents AskUserQuestion block", () => {
+	const content = readFileSync(
+		"dist/package/global/commands/specflow.apply.md",
+		"utf8",
+	);
+	const handoffIndex = content.indexOf("apply_ready");
+	assert.notEqual(handoffIndex, -1, "Missing apply_ready reference");
+	const handoffSection = content.slice(handoffIndex);
+	assert.ok(
+		handoffSection.includes("AskUserQuestion:"),
+		"apply_ready handoff must include an AskUserQuestion block",
+	);
+	assert.ok(
+		handoffSection.includes("/specflow.approve"),
+		"apply_ready handoff must reference /specflow.approve",
+	);
+	assert.ok(
+		handoffSection.includes("/specflow.fix_apply"),
+		"apply_ready handoff must reference /specflow.fix_apply",
+	);
+	assert.ok(
+		handoffSection.includes("/specflow.reject"),
+		"apply_ready handoff must reference /specflow.reject",
+	);
 });
 
 test("generated /specflow.approve command keeps archive before commit and conditional issue closing", () => {


### PR DESCRIPTION
## Summary

- Adds `AskUserQuestion:` blocks to `/specflow`, `/specflow.design`, and `/specflow.apply` so Claude Code renders clickable buttons at the three mainline terminal handoffs (`spec_ready`, `design_ready`, `apply_ready`) instead of prose-only "recommended handoff" text.
- Extends the `slash-command-guides` spec with a new terminal-handoff requirement asserting block presence and the required set of slash-command targets; MODIFIES the existing strict-phase-gate requirement to cross-reference it while preserving every baseline scenario verbatim.
- Extends `command-order.test.ts` with ordered-fragment and section-scoped assertions; regenerates the three snapshot files.
- Non-goals: TS-side renderer changes, review-loop guide edits, cross-tool compatibility.

## Issue

Closes https://github.com/skr19930617/specflow/issues/171