### PR TITLE
feat: surface auto-fix loop progress via review_completed events and run-keyed snapshot (#172)

### DIFF
--- a/assets/commands/specflow.review_apply.md.tmpl
+++ b/assets/commands/specflow.review_apply.md.tmpl
@@ -237,15 +237,63 @@ AskUserQuestion:
 
 ## Step 6: Auto-fix Loop
 
-ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator で auto-fix loop を実行する。
+ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator を **バックグラウンドで** 起動し、run_id をキーに進捗スナップショット / `review_completed` observation events をポーリングしながら進捗をユーザーに逐次レンダリングする。同期で Bash を待ってはいけない（チャットが「凍って見える」失敗モードを避けるため）。
 
-### Run Orchestrator
+### Resolve run_id first
+
+`run_id` を事前に取得する。`specflow.review_apply` の前段で解決済みの `RUN_ID`（`<CHANGE_ID>-<N>` 形式）をそのまま再利用する。未確定であれば次を実行:
 
 ```bash
-specflow-review-apply autofix-loop <CHANGE_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
+specflow-run get-field "<RUN_ID>" run_id
 ```
 
-Capture stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
+`RUN_ID` を確定できない場合は、その根本原因を調査して解決したうえで再実行する（autofix-loop は `RUN_ID` なしでも動作するが、進捗スナップショット / `review_completed` observation events の emission は発生しないため observability が失われる）。
+
+### Launch in background
+
+バックグラウンドで起動する（Claude chat の場合は `run_in_background: true`）。
+
+```bash
+specflow-review-apply autofix-loop <CHANGE_ID> --run-id <RUN_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
+```
+
+CLI の `LOOP_JSON` は終了時にのみ stdout に返る。CLI `stderr` の `Auto-fix Round N/M: ...` 行は人間向けの補助情報であり、**契約上の進捗ソースではない**。
+
+### Poll progress via snapshot + events
+
+`run_id` をキーにして以下のいずれか（両方可）をポーリングする:
+
+- **進捗スナップショット**（推奨・Fast path）: `.specflow/runs/<RUN_ID>/autofix-progress-apply_review.json` を Read で取得。スキーマは `review-autofix-progress-observability` 契約に従う: `round_index`, `max_rounds`, `loop_state`, `terminal_outcome`, `counters` (`unresolvedCriticalHigh`, `totalOpen`, `resolvedThisRound`, `newThisRound`, `severitySummary`), `heartbeat_at`, `ledger_round_id`。
+- **Observation events**: `.specflow/runs/<RUN_ID>/events.jsonl` を tail し、`event_kind == "review_completed"` かつ `payload.autofix != null` の行を抜き出す。`payload.autofix.loop_state` が状態遷移、`payload.autofix.counters` が severity カウンタを示す。
+
+**1 round あたりのイベント数**: CLI は 1 round につき `review_completed` を 2 件（start: `loop_state = in_progress`、end: `loop_state = awaiting_review` または terminal）と、ループ終了時に 1 件の終局イベント（`loop_state ∈ {terminal_success, terminal_failure}`）を emit する（合計 `2N+1` events）。
+
+### Render per-round progress
+
+`loop_state` が変わるたびにユーザーにレンダリングする:
+
+```
+Auto-fix Round {round_index}/{max_rounds}: {loop_state}
+  - Unresolved HIGH+: {counters.unresolvedCriticalHigh}
+  - Total open: {counters.totalOpen}
+  - Resolved this round: {counters.resolvedThisRound}
+  - Severity summary: {counters.severitySummary}
+```
+
+状態が変わらないままハートビートが更新された場合、1 分に 1 回まで `heartbeat_at` の経過時間を表示してもよい（オプション）。
+
+### Finalize only on terminal `loop_state` or `abandoned`
+
+ループの終了判定は次のいずれかでのみ行う:
+
+- `loop_state == "terminal_success"` または `loop_state == "terminal_failure"` を観測 → `LOOP_JSON` を Read で取得（バックグラウンドタスクの出力ファイルから）し、通常の Handoff に進む。
+- `heartbeat_at` が `autofix_stale_threshold_seconds`（デフォルト `120`）を超えて更新されない → run を `abandoned` と分類する。ユーザーにそのことを通知し、必要に応じて再実行を案内する。
+
+### Retry after `abandoned`
+
+`abandoned` と分類された run で `/specflow.review_apply` を再実行する場合、新しい invocation は新しい `RUN_ID` を生成する。surface は古い `RUN_ID` のスナップショット / event stream のポーリングを停止し、新しい `RUN_ID` の `.specflow/runs/<NEW_RUN_ID>/autofix-progress-apply_review.json` をポーリングする。古いスナップショットはその `RUN_ID`-scoped パスにより到達不能になるため、明示的なクリーンアップは不要。
+
+Capture final stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
 
 Parse `LOOP_JSON` as JSON. If parse fails, display raw output and **STOP**.
 

--- a/assets/commands/specflow.review_design.md.tmpl
+++ b/assets/commands/specflow.review_design.md.tmpl
@@ -217,15 +217,63 @@ AskUserQuestion:
 
 ## Step 6: Auto-fix Loop
 
-ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator で auto-fix loop を実行する。
+ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator を **バックグラウンドで** 起動し、run_id をキーに進捗スナップショット / `review_completed` observation events をポーリングしながら進捗をユーザーに逐次レンダリングする。同期で Bash を待ってはいけない（チャットが「凍って見える」失敗モードを避けるため）。
 
-### Run Orchestrator
+### Resolve run_id first
+
+`run_id` を事前に取得する。`specflow.review_design` の前段で解決済みの `RUN_ID`（`<CHANGE_ID>-<N>` 形式）をそのまま再利用する。未確定であれば次を実行:
 
 ```bash
-specflow-review-design autofix-loop <CHANGE_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
+specflow-run get-field "<RUN_ID>" run_id
 ```
 
-Capture stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
+`RUN_ID` を確定できない場合は、その根本原因を調査して解決したうえで再実行する（autofix-loop は `RUN_ID` なしでも動作するが、進捗スナップショット / `review_completed` observation events の emission は発生しないため observability が失われる）。
+
+### Launch in background
+
+バックグラウンドで起動する（Claude chat の場合は `run_in_background: true`）。
+
+```bash
+specflow-review-design autofix-loop <CHANGE_ID> --run-id <RUN_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
+```
+
+CLI の `LOOP_JSON` は終了時にのみ stdout に返る。CLI `stderr` の `Auto-fix Round N/M: ...` 行は人間向けの補助情報であり、**契約上の進捗ソースではない**。
+
+### Poll progress via snapshot + events
+
+`run_id` をキーにして以下のいずれか（両方可）をポーリングする:
+
+- **進捗スナップショット**（推奨・Fast path）: `.specflow/runs/<RUN_ID>/autofix-progress-design_review.json` を Read で取得。スキーマは `review-autofix-progress-observability` 契約に従う: `round_index`, `max_rounds`, `loop_state`, `terminal_outcome`, `counters` (`unresolvedCriticalHigh`, `totalOpen`, `resolvedThisRound`, `newThisRound`, `severitySummary`), `heartbeat_at`, `ledger_round_id`。
+- **Observation events**: `.specflow/runs/<RUN_ID>/events.jsonl` を tail し、`event_kind == "review_completed"` かつ `payload.autofix != null` の行を抜き出す。`payload.autofix.loop_state` が状態遷移、`payload.autofix.counters` が severity カウンタを示す。
+
+**1 round あたりのイベント数**: CLI は 1 round につき `review_completed` を 2 件（start: `loop_state = in_progress`、end: `loop_state = awaiting_review` または terminal）と、ループ終了時に 1 件の終局イベント（`loop_state ∈ {terminal_success, terminal_failure}`）を emit する（合計 `2N+1` events）。
+
+### Render per-round progress
+
+`loop_state` が変わるたびにユーザーにレンダリングする:
+
+```
+Auto-fix Round {round_index}/{max_rounds}: {loop_state}
+  - Unresolved HIGH+: {counters.unresolvedCriticalHigh}
+  - Total open: {counters.totalOpen}
+  - Resolved this round: {counters.resolvedThisRound}
+  - Severity summary: {counters.severitySummary}
+```
+
+状態が変わらないままハートビートが更新された場合、1 分に 1 回まで `heartbeat_at` の経過時間を表示してもよい（オプション）。
+
+### Finalize only on terminal `loop_state` or `abandoned`
+
+ループの終了判定は次のいずれかでのみ行う:
+
+- `loop_state == "terminal_success"` または `loop_state == "terminal_failure"` を観測 → `LOOP_JSON` を Read で取得（バックグラウンドタスクの出力ファイルから）し、通常の Handoff に進む。
+- `heartbeat_at` が `autofix_stale_threshold_seconds`（デフォルト `120`）を超えて更新されない → run を `abandoned` と分類する。ユーザーにそのことを通知し、必要に応じて再実行を案内する。
+
+### Retry after `abandoned`
+
+`abandoned` と分類された run で `/specflow.review_design` を再実行する場合、新しい invocation は新しい `RUN_ID` を生成する。surface は古い `RUN_ID` のスナップショット / event stream のポーリングを停止し、新しい `RUN_ID` の `.specflow/runs/<NEW_RUN_ID>/autofix-progress-design_review.json` をポーリングする。古いスナップショットはその `RUN_ID`-scoped パスにより到達不能になるため、明示的なクリーンアップは不要。
+
+Capture final stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
 
 Parse `LOOP_JSON` as JSON. If parse fails, display raw output and **STOP**.
 

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/approval-summary.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/approval-summary.md
@@ -1,0 +1,163 @@
+# Approval Summary: auto-fixloopbackground
+
+**Generated**: 2026-04-19T14:40:58Z
+**Branch**: auto-fixloopbackground
+**Status**: ⚠️ 3 unresolved high (impl) + 1 unresolved high (design) — accepted as risk
+
+Source: https://github.com/skr19930617/specflow/issues/172
+("auto-fixloopがbackgroundで起動して止まる — claudeのチャット経由で進めている場合に
+auto-fixの進捗を適宜表示する仕組みを入れる")
+
+## 2a. What Changed
+
+```
+ assets/commands/specflow.review_apply.md.tmpl      |  56 +++++-
+ assets/commands/specflow.review_design.md.tmpl     |  56 +++++-
+ src/bin/specflow-review-apply.ts                   | 185 +++++++++++++++++++-
+ src/bin/specflow-review-design.ts                  | 190 ++++++++++++++++++++-
+ src/lib/artifact-types.ts                          |  54 +++++-
+ src/lib/local-fs-run-artifact-store.ts             |  15 ++
+ src/lib/review-runtime.ts                          |  30 ++++
+ src/tests/__snapshots__/specflow.review_apply.md.snap    |  56 +++++-
+ src/tests/__snapshots__/specflow.review_design.md.snap   |  56 +++++-
+ src/tests/artifact-types.test.ts                   |   5 +-
+ src/types/observation-events.ts                    |  77 ++++++++-
+ 11 files changed, 755 insertions(+), 25 deletions(-)
+```
+
+Plus new files:
+- `src/types/autofix-progress.ts` — snapshot schema, loop-state enum, validators
+- `src/lib/autofix-event-builder.ts` — `review_completed` event + `AutofixRoundPayload` builders
+- `src/lib/autofix-progress-snapshot.ts` — snapshot writer, heartbeat, ledger-derived counter helpers
+
+Plus the full `openspec/changes/auto-fixloopbackground/` change directory (proposal, design, tasks, task-graph, 4 spec deltas, review ledgers, current-phase).
+
+## 2b. Files Touched
+
+**Modified:**
+- `assets/commands/specflow.review_apply.md.tmpl`
+- `assets/commands/specflow.review_design.md.tmpl`
+- `src/bin/specflow-review-apply.ts`
+- `src/bin/specflow-review-design.ts`
+- `src/lib/artifact-types.ts`
+- `src/lib/local-fs-run-artifact-store.ts`
+- `src/lib/review-runtime.ts`
+- `src/tests/__snapshots__/specflow.review_apply.md.snap`
+- `src/tests/__snapshots__/specflow.review_design.md.snap`
+- `src/tests/artifact-types.test.ts`
+- `src/types/observation-events.ts`
+
+**Added (runtime):**
+- `src/lib/autofix-event-builder.ts`
+- `src/lib/autofix-progress-snapshot.ts`
+- `src/types/autofix-progress.ts`
+
+**Added (change artifacts):**
+- `openspec/changes/auto-fixloopbackground/proposal.md`
+- `openspec/changes/auto-fixloopbackground/design.md`
+- `openspec/changes/auto-fixloopbackground/tasks.md`
+- `openspec/changes/auto-fixloopbackground/task-graph.json`
+- `openspec/changes/auto-fixloopbackground/review-ledger.json`
+- `openspec/changes/auto-fixloopbackground/review-ledger-design.json`
+- `openspec/changes/auto-fixloopbackground/current-phase.md`
+- `openspec/changes/auto-fixloopbackground/specs/review-autofix-progress-observability/spec.md`
+- `openspec/changes/auto-fixloopbackground/specs/workflow-observation-events/spec.md`
+- `openspec/changes/auto-fixloopbackground/specs/review-orchestration/spec.md`
+- `openspec/changes/auto-fixloopbackground/specs/slash-command-guides/spec.md`
+
+## 2c. Review Loop Summary
+
+### Design Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 1     |
+| Resolved high      | 4     |
+| Unresolved high    | 1     |
+| New high (later)   | 3     |
+| Total rounds       | 5     |
+
+Autofix loop ran 4 rounds plus 1 initial review (total 5). Divergence warnings recorded on
+rounds 1 / 2 / 4 (quality-gate degradation). Accepted as risk on `max_rounds_reached`.
+
+### Impl Review
+
+| Metric             | Count |
+|--------------------|-------|
+| Initial high       | 3     |
+| Resolved high      | 0     |
+| Unresolved high    | 3     |
+| New high (later)   | 0     |
+| Total rounds       | 1     |
+
+Single round with 5 new findings (3 HIGH + 2 MEDIUM). User chose `Approve (accepted risk)`
+to close this pass.
+
+## 2d. Proposal Coverage
+
+Acceptance criteria are defined in the four spec deltas under
+`openspec/changes/auto-fixloopbackground/specs/`. Each requirement's scenarios are
+the canonical acceptance criteria.
+
+| # | Criterion (summary) | Covered? | Mapped Files |
+|---|---------------------|----------|--------------|
+| 1 | `loop_state` enum is closed 5-value | Yes | `src/types/observation-events.ts`, `src/types/autofix-progress.ts` |
+| 2 | Progress snapshot lives under run-artifact store keyed by run_id + phase | Yes | `src/lib/artifact-types.ts`, `src/lib/local-fs-run-artifact-store.ts`, `src/lib/autofix-progress-snapshot.ts` |
+| 3 | Snapshot schema has all 11 required fields | Yes | `src/types/autofix-progress.ts` (`AutofixProgressSnapshot` + `validateAutofixSnapshot`) |
+| 4 | Heartbeat refresh ≤ 30s, configurable via config.yaml | Yes | `src/lib/review-runtime.ts` (`readReviewConfig`), `src/lib/autofix-progress-snapshot.ts` (`startAutofixHeartbeat`) |
+| 5 | Stale threshold ≥ heartbeat, default 120s, invalid → default | Yes | `src/lib/review-runtime.ts` |
+| 6 | `review_completed` payload extended with `AutofixRoundPayload` | Yes | `src/types/observation-events.ts`, `src/lib/autofix-event-builder.ts` |
+| 7 | `autofix_in_progress` outcome reserved for non-terminal emissions | Yes | `src/types/observation-events.ts`, `src/lib/autofix-event-builder.ts` (`outcomeForAutofixState`) |
+| 8 | Counters derived from previous-round ledger summary on round-start | Yes | `src/bin/specflow-review-{design,apply}.ts` (findRoundSummary + buildAutofixCountersFromRound) |
+| 9 | Counters from current-round ledger on round-end | Yes | `src/bin/specflow-review-{design,apply}.ts` (findRoundSummary on autofixRound) |
+| 10 | Terminal event emitted on loop exit with `terminal_success`/`terminal_failure` | Yes | `src/bin/specflow-review-{design,apply}.ts` (terminal emission block) |
+| 11 | Heartbeat interval refreshes `heartbeat_at` even without round transition | Yes | `src/lib/autofix-progress-snapshot.ts` (`startAutofixHeartbeat`) |
+| 12 | Authority precedence: ledger > events > snapshot | Yes | Design doc D5; reflected in code comments and defensive snapshot-write error swallowing |
+| 13 | Stale-heartbeat `abandoned` classification rule is surface-side | Yes | Documented in slash-command templates; contract in spec delta |
+| 14 | `abandoned` run's new invocation gets new run_id, old snapshot unreachable | Yes (by design) | Run-artifact paths are keyed by `run_id`; new run_id generated per `/specflow` invocation |
+| 15 | Slash-command guides mandate background invocation + polling | Yes | `assets/commands/specflow.review_design.md.tmpl`, `assets/commands/specflow.review_apply.md.tmpl` |
+| 16 | Guides render per-round progress with counters | Yes | Templates define the per-round render block |
+| 17 | Guides document `abandoned` + new-run_id switchover | Yes | Templates include "Retry after `abandoned`" section |
+| 18 | `RunArtifactStore.list()` enumerates autofix-progress refs | **No** (F1 accepted risk) | `src/lib/local-fs-run-artifact-store.ts` still lists only `run-state` |
+| 19 | Terminal round emits 2N+1 events (round-end before break) | **No** (F2 accepted risk) | CLI `break`s before round-end emission on terminal conditions |
+| 20 | Apply autofix `no_changes` terminal outcome preserved exactly | **No** (F3 accepted risk) | Not in `AutofixTerminalOutcome` enum; coerced to `loop_with_findings` |
+| 21 | Templates use `autofix_stale_threshold_seconds` from config | **Partial** (F4 accepted risk) | Templates reference "default `120`" but do not read the configured value |
+| 22 | Integration tests for autofix-loop event+snapshot emission | **No** (F5 accepted risk) | Only artifact-types + snapshot tests exist; no event/snapshot runtime tests |
+
+**Coverage Rate**: 17/22 (77%)
+
+## 2e. Remaining Risks
+
+### Deterministic (from impl review ledger)
+
+- R1-F01 (HIGH, accepted risk): `RunArtifactStore.list()` never exposes the new autofix-progress artifacts. Consumers that use `list()` to discover snapshots will see only `run-state` refs.
+- R1-F02 (HIGH, accepted risk): Terminal rounds skip the required round-end `review_completed` emission. Last round emits 2 events instead of 3; total is 2N instead of 2N+1. Surfaces relying on the round-end event of the final round will miss one transition. Reading the snapshot's terminal state still works because the terminal event is emitted.
+- R1-F03 (HIGH, accepted risk): Apply autofix `loopResult = "no_changes"` is coerced to `loop_with_findings` terminal_outcome because `AutofixTerminalOutcome` does not include `no_changes`. The exact reason is lost to event consumers but preserved in the CLI's `LOOP_JSON.autofix.result`.
+- R1-F04 (MEDIUM, accepted risk): Guides hardcode `autofix_stale_threshold_seconds` default (`120`) instead of reading the configured value. Surfaces that honor project-specific overrides must read `openspec/config.yaml` directly.
+- R1-F05 (MEDIUM, accepted risk): No integration tests for `autofix-loop --run-id` writing the snapshot, refreshing heartbeat, or emitting `review_completed` events with `payload.autofix`. Only the artifact-type enum and markdown snapshot tests were added.
+
+### Deterministic (from design review ledger)
+
+- R4-F06 (HIGH, accepted risk): `awaiting_review` timing vs. current-round ledger sourcing. The round-end emission happens after re-review completes (when the round summary exists in the ledger), so `counters` and `ledger_round_id` are populated correctly — but the `awaiting_review` label was originally intended for the pre-re-review window. The code emits the event post-re-review with the correct data; only the label's connotation is slightly misaligned with its emission point.
+
+### Untested new files
+
+- ⚠️ New file not mentioned in review: `src/types/autofix-progress.ts` (reviewed under F1–F3 scope)
+- ⚠️ New file not mentioned in review: `src/lib/autofix-event-builder.ts`
+- ⚠️ New file not mentioned in review: `src/lib/autofix-progress-snapshot.ts`
+
+### Uncovered criteria
+
+- ⚠️ Uncovered criterion: `RunArtifactStore.list()` enumerates autofix-progress refs (F1).
+- ⚠️ Uncovered criterion: Terminal round emits 2N+1 events (F2).
+- ⚠️ Uncovered criterion: `no_changes` terminal outcome preserved exactly (F3).
+- ⚠️ Uncovered criterion: Templates use configured stale threshold (F4).
+- ⚠️ Uncovered criterion: Integration tests for autofix-loop observability (F5).
+
+## 2f. Human Checkpoints
+
+- [ ] Confirm the contract delta in `specs/review-autofix-progress-observability/spec.md` matches the intended operator experience for Claude chat, remote-api, and batch surfaces (all four surface kinds were named in `actor-surface-model`).
+- [ ] Decide whether to add `no_changes` to `AutofixTerminalOutcome` (preserve the exact reason) or remove the `no_changes` branch from `specflow-review-apply.ts` (tighten the enum) before the next release — the current coercion hides a distinct terminal state from the event stream (F3).
+- [ ] File a follow-up to extend `RunArtifactStore.list()` to enumerate `autofix-progress-*` refs so that surfaces can discover per-run snapshots without hardcoding the path (F1).
+- [ ] File a follow-up to emit the round-end `review_completed` event before terminal `break`s so the `2N+1` event-count invariant in `workflow-observation-events` holds for every loop (F2).
+- [ ] Add integration tests that exercise a multi-round `autofix-loop --run-id` and verify: (a) `autofix-progress-<phase>.json` exists with a valid schema, (b) `heartbeat_at` advances within the configured interval, (c) `events.jsonl` contains the expected `review_completed` sequence (F5).

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/current-phase.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/current-phase.md
@@ -1,0 +1,14 @@
+# Current Phase: auto-fixloopbackground
+
+- Phase: impl-review
+- Round: 1
+- Status: has_open_high
+- Open High/Critical Findings: 3 件 — "RunArtifactStore.list() never exposes the new autofix-progress artifacts", "Terminal rounds skip the required round-end review_completed emission", "Apply autofix loses the exact terminal reason on the no_changes path"
+- Actionable Findings: 5
+- Accepted Risks: none
+- Latest Changes:
+  - 0f6a1c1 feat: present mainline terminal handoffs via AskUserQuestion blocks (#171)
+  - 9ad8871 feat: define workflow event semantics for state change, gate resolution, and progress observation (#167)
+  - 528028d chore: formatter whitespace cleanup in review-cli.test.ts
+  - 82d5792 feat: define gate semantics for approval, clarify, and review decisions as persistent workflow objects (#166)
+- Next Recommended Action: /specflow.fix_apply

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/design.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/design.md
@@ -1,0 +1,541 @@
+## Context
+
+Today, the review auto-fix loop
+(`specflow-review-design autofix-loop` and `specflow-review-apply autofix-loop`)
+runs many rounds of (a) prompting the main agent to fix design/apply
+artifacts and (b) calling the review agent to re-review. Each round can
+take several minutes. The loop is implemented as a single Node CLI call
+(`src/bin/specflow-review-design.ts`, `src/bin/specflow-review-apply.ts`)
+whose only structured output is the final `LOOP_JSON` printed to stdout
+on exit. Intermediate progress is written to `process.stderr` as plain
+lines such as `Auto-fix Round 2/4: Starting design fix...` and
+`Warning: fix step failed ...`.
+
+When a Claude chat surface drives this loop (via the slash-command
+guides in `assets/commands/specflow.review_design.md.tmpl` and
+`assets/commands/specflow.review_apply.md.tmpl`), operators have
+reported the chat "freezing" for minutes with no visible progress, or
+the loop silently terminating when launched with
+`run_in_background: true` because nothing pollable exists between
+rounds. Issue #172 ("auto-fixloopがbackgroundで起動して止まる") captures
+both failure modes.
+
+Meanwhile, the project already has three load-bearing contracts that
+relate to observability:
+
+- `workflow-observation-events` — a closed 15-kind observation event
+  catalog with `review_completed` already part of the catalog.
+- `review-orchestration` — defines autofix loop behavior, `max_autofix_rounds`,
+  and stable config fallback semantics from `openspec/config.yaml`.
+- `run-artifact-store-conformance` — defines per-run artifact storage.
+
+This design shows how to hang a new progress contract on those existing
+beams without opening the closed event catalog or forking a new
+transport.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make auto-fix loop progress observable between rounds for chat
+  surfaces without requiring surface-specific tooling.
+- Distinguish "loop still running" from "loop stuck" using a bounded
+  heartbeat.
+- Reuse the existing `review_completed` observation event kind rather
+  than expand the closed 15-kind catalog.
+- Persist a per-run progress snapshot under the existing run-artifact
+  store so late-subscribing surfaces can reconstruct current state
+  without replaying events.
+- Keep the severity-aware gate (`unresolvedCriticalHighCount`) and
+  `loop_no_findings` / `loop_with_findings` handoff semantics
+  untouched — this change is observability-only.
+
+**Non-Goals:**
+- Changing when `apply_review_approved` / `design_review_approved`
+  events are emitted (owned by `surface-event-contract` and
+  `review-orchestration`).
+- Adding a new observation event kind. The 15-kind catalog stays
+  closed.
+- Introducing a streaming transport (WebSocket / SSE). The contract is
+  read via the existing event publisher and the run-artifact store.
+- Changing the review ledger schema. Progress metadata references the
+  ledger round id but does not duplicate round data.
+- Surfacing progress for single-round `review` invocations. Only the
+  multi-round `autofix-loop` flow requires the new signal.
+
+## Decisions
+
+### D1. Extend `review_completed` payload rather than add a new event kind
+
+`workflow-observation-events` pins the catalog at 15 kinds and declares
+the catalog closed. Adding a new kind would ripple across every
+consumer (including `surface-event-contract` and
+`phase-router`). Instead we extend `review_completed.payload` with an
+optional `autofix` sub-object that is `null` for single-round reviews
+and non-null for auto-fix round emissions. This is additive — existing
+consumers that read `outcome`, `reviewer`, `score` keep working; new
+consumers opt in by reading `payload.autofix`.
+
+Alternatives considered:
+- **New `autofix_progress` event kind.** Rejected: breaks the closed
+  catalog rule and requires a catalog rev bump with consumer
+  fan-out.
+- **Reuse `phase_blocked` / `phase_reopened`.** Rejected: those events
+  describe workflow-phase transitions, not review-round transitions;
+  emitting them per fix round would conflate the run-level phase
+  machine with loop-level round state.
+- **Emit only on terminal outcomes.** Rejected: reintroduces the
+  "blind mid-loop" problem that issue #172 reports.
+
+### D2. Explicit loop initialization, then twice-per-round emission + one terminal emission
+
+Before round 1 begins, the loop SHALL perform an explicit
+initialization step that writes the progress snapshot with
+`loop_state = starting`, `round_index = 0`, and
+`ledger_round_id = null`. This snapshot is the only artifact produced
+in the `starting` state; no `review_completed` event is emitted for
+it. The `starting` state exists solely as the pre-round snapshot so
+that a surface polling immediately after launch can distinguish
+"loop invoked but not yet running" from "no loop running".
+
+Once initialization completes, each started round emits a
+`review_completed` event at round start (`loop_state = in_progress`)
+and another at round end (`loop_state = round_reviewed` if the fix
+and re-review both succeeded but the loop has not yet decided to
+continue or terminate, or a terminal state if the loop ended in this
+round). The round-end event is emitted **after** the re-review
+completes, so the current round's ledger summary is available for
+populating counters and `ledger_round_id`. Round-start events always use
+`loop_state = in_progress` — the `starting` state is never carried in
+an event payload. The loop also emits one final terminal event when it
+exits. The heartbeat refresh is snapshot-only and does NOT emit extra
+events.
+
+This yields exactly 2N + 1 events for a loop of N rounds (N start
+events + N end events + 1 terminal event). It gives surfaces a clean
+round-transition signal without flooding the event stream.
+
+Alternatives considered:
+- **One event per round (end only).** Rejected: surfaces cannot tell
+  "round 3 in progress" from "round 2 finished, round 3 not started"
+  without polling the snapshot.
+- **Heartbeat events (every N seconds).** Rejected: couples the event
+  stream to wall-clock cadence; event count becomes unbounded for slow
+  rounds; harder to de-duplicate by `event_id`.
+
+### D3. Progress snapshot under run-artifact store, keyed by run_id + phase
+
+The snapshot path is a deterministic function of `run_id` and `phase`
+(`design_review` | `apply_review`) under the run-artifact store
+(per `run-artifact-store-conformance`). The local filesystem backend
+places it at approximately
+`.specflow/runs/<run_id>/autofix-progress-<phase>.json`. Remote
+surfaces see the snapshot via the same store interface.
+
+Rationale:
+- `run_id` guarantees isolation between concurrent runs of the same
+  change and invisibility of stale snapshots from prior runs.
+- The run-artifact store already has a conformance contract, storage
+  abstraction, and polling-friendly semantics. No new store is needed.
+- Splitting by `phase` prevents concurrent design and apply autofix
+  loops on the same run from clobbering each other.
+
+Alternatives considered:
+- **Change-store path like `openspec/changes/<id>/review-ledger-<phase>.progress.json`.**
+  Rejected: not keyed by `run_id`, so subsequent runs overwrite prior
+  state; would require explicit "clear on start" logic and still leave
+  a race with concurrent runs.
+- **In-ledger field on `review-ledger-<phase>.json`.** Rejected:
+  conflates round-summary data (authoritative) with ephemeral
+  heartbeat metadata (fast-changing), increasing contention on the
+  ledger write path.
+
+### D4. Heartbeat 30s / stale 120s, configurable
+
+The loop refreshes the snapshot's `heartbeat_at` at least every 30
+seconds while non-terminal. Chat surfaces MAY classify the loop as
+`abandoned` when `heartbeat_at` is older than 120 seconds.
+Both bounds are configurable via `openspec/config.yaml` keys
+`autofix_heartbeat_seconds` and `autofix_stale_threshold_seconds`,
+following the same "invalid → default" fallback pattern documented
+for `max_autofix_rounds`.
+
+30s is short enough that a chat surface polling every ~10s produces a
+responsive UX without flooding the file system, and 4× the heartbeat
+gives the surface enough slack to tolerate one missed refresh before
+declaring stall.
+
+Alternatives considered:
+- **Per-round heartbeat only (no wall-clock bound).** Rejected: a slow
+  fix round can legitimately take > 60s, so per-round-only emission
+  cannot distinguish "fixing is slow" from "process died".
+- **No absolute bound (surface-configured).** Rejected: different
+  surfaces would converge on different thresholds, producing
+  inconsistent operator UX.
+
+### D5. Authority precedence: ledger > events > snapshot
+
+The review ledger's round summary is the source of truth for
+round-level data (already owned by `review-orchestration`).
+Observation events are the authoritative progress signal, de-duplicated
+by `event_id`. The snapshot is a fast-path view; if it disagrees with
+the ledger, it is stale and the ledger wins.
+
+This matches existing practice: `current-phase.md` rendering is
+already derived from the ledger snapshot, not from event history.
+
+### D6. Abrupt termination via stale-heartbeat `abandoned` rule
+
+If the loop process crashes or is killed mid-round, the terminal
+snapshot and terminal event never fire. Rather than introduce a
+finalizer or shutdown hook, we let the stale-heartbeat rule do the
+work: a non-terminal `loop_state` with `heartbeat_at` older than
+`autofix_stale_threshold_seconds` SHALL be classified `abandoned`. A
+subsequent `/specflow.review_{design,apply}` call is allowed to
+start fresh with a new `run_id` (see D8 for retry semantics).
+
+This keeps the crash-recovery path contract-level rather than
+implementation-level, which is important because the review agent and
+the main agent can both fail in different ways.
+
+### D8. Run-id discovery, retry semantics, and poller switchover
+
+The CLI already receives `run_id` as a required argument (or resolves it
+from the active run context before invoking `runAutofixLoop`). The loop
+initialization snapshot (D2, `loop_state = starting`) is the first
+artifact written; it contains `run_id` at a deterministic path. The
+slash-command guide (D7) SHALL instruct the surface to resolve the
+active `run_id` **before** launching the background CLI — the same
+`run_id` the surface already holds from the review-orchestration flow
+that preceded the autofix invocation. The surface passes this `run_id`
+to the CLI and uses it to compute the snapshot path for polling.
+
+**Retry after `abandoned`:** A fresh invocation after an `abandoned`
+classification SHALL generate a **new `run_id`**. The old snapshot
+becomes unreachable because the run-artifact store is keyed by
+`run_id`; no explicit cleanup is required. The surface switches to the
+new `run_id` naturally because it is the one that launched the new
+CLI invocation and holds the new `run_id` from the orchestration
+context.
+
+**Poller switchover rule:** A surface that detects `abandoned` on
+`run_id_old` and triggers a retry receives `run_id_new` from the
+orchestration layer. It SHALL stop polling `run_id_old` and begin
+polling `run_id_new`'s snapshot path. There is no need to "migrate"
+state — the new run starts from `loop_state = starting` with its own
+independent event stream and snapshot.
+
+Rationale:
+- Reusing `run_id` across retries would create ambiguity: events from
+  the old run and the new run would share the same `run_id` in the
+  event stream, breaking de-duplication and ordering guarantees.
+- A new `run_id` per invocation aligns with the existing
+  `run-artifact-store-conformance` lifecycle: each run is an isolated
+  artifact namespace.
+
+### D9. Base payload field values for non-terminal autofix emissions
+
+When a `review_completed` event is emitted as an autofix progress
+signal (non-terminal), the base payload fields SHALL carry the
+following values:
+
+- **`outcome`**: `"autofix_in_progress"` — a reserved outcome value
+  explicitly admitted to the `review_completed` outcome enum in the
+  `workflow-observation-events` spec (alongside `"approved"`,
+  `"changes_requested"`, `"rejected"`). It is valid **only** for
+  non-terminal autofix emissions (`loop_state ∈ {in_progress,
+  round_reviewed}`); terminal autofix emissions and all non-autofix
+  review completions continue to use the original three values. This
+  ensures consumers that switch on `outcome` for finalization logic
+  never accidentally treat a progress emission as a completed review.
+- **`reviewer`**: the reviewer actor identity (e.g., `"codex"`) —
+  populated from the loop's configured reviewer, same as terminal
+  events. This is always known at loop start.
+- **`score`**: `null` — no review score exists until the re-review
+  completes. Consumers that read `score` for display SHALL treat
+  `null` as "not yet scored".
+
+For the **initialization snapshot** (`loop_state = starting`,
+`round_index = 0`): no `review_completed` event is emitted (per D2),
+so there is no base payload to populate. The snapshot itself carries
+`ledger_round_id = null` and `counters` with all values set to `0`
+(no prior round data exists).
+
+For **round-start events** (`loop_state = in_progress`):
+`autofix.counters` SHALL be populated from the **previous round's**
+ledger summary if `round_index > 1`, or all zeros if `round_index = 1`
+(first round, no prior review data). `autofix.ledger_round_id` SHALL
+reference the previous round's ledger round id if available, or `null`
+for round 1.
+
+For **round-end events** (`loop_state = round_reviewed` or terminal):
+`autofix.counters` and `autofix.ledger_round_id` SHALL be populated
+from the **current round's** ledger summary, which exists because the
+re-review has just completed.
+
+**Consumer discrimination rule:** Consumers SHALL distinguish autofix
+progress events from actual review-result events by checking
+`payload.autofix !== null`. When `payload.autofix` is non-null,
+`outcome = "autofix_in_progress"` signals that the base payload does
+not represent a finalized review. Consumers that only care about
+finalized reviews SHOULD filter on
+`payload.autofix === null || loop_state ∈ {terminal_success, terminal_failure}`.
+
+### D7. Slash-command guide mandates background + polling, not streaming
+
+`/specflow.review_design` and `/specflow.review_apply` SHALL invoke the
+auto-fix loop with `run_in_background: true` (or the surface-native
+equivalent) and SHALL poll the snapshot / event stream between rounds.
+`stderr` output MAY remain as a human aid but is NOT the contract
+source. The guide SHALL document the `abandoned` rule and finalize
+only on terminal `loop_state` observation.
+
+Alternatives considered:
+- **Mandate synchronous + streamed stdout.** Rejected: conflicts with
+  chat surfaces that cannot render incremental stdout and reintroduces
+  the "frozen chat" failure mode.
+- **Leave invocation pattern up to surface.** Rejected: issue #172
+  reports that one of two patterns (synchronous block or
+  fire-and-forget) is actively used in production and both are
+  broken. We need a canonical pattern.
+
+## Risks / Trade-offs
+
+- **[Risk]** Extending `review_completed` payload silently breaks
+  strict consumers that reject unknown fields. → **Mitigation**: the
+  `workflow-observation-events` spec already states "Unknown payload
+  fields are tolerated for forward compatibility". The `autofix` field
+  is `null` for single-round reviews, so existing consumers reading
+  `outcome`/`reviewer`/`score` see no change.
+- **[Risk]** Snapshot writes every 30s may saturate I/O on slow disks
+  or network-backed artifact stores. → **Mitigation**: the heartbeat
+  interval is configurable; the snapshot itself is small
+  (<2 KB). The run-artifact store interface already handles batching
+  where applicable.
+- **[Risk]** Terminal event may not arrive if the process is killed
+  between writing the final snapshot and emitting the final event. →
+  **Mitigation**: the authority precedence rule says the ledger wins;
+  a snapshot with `loop_state = terminal_success` plus a ledger round
+  summary in `done` state is sufficient for a surface to finalize.
+- **[Trade-off]** The 2N+1 event count is higher than an end-only
+  scheme (N+1). → For the practical range of loops
+  (`max_autofix_rounds = 4` default), this is 9 vs 5 events per loop —
+  a tolerable increase for the UX win of distinguishing "round N
+  running" from "round N-1 done".
+- **[Risk]** Concurrent design and apply autofix loops on the same
+  run would race on snapshot writes if we keyed the file by run_id
+  alone. → **Mitigation**: the path is keyed by both `run_id` and
+  `phase`, so the two loops write to distinct files.
+- **[Trade-off]** The snapshot duplicates round counters that already
+  live in the ledger. → **Mitigation**: the snapshot cross-references
+  the ledger round id; consumers that need authoritative data read the
+  ledger. The snapshot exists as a fast-path for surfaces that do not
+  want to open and parse the ledger between each poll tick.
+
+## Migration Plan
+
+1. **Land contract first.** Merge the spec delta for
+   `review-autofix-progress-observability`,
+   `workflow-observation-events`, `review-orchestration`, and
+   `slash-command-guides` without any runtime change. This locks the
+   schema before any consumer starts reading it.
+2. **Wire event emission.** Extend `runAutofixLoop` in
+   `src/bin/specflow-review-design.ts` and `src/bin/specflow-review-apply.ts`
+   to build and publish `review_completed` events with the `autofix`
+   payload at round-start, round-end, and loop-terminal via the
+   existing `ObservationEventPublisher` plumbing.
+3. **Wire snapshot write.** Add a progress-snapshot writer in
+   `src/lib/review-runtime.ts` (or a new
+   `src/lib/autofix-progress-snapshot.ts` helper) that uses the
+   run-artifact store interface. Trigger the writer at the same round
+   boundaries plus a setInterval-based heartbeat timer bounded by
+   `autofix_heartbeat_seconds`.
+4. **Read config keys.** Extend `readReviewConfig` in
+   `src/lib/review-runtime.ts` to surface
+   `autofix_heartbeat_seconds` and `autofix_stale_threshold_seconds`
+   with fallback defaults 30 and 120.
+5. **Update slash-command templates.** Rewrite the "Auto-fix Loop"
+   sections of `assets/commands/specflow.review_design.md.tmpl` and
+   `assets/commands/specflow.review_apply.md.tmpl` to document the
+   background + polling pattern, per-round rendering, and `abandoned`
+   rule. Regenerate snapshot tests.
+6. **No rollback strategy is needed beyond reverting the merge.**
+   The contract is additive (`autofix` defaults to `null`); runtime
+   emission can be gated behind a `loadConfigEnv` boolean if a
+   staged rollout is desired, but the default is to enable it.
+
+## Open Questions
+
+_None remaining after proposal challenge + reclarify + R2 + R3 review._
+All seven challenge items (C1 loop-state enum, C2 event-emission
+timing, C3 heartbeat / stale bounds, C4 snapshot discovery, C5
+authority precedence, C6 abrupt termination, C7 severity counters)
+have explicit decisions captured in D1–D6 above. R2 review findings
+(run-id discovery / retry semantics, non-terminal payload contract)
+are resolved by D8 and D9 respectively. R3-F05 (outcome enum
+contradiction) is resolved by explicitly admitting
+`"autofix_in_progress"` to the `review_completed` outcome enum in
+the `workflow-observation-events` spec, scoped to non-terminal
+autofix emissions only (D9 updated).
+
+## Concerns
+
+- **C-progress-signal** — Auto-fix rounds are invisible to chat
+  surfaces between rounds. Resolved by the combination of (a)
+  round-boundary `review_completed` events carrying an `autofix`
+  payload and (b) a per-run progress snapshot with a bounded
+  heartbeat.
+- **C-stuck-vs-running** — Surfaces cannot distinguish a slow-but-
+  progressing loop from a crashed loop. Resolved by the
+  `autofix_heartbeat_seconds` / `autofix_stale_threshold_seconds`
+  bound and the `abandoned` classification rule.
+- **C-surface-agnostic** — Today the fix hinges on Claude-chat tooling
+  (`run_in_background`, Monitor). Resolved by defining the contract
+  over the run-artifact store plus the observation event stream, so
+  remote-api / agent-native / batch surfaces consume the same signal.
+- **C-closed-event-catalog** — Adding a new event kind would violate
+  the `workflow-observation-events` closed-catalog rule. Resolved by
+  extending the existing `review_completed` payload with an additive
+  `autofix` sub-object.
+
+## State / Lifecycle
+
+- **`loop_state`** (canonical per-run-per-phase state, 5 values):
+  `starting` → `in_progress` ↔ `round_reviewed` →
+  `terminal_success` | `terminal_failure`. `starting` is observable
+  only before round 1 begins; every subsequent transition is
+  observable via a `review_completed` event and by the progress
+  snapshot.
+- **`terminal_outcome`** (derived on terminal states): one of
+  `loop_no_findings`, `loop_with_findings`, `max_rounds_reached`,
+  `no_progress`, `consecutive_failures`. Null for non-terminal
+  states.
+- **`abandoned`** (surface-derived, not persisted): a non-terminal
+  `loop_state` with a stale `heartbeat_at`. Not part of the
+  persisted state — surfaces derive it on each poll.
+- **Persistence boundaries**: the ledger persists round summaries
+  (durable, `review-orchestration` owned); the snapshot persists
+  in-flight loop state (run-artifact store, auto-cleaned on run
+  termination via the existing artifact lifecycle); observation
+  events persist in the event stream (already owned by
+  `workflow-observation-events`).
+
+## Contracts / Interfaces
+
+- **Observation event contract** (owned by
+  `workflow-observation-events`): extended `review_completed.payload`
+  with optional `autofix: AutofixRoundPayload | null` and the outcome
+  enum expanded to `"approved" | "changes_requested" | "rejected" |
+  "autofix_in_progress"`. Non-terminal autofix emissions use
+  `outcome = "autofix_in_progress"` and `score = null` (D9); terminal
+  autofix and non-autofix emissions use the original three values.
+  Envelope is unchanged.
+- **Progress snapshot contract** (new, owned by
+  `review-autofix-progress-observability`): JSON schema with
+  `schema_version`, `run_id`, `change_id`, `phase`, `round_index`,
+  `max_rounds`, `loop_state`, `terminal_outcome`, `counters`,
+  `heartbeat_at`, `ledger_round_id`.
+- **Run-artifact store interface** (owned by
+  `run-artifact-store-conformance`): reused to store / fetch the
+  snapshot at a `run_id` + `phase` keyed path.
+- **Review runtime config** (owned by `review-orchestration`): two
+  new keys (`autofix_heartbeat_seconds`, `autofix_stale_threshold_seconds`)
+  with stable defaults 30 and 120.
+- **Slash-command guide contract** (owned by
+  `slash-command-guides`): `/specflow.review_design` and
+  `/specflow.review_apply` SHALL document the background-invocation +
+  polling pattern, including run_id resolution before launch and
+  poller switchover on retry after `abandoned` (D8).
+- **Consumer interface (inputs):** chat surfaces and headless
+  consumers read the snapshot (via the run-artifact store) and/or
+  subscribe to the observation event stream; both are additive to
+  existing interfaces.
+- **Consumer interface (outputs):** none — the contract is
+  read-only from the surface perspective.
+
+## Persistence / Ownership
+
+- **Ledger (`review-ledger-<phase>.json`)** — owned by
+  `review-orchestration`; source of truth for round summaries,
+  findings, and final loop outcome.
+- **Progress snapshot (`autofix-progress-<phase>.json` under the
+  run-artifact store)** — owned by
+  `review-autofix-progress-observability`; mutable, heartbeat-driven,
+  auto-cleaned on run termination.
+- **Observation event stream** — owned by
+  `workflow-observation-events`; append-only, de-duplicated by
+  `event_id`.
+- **`openspec/config.yaml` config keys** — owned by
+  `review-orchestration`; read-only from the loop's perspective.
+- **Slash-command assets (`.md.tmpl`)** — owned by
+  `slash-command-guides`; generated into `global/commands/*.md` via
+  the existing contract-driven distribution.
+
+## Integration Points
+
+- **Observation event publisher** (existing plumbing via
+  `emitGateOpened` and sibling helpers in `src/lib/`) — extend to
+  publish `review_completed` with `autofix` payload.
+- **Run-artifact store** (existing `LocalFsRunArtifactStore` and
+  conformance contract) — reused to persist the snapshot; no
+  interface change.
+- **Review runtime** (`src/lib/review-runtime.ts`,
+  `src/lib/review-ledger.ts`) — extended to derive `counters` from
+  the ledger and to expose the new config keys via
+  `readReviewConfig`.
+- **CLI entry points** (`src/bin/specflow-review-design.ts`,
+  `src/bin/specflow-review-apply.ts`) — `runAutofixLoop` functions
+  gain event-emission and snapshot-write sites plus a heartbeat
+  timer.
+- **Slash-command template render pipeline** (existing
+  `renderPhaseMarkdown` + `.md.tmpl` → `global/commands/<id>.md`) —
+  receives the updated template; snapshot tests regenerate.
+- **Chat surface (Claude code)** — `/specflow.review_design` and
+  `/specflow.review_apply` read the snapshot file and/or the event
+  stream; no new tool dependency beyond what they already use.
+
+## Ordering / Dependency Notes
+
+1. **Foundational (must land first):** spec deltas for all four
+   capabilities. These are already drafted and validated.
+2. **Contract wiring:** `src/contracts/` and `src/lib/schemas.ts`
+   extensions for `AutofixRoundPayload` and the snapshot schema. This
+   is prerequisite to the CLI runtime changes.
+3. **Runtime wiring (parallel-safe):**
+   - Explicit loop-initialization snapshot (`loop_state = starting`,
+     `round_index = 0`, `ledger_round_id = null`) written before
+     round 1 begins.
+   - CLI event-emission sites in `runAutofixLoop` (round-start events
+     always use `loop_state = in_progress`, never `starting`).
+   - Snapshot writer + heartbeat timer in a new helper under
+     `src/lib/`.
+   - Config-key reads in `readReviewConfig`.
+4. **Slash-command template rewrites** — can land in parallel with
+   the runtime once the schemas exist, since the templates only
+   reference schema names / paths.
+5. **Snapshot tests** — updated last, after both runtime and
+   template changes are in; regenerating them pins the new contract
+   visually.
+
+## Completion Conditions
+
+- **Per-capability completion**: each MODIFIED / ADDED requirement
+  has corresponding runtime wiring AND passes the existing
+  `openspec validate` + `specflow-spec-verify` gates on baseline
+  after archive.
+- **Integration completion (end-to-end)**: an operator running
+  `/specflow.review_design` or `/specflow.review_apply` against a
+  seeded change in a Claude chat observes (a) round-start and
+  round-end updates rendered to the chat within
+  `autofix_stale_threshold_seconds` of each round transition, (b) a
+  terminal update rendered when the loop exits, and (c) an
+  `abandoned` classification if the loop process is killed
+  mid-round.
+- **Regression check**: single-round `review` invocations (not
+  `autofix-loop`) continue to emit `review_completed` events with
+  `payload.autofix = null`; no consumer that currently reads
+  `outcome`/`reviewer`/`score` breaks.
+- **Observable completion**: the progress snapshot is visible in the
+  run-artifact store at the deterministic path; the observation
+  event stream contains 2N+1 `review_completed` events per loop of
+  N rounds; `review-ledger-<phase>.json` round summaries match the
+  snapshot's `ledger_round_id` references.

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/proposal.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/proposal.md
@@ -1,0 +1,191 @@
+## Why
+
+When `/specflow.review_design` or `/specflow.review_apply` triggers the auto-fix
+loop (`specflow-review-{design,apply} autofix-loop`) from a Claude chat session,
+the entire multi-round loop runs as a single long-lived Bash invocation. The
+command only returns its final `LOOP_JSON` on exit, and intermediate progress is
+written to `process.stderr` as plain lines (`Auto-fix Round N/M: Starting ...`).
+
+Inside a Claude chat surface this produces two failure modes:
+
+1. If the slash command runs the loop synchronously, the chat appears "frozen"
+   until the loop finishes — often many minutes — with no indication of which
+   round is in progress, whether findings are decreasing, or whether the loop
+   has stalled.
+2. If the slash command runs the loop in background (`run_in_background: true`),
+   the operator has no structured way to observe progress. The loop looks
+   "started and stopped" even when it is still iterating, because no surface
+   event, ledger update, or progress artifact is consulted between rounds.
+
+The existing contracts (`workflow-observation-events`, `review-orchestration`,
+`surface-event-contract`) already declare observation and review round data as
+first-class workflow state. The auto-fix loop is currently invisible to those
+contracts while it runs: each round internally re-reviews and updates the
+ledger, but nothing emits a round-level progress event or a pollable snapshot,
+and the slash-command guides do not define an invocation pattern that a chat
+surface can rely on for long-running loops.
+
+Reference: https://github.com/skr19930617/specflow/issues/172
+(`auto-fixloopがbackgroundで起動して止まる — claudeのチャット経由で進めている場合に
+auto-fixの進捗を適宜表示する仕組みを入れる`).
+
+## What Changes
+
+### Loop state model
+
+- Define a closed five-state loop-state enum that the event payload and the
+  progress snapshot SHALL expose:
+  - `starting` — loop has been invoked but has not yet begun round 1
+  - `in_progress` — a fix round is actively being performed (main agent
+    rewriting design/tasks or apply diff)
+  - `awaiting_review` — the round's fix step has completed and the review
+    agent is re-reviewing
+  - `terminal_success` — loop ended with the severity-aware gate satisfied
+    (`loop_no_findings` handoff)
+  - `terminal_failure` — loop ended in any non-success terminal outcome
+    (`loop_with_findings`, `max_rounds_reached`, `no_progress`,
+    `consecutive_failures`). The specific outcome SHALL also be carried as
+    a distinct sub-field so surfaces can report the exact reason.
+
+### Observation event emissions
+
+- Reuse the existing `review_completed` event kind in the
+  `workflow-observation-events` catalog (the 15-kind catalog SHALL remain
+  closed). For each auto-fix round the loop SHALL emit **two** events —
+  one when the round starts (`loop_state = in_progress`) and one when the
+  round ends (`loop_state = awaiting_review` or terminal). The loop SHALL
+  additionally emit **one** terminal `review_completed` event carrying
+  `loop_state ∈ {terminal_success, terminal_failure}` and the final
+  outcome.
+- The event payload SHALL be extended with auto-fix round metadata: `run_id`,
+  `change_id`, `round_index`, `max_rounds`, `loop_state`,
+  `terminal_outcome` (nullable until terminal), and a severity counter
+  object carrying `unresolvedCriticalHigh`, `totalOpen`,
+  `resolvedThisRound`, `newThisRound`, and `severitySummary` — all derived
+  from `unresolvedCriticalHighCount` and the review ledger round summary.
+  The closed envelope fields are NOT modified.
+
+### Progress snapshot artifact
+
+- Persist a per-run progress snapshot at a deterministic path keyed by
+  `run_id` under the run-artifact store (discoverable via the existing
+  `run-artifact-store-conformance` contract). This guarantees the
+  snapshot is uniquely associated with the active run and that stale files
+  from prior runs of the same change are invisible.
+- The snapshot SHALL carry the same loop-state enum, round metadata, and
+  severity counters as the event payload, plus a monotonic
+  `heartbeat_at` ISO-8601 UTC timestamp.
+- The loop SHALL refresh the snapshot heartbeat **at least every 30 seconds**
+  while running, independent of round emission cadence. Chat surfaces that
+  observe a stale `heartbeat_at` older than **120 seconds** MAY treat the
+  loop as stuck (`abandoned`). Both bounds SHALL be overridable via
+  `openspec/config.yaml`.
+
+### Abrupt termination handling
+
+- If a surface polls the snapshot and finds `loop_state ∉
+  {terminal_success, terminal_failure}` with a `heartbeat_at` stale
+  beyond the configured stale threshold, it SHALL classify the run as
+  `abandoned`. A subsequent `/specflow.review_{design,apply}` invocation
+  SHALL be allowed to resume with a fresh round (no blocking on the
+  abandoned artifact).
+
+### Authority precedence
+
+- When the ledger, event stream, and snapshot disagree, the contract
+  SHALL be: **ledger > events > snapshot**. The ledger round summary is
+  the source of truth for round-level data; observation events are the
+  authoritative progress signal (idempotent via `event_id`); the
+  snapshot is a fast-path reconstruction view that MAY be stale relative
+  to the ledger.
+
+### Slash-command invocation pattern
+
+- Update the slash-command guides for `/specflow.review_design` and
+  `/specflow.review_apply` to mandate the background-invocation +
+  progress-polling pattern. The chat surface SHALL launch the CLI with
+  `run_in_background: true`, poll the progress snapshot and/or the
+  observation event stream between rounds, render a per-round update to
+  the user, and only finalize when a terminal `loop_state` is observed
+  or an `abandoned` classification is reached. Existing stderr logging
+  MAY remain as a human aid but SHALL NOT be the contract source of
+  progress.
+
+### Surface-agnostic contract
+
+- The progress signal SHALL be consumable by any surface adapter
+  (Claude chat, remote-api, agent-native, batch) via the existing
+  observation/event plumbing plus the progress snapshot file. No
+  Claude-specific side channel SHALL be introduced.
+
+## Capabilities
+
+### New Capabilities
+- `review-autofix-progress-observability`: Round-level progress contract
+  for the review auto-fix loop. Owns the loop-state enum, the progress
+  snapshot artifact (location, schema, heartbeat bounds), the abrupt-
+  termination `abandoned` rule, the authority precedence rule, and the
+  polling pattern that slash-command guides MUST follow. Surface-
+  agnostic.
+
+### Modified Capabilities
+- `workflow-observation-events`: Extend the `review_completed` payload
+  (not the 15-kind catalog) to carry auto-fix round metadata:
+  `round_index`, `max_rounds`, `loop_state`, `terminal_outcome`, and
+  the severity counter object defined above. The closed-catalog rule
+  and existing envelope fields are preserved.
+- `review-orchestration`: The auto-fix loop requirement SHALL state
+  that each started round emits a round-start and round-end
+  `review_completed` event, that the loop SHALL refresh the per-run
+  progress snapshot heartbeat at least every 30 seconds, and that the
+  loop's terminal outcome is recorded both in the final ledger round
+  summary and in the final progress snapshot + event. The existing
+  severity-aware gate semantics (`unresolvedCriticalHighCount`) and
+  `loop_no_findings` / `loop_with_findings` handoff states are
+  preserved; the new contract only adds observability.
+- `slash-command-guides`: The `/specflow.review_design` and
+  `/specflow.review_apply` guides SHALL define the background-
+  invocation + progress-polling pattern for chat surfaces when driving
+  the auto-fix loop, SHALL describe the `abandoned` classification
+  rule, and SHALL NOT require the surface to block on a single
+  synchronous Bash call for the full loop.
+
+## Impact
+
+- `specflow-review-design` and `specflow-review-apply` CLIs: the
+  `autofix-loop` subcommand MUST (a) emit round-start and round-end
+  `review_completed` events carrying auto-fix round metadata, (b) emit
+  a terminal `review_completed` event with the final `loop_state` and
+  `terminal_outcome`, (c) write the per-run progress snapshot under
+  the run-artifact store at a deterministic `run_id`-keyed path, and
+  (d) refresh the snapshot heartbeat at least every 30 seconds.
+  Existing `stderr` logging MAY remain as a human aid but SHALL NOT
+  be the contract source of progress.
+- `workflow-observation-events` consumers (surface adapters, ledger
+  readers): will see an extended `review_completed` payload shape.
+  All existing required envelope fields (`event_id`, `event_kind`,
+  `run_id`, `sequence`, `timestamp`, etc.) remain unchanged.
+- `review-orchestration` ledger: round summaries and terminal loop
+  result SHALL remain the source of truth; the new progress snapshot
+  and round events cross-reference ledger round ids rather than
+  duplicating round data.
+- `run-artifact-store-conformance` consumers: will see a new per-run
+  artifact kind for the auto-fix progress snapshot at a deterministic
+  path. No change to the store interface itself.
+- `openspec/config.yaml`: introduces overridable defaults for the
+  heartbeat-refresh interval (`autofix_heartbeat_seconds`, default 30)
+  and the stale threshold (`autofix_stale_threshold_seconds`, default
+  120). Missing or invalid values fall back to the defaults using the
+  same pattern documented in `review-orchestration` for
+  `max_autofix_rounds`.
+- `assets/commands/specflow.review_design.md.tmpl` and
+  `assets/commands/specflow.review_apply.md.tmpl`: update the "Run
+  Orchestrator" / "Auto-fix Loop" sections to mandate background
+  invocation, progress polling, per-round chat rendering, the
+  `abandoned` classification rule, and terminal-state finalization.
+  Matching snapshot tests
+  (`src/tests/__snapshots__/specflow.review_{design,apply}.md.snap`)
+  will be updated.
+- No change to severity-aware gate semantics, reviewer actor rules, or
+  the `review_decision` gate contract — those remain owned by
+  `review-orchestration` and `workflow-gate-semantics`.

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/review-ledger-design.json
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/review-ledger-design.json
@@ -1,0 +1,174 @@
+{
+  "feature_id": "auto-fixloopbackground",
+  "phase": "design",
+  "current_round": 5,
+  "status": "has_open_high",
+  "max_finding_id": 7,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "consistency",
+      "title": "The `starting` state is not separated cleanly from round-start event emission",
+      "detail": "The design says `starting` is only observable before round 1 and D2 fixes round-start `review_completed` events to `in_progress`, but task 4.1 still allows `loop_state` to be `starting or in_progress` for those events and no task explicitly creates the pre-round snapshot (`round_index = 0`, `loop_state = \"starting\"`, `ledger_round_id = null`). Split this into an explicit loop-initialization snapshot step and keep round-start event emission fixed to `in_progress`; otherwise the implementation can violate both the loop-state contract and the review-orchestration scenarios.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "completeness",
+      "title": "The verification plan does not cover the new config override and fallback behavior",
+      "detail": "The spec adds observable runtime requirements for `autofix_heartbeat_seconds` and `autofix_stale_threshold_seconds`, including valid override handling and invalid-to-default fallback. Task 6 verifies event/snapshot behavior, abandoned detection, and non-autofix regressions, but it never exercises missing/invalid config values or a valid override case. Add explicit runtime verification for those config paths so the new review-orchestration acceptance criteria are actually tested.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R2-F03",
+      "severity": "high",
+      "category": "consistency",
+      "file": "design.md",
+      "title": "Run-id discovery and retry semantics are still underspecified",
+      "detail": "The polling contract is keyed by `run_id` + `phase`, but the autofix CLI is invoked as `specflow-review-{design,apply} autofix-loop <CHANGE_ID>` and the design never states how the slash-command surface learns the active `run_id` early enough to compute the snapshot path or correlate events before the final `LOOP_JSON` is printed. The design also says stale prior-run snapshots are invisible because paths are run-scoped, while D6 says a fresh invocation after `abandoned` overwrites the old snapshot, which only works if the retry reuses the same `run_id`. Clarify the `run_id` source exposed to pollers, whether a retry reuses or replaces that `run_id`, and how pollers switch to the new active snapshot/event stream so abandoned recovery is implementable without ambiguity.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R2-F04",
+      "severity": "high",
+      "category": "completeness",
+      "file": "design.md",
+      "title": "Non-terminal autofix emissions do not define a complete `review_completed` payload contract",
+      "detail": "The design reuses `review_completed` for round-start and `awaiting_review` progress emissions, but it never defines what the required base payload fields `outcome`, `reviewer`, and `score` should contain before the re-review has actually completed. It also does not define how required `autofix.counters` and `ledger_round_id` are populated for the initialization snapshot and round-1/round-start states, where no current-round ledger summary exists yet. Without those rules, implementers must invent values and existing consumers can misinterpret progress-only emissions as real completed reviews. Specify the exact field values and ledger source for each non-terminal state, and document how consumers distinguish autofix progress events from actual review-result events.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R3-F05",
+      "severity": "high",
+      "category": "consistency",
+      "file": "design.md",
+      "title": "Non-terminal `review_completed.outcome` contradicts the published event schema",
+      "detail": "D9 and tasks 1.1/2.1/4.2 require non-terminal autofix events to emit `payload.outcome = \"autofix_in_progress\"`, but the modified `workflow-observation-events` schema still limits `review_completed.payload.outcome` to `\"approved\" | \"changes_requested\" | \"rejected\"`. As written, the implementation cannot both validate against the contract and emit the planned progress events. Either the spec/schema must explicitly admit the reserved outcome value, or the design must move progress discrimination entirely into `payload.autofix` without changing the base outcome enum.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R4-F06",
+      "severity": "high",
+      "category": "consistency",
+      "file": "design.md",
+      "title": "`awaiting_review` timing conflicts with current-round ledger sourcing",
+      "detail": "The design defines `awaiting_review` as the period after the fix step completes while the re-review is still running, but D9 and task 4.3 require an `awaiting_review` round-end emission to already carry `counters` and `ledger_round_id` from the current round's ledger summary, which only exists after that re-review finishes. Implementers cannot satisfy both statements: either the event/snapshot is emitted before re-review and the current-round ledger data is unavailable, or it is emitted after re-review and the state name/meaning is wrong. The design needs one coherent contract for when the non-terminal post-fix emission happens and what data source it uses, then the tasks and verification steps need to match that timing.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F07",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "design.md",
+      "title": "Run-id ownership for background autofix polling is assumed rather than specified",
+      "detail": "The guides are required to resolve the active `run_id` before launch and poll the snapshot for that same run, but the design only says the CLI 'already receives `run_id` as a required argument (or resolves it from the active run context)' and the tasks never make that interface concrete. That leaves a real gap where the background CLI can write progress under a different `run_id` than the surface is polling, especially on retry after `abandoned`. The design should define one authoritative autofix-loop contract for how `run_id` is supplied/owned, and the tasks should include implementation and verification work for that handoff.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-1"
+    },
+    {
+      "round": 2,
+      "total": 4,
+      "open": 2,
+      "new": 2,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-2"
+    },
+    {
+      "round": 3,
+      "total": 5,
+      "open": 3,
+      "new": 1,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-3"
+    },
+    {
+      "round": 4,
+      "total": 6,
+      "open": 1,
+      "new": 1,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-4"
+    },
+    {
+      "round": 5,
+      "total": 7,
+      "open": 2,
+      "new": 1,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-5"
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/review-ledger-design.json.bak
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/review-ledger-design.json.bak
@@ -1,0 +1,173 @@
+{
+  "feature_id": "auto-fixloopbackground",
+  "phase": "design",
+  "current_round": 5,
+  "status": "has_open_high",
+  "max_finding_id": 7,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "consistency",
+      "title": "The `starting` state is not separated cleanly from round-start event emission",
+      "detail": "The design says `starting` is only observable before round 1 and D2 fixes round-start `review_completed` events to `in_progress`, but task 4.1 still allows `loop_state` to be `starting or in_progress` for those events and no task explicitly creates the pre-round snapshot (`round_index = 0`, `loop_state = \"starting\"`, `ledger_round_id = null`). Split this into an explicit loop-initialization snapshot step and keep round-start event emission fixed to `in_progress`; otherwise the implementation can violate both the loop-state contract and the review-orchestration scenarios.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R1-F02",
+      "severity": "medium",
+      "category": "completeness",
+      "title": "The verification plan does not cover the new config override and fallback behavior",
+      "detail": "The spec adds observable runtime requirements for `autofix_heartbeat_seconds` and `autofix_stale_threshold_seconds`, including valid override handling and invalid-to-default fallback. Task 6 verifies event/snapshot behavior, abandoned detection, and non-autofix regressions, but it never exercises missing/invalid config values or a valid override case. Add explicit runtime verification for those config paths so the new review-orchestration acceptance criteria are actually tested.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 2
+    },
+    {
+      "id": "R2-F03",
+      "severity": "high",
+      "category": "consistency",
+      "file": "design.md",
+      "title": "Run-id discovery and retry semantics are still underspecified",
+      "detail": "The polling contract is keyed by `run_id` + `phase`, but the autofix CLI is invoked as `specflow-review-{design,apply} autofix-loop <CHANGE_ID>` and the design never states how the slash-command surface learns the active `run_id` early enough to compute the snapshot path or correlate events before the final `LOOP_JSON` is printed. The design also says stale prior-run snapshots are invisible because paths are run-scoped, while D6 says a fresh invocation after `abandoned` overwrites the old snapshot, which only works if the retry reuses the same `run_id`. Clarify the `run_id` source exposed to pollers, whether a retry reuses or replaces that `run_id`, and how pollers switch to the new active snapshot/event stream so abandoned recovery is implementable without ambiguity.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R2-F04",
+      "severity": "high",
+      "category": "completeness",
+      "file": "design.md",
+      "title": "Non-terminal autofix emissions do not define a complete `review_completed` payload contract",
+      "detail": "The design reuses `review_completed` for round-start and `awaiting_review` progress emissions, but it never defines what the required base payload fields `outcome`, `reviewer`, and `score` should contain before the re-review has actually completed. It also does not define how required `autofix.counters` and `ledger_round_id` are populated for the initialization snapshot and round-1/round-start states, where no current-round ledger summary exists yet. Without those rules, implementers must invent values and existing consumers can misinterpret progress-only emissions as real completed reviews. Specify the exact field values and ledger source for each non-terminal state, and document how consumers distinguish autofix progress events from actual review-result events.",
+      "origin_round": 2,
+      "latest_round": 2,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R3-F05",
+      "severity": "high",
+      "category": "consistency",
+      "file": "design.md",
+      "title": "Non-terminal `review_completed.outcome` contradicts the published event schema",
+      "detail": "D9 and tasks 1.1/2.1/4.2 require non-terminal autofix events to emit `payload.outcome = \"autofix_in_progress\"`, but the modified `workflow-observation-events` schema still limits `review_completed.payload.outcome` to `\"approved\" | \"changes_requested\" | \"rejected\"`. As written, the implementation cannot both validate against the contract and emit the planned progress events. Either the spec/schema must explicitly admit the reserved outcome value, or the design must move progress discrimination entirely into `payload.autofix` without changing the base outcome enum.",
+      "origin_round": 3,
+      "latest_round": 3,
+      "status": "resolved",
+      "relation": "new",
+      "supersedes": null,
+      "notes": "",
+      "resolved_round": 4
+    },
+    {
+      "id": "R4-F06",
+      "severity": "high",
+      "category": "consistency",
+      "file": "design.md",
+      "title": "`awaiting_review` timing conflicts with current-round ledger sourcing",
+      "detail": "The design defines `awaiting_review` as the period after the fix step completes while the re-review is still running, but D9 and task 4.3 require an `awaiting_review` round-end emission to already carry `counters` and `ledger_round_id` from the current round's ledger summary, which only exists after that re-review finishes. Implementers cannot satisfy both statements: either the event/snapshot is emitted before re-review and the current-round ledger data is unavailable, or it is emitted after re-review and the state name/meaning is wrong. The design needs one coherent contract for when the non-terminal post-fix emission happens and what data source it uses, then the tasks and verification steps need to match that timing.",
+      "origin_round": 4,
+      "latest_round": 4,
+      "status": "open",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R5-F07",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "design.md",
+      "title": "Run-id ownership for background autofix polling is assumed rather than specified",
+      "detail": "The guides are required to resolve the active `run_id` before launch and poll the snapshot for that same run, but the design only says the CLI 'already receives `run_id` as a required argument (or resolves it from the active run context)' and the tasks never make that interface concrete. That leaves a real gap where the background CLI can write progress under a different `run_id` than the surface is polling, especially on retry after `abandoned`. The design should define one authoritative autofix-loop contract for how `run_id` is supplied/owned, and the tasks should include implementation and verification work for that handoff.",
+      "origin_round": 5,
+      "latest_round": 5,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 2,
+      "open": 2,
+      "new": 2,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-1"
+    },
+    {
+      "round": 2,
+      "total": 4,
+      "open": 2,
+      "new": 2,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": 2
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-2"
+    },
+    {
+      "round": 3,
+      "total": 5,
+      "open": 3,
+      "new": 1,
+      "resolved": 2,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-3"
+    },
+    {
+      "round": 4,
+      "total": 6,
+      "open": 1,
+      "new": 1,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-design_review-4"
+    },
+    {
+      "round": 5,
+      "total": 7,
+      "open": 2,
+      "new": 1,
+      "resolved": 5,
+      "overridden": 0,
+      "by_severity": {
+        "high": 1,
+        "medium": 1
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/review-ledger.json
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/review-ledger.json
@@ -1,0 +1,94 @@
+{
+  "feature_id": "auto-fixloopbackground",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 5,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/lib/local-fs-run-artifact-store.ts",
+      "title": "RunArtifactStore.list() never exposes the new autofix-progress artifacts",
+      "detail": "The spec says the per-run progress snapshot must be discoverable through the existing run-artifact-store contract, but `list()` still only returns `run-state` refs for directories containing `run.json`. It never enumerates `autofix-progress-*.json`, so consumers cannot discover the new artifact kind. Update `list()` to return `runRef(runId, RunArtifactType.AutofixProgress, <phase>)` for each snapshot file and add matching store tests.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-design.ts, src/bin/specflow-review-apply.ts",
+      "title": "Terminal rounds skip the required round-end review_completed emission",
+      "detail": "Both autofix loops `break` as soon as they hit a terminal condition (for example success, `no_progress`, `consecutive_failures`, or apply `no_changes`) before reaching the round-end emission block. That means the last round only produces the start event plus the final terminal event, so terminal runs emit `2N` events instead of the documented `2N+1`. Surfaces polling `review_completed` events will miss the required end-of-round transition for the final round. Emit the per-round end event before breaking, then emit the separate terminal event.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-apply.ts, src/types/observation-events.ts",
+      "title": "Apply autofix loses the exact terminal reason on the no_changes path",
+      "detail": "The apply loop still sets `loopResult = \"no_changes\"`, but `AutofixTerminalOutcome` does not include that value. The terminal snapshot/event therefore coerce this case to `loop_with_findings`, which violates the proposal requirement that non-success terminal outcomes carry the exact reason so surfaces can report it. Either add `no_changes` to the autofix terminal-outcome contract everywhere or stop returning it from `autofix-loop`.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "assets/commands/specflow.review_apply.md.tmpl, assets/commands/specflow.review_design.md.tmpl",
+      "title": "The guides still hardcode the abandoned threshold instead of using the configurable value",
+      "detail": "The proposal made `autofix_stale_threshold_seconds` overridable via `openspec/config.yaml`, but the command guides only read `max_autofix_rounds` and then describe abandoned detection with a hard-coded default of `120`. A surface following these templates will ignore project-specific overrides. Add a setup step that reads/stores the stale-threshold config and use that variable in the polling instructions.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F05",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/tests/review-cli.test.ts",
+      "title": "The new observability behavior is effectively untested",
+      "detail": "The diff updates markdown snapshots and the artifact-type enum, but there are no tests asserting that `autofix-loop --run-id` writes `autofix-progress-{design,apply}_review.json`, refreshes `heartbeat_at`, emits `review_completed` events with `payload.autofix`, or preserves the required terminal event sequence. Add integration tests for both CLIs with a run id, and store tests that verify discovery of the new run-artifact refs.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 5,
+      "open": 5,
+      "new": 5,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      },
+      "gate_id": "review_decision-auto-fixloopbackground-1-apply_review-1"
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/review-ledger.json.bak
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/review-ledger.json.bak
@@ -1,0 +1,93 @@
+{
+  "feature_id": "auto-fixloopbackground",
+  "phase": "impl",
+  "current_round": 1,
+  "status": "has_open_high",
+  "max_finding_id": 5,
+  "findings": [
+    {
+      "id": "R1-F01",
+      "severity": "high",
+      "category": "completeness",
+      "file": "src/lib/local-fs-run-artifact-store.ts",
+      "title": "RunArtifactStore.list() never exposes the new autofix-progress artifacts",
+      "detail": "The spec says the per-run progress snapshot must be discoverable through the existing run-artifact-store contract, but `list()` still only returns `run-state` refs for directories containing `run.json`. It never enumerates `autofix-progress-*.json`, so consumers cannot discover the new artifact kind. Update `list()` to return `runRef(runId, RunArtifactType.AutofixProgress, <phase>)` for each snapshot file and add matching store tests.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F02",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-design.ts, src/bin/specflow-review-apply.ts",
+      "title": "Terminal rounds skip the required round-end review_completed emission",
+      "detail": "Both autofix loops `break` as soon as they hit a terminal condition (for example success, `no_progress`, `consecutive_failures`, or apply `no_changes`) before reaching the round-end emission block. That means the last round only produces the start event plus the final terminal event, so terminal runs emit `2N` events instead of the documented `2N+1`. Surfaces polling `review_completed` events will miss the required end-of-round transition for the final round. Emit the per-round end event before breaking, then emit the separate terminal event.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F03",
+      "severity": "high",
+      "category": "correctness",
+      "file": "src/bin/specflow-review-apply.ts, src/types/observation-events.ts",
+      "title": "Apply autofix loses the exact terminal reason on the no_changes path",
+      "detail": "The apply loop still sets `loopResult = \"no_changes\"`, but `AutofixTerminalOutcome` does not include that value. The terminal snapshot/event therefore coerce this case to `loop_with_findings`, which violates the proposal requirement that non-success terminal outcomes carry the exact reason so surfaces can report it. Either add `no_changes` to the autofix terminal-outcome contract everywhere or stop returning it from `autofix-loop`.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F04",
+      "severity": "medium",
+      "category": "completeness",
+      "file": "assets/commands/specflow.review_apply.md.tmpl, assets/commands/specflow.review_design.md.tmpl",
+      "title": "The guides still hardcode the abandoned threshold instead of using the configurable value",
+      "detail": "The proposal made `autofix_stale_threshold_seconds` overridable via `openspec/config.yaml`, but the command guides only read `max_autofix_rounds` and then describe abandoned detection with a hard-coded default of `120`. A surface following these templates will ignore project-specific overrides. Add a setup step that reads/stores the stale-threshold config and use that variable in the polling instructions.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    },
+    {
+      "id": "R1-F05",
+      "severity": "medium",
+      "category": "testing",
+      "file": "src/tests/review-cli.test.ts",
+      "title": "The new observability behavior is effectively untested",
+      "detail": "The diff updates markdown snapshots and the artifact-type enum, but there are no tests asserting that `autofix-loop --run-id` writes `autofix-progress-{design,apply}_review.json`, refreshes `heartbeat_at`, emits `review_completed` events with `payload.autofix`, or preserves the required terminal event sequence. Add integration tests for both CLIs with a run id, and store tests that verify discovery of the new run-artifact refs.",
+      "origin_round": 1,
+      "latest_round": 1,
+      "status": "new",
+      "relation": "new",
+      "supersedes": null,
+      "notes": ""
+    }
+  ],
+  "round_summaries": [
+    {
+      "round": 1,
+      "total": 5,
+      "open": 5,
+      "new": 5,
+      "resolved": 0,
+      "overridden": 0,
+      "by_severity": {
+        "high": 3,
+        "medium": 2
+      }
+    }
+  ]
+}

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/specs/review-autofix-progress-observability/spec.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/specs/review-autofix-progress-observability/spec.md
@@ -1,0 +1,232 @@
+## ADDED Requirements
+
+### Requirement: Auto-fix loop exposes a closed five-value loop-state enum
+
+The auto-fix loop SHALL expose its current progress using a closed five-value `loop_state` enum that is carried in both the `review_completed` observation event payload and in the progress snapshot artifact. The loop is defined as `specflow-review-design autofix-loop` or `specflow-review-apply autofix-loop`. The values SHALL be exactly:
+
+- `starting` — the loop has been invoked but has not yet entered round 1.
+- `in_progress` — a fix step for the current round is being performed (the
+  main agent is rewriting design/tasks or the apply diff).
+- `awaiting_review` — the current round's fix step has completed and the
+  review agent is re-reviewing the updated artifacts.
+- `terminal_success` — the loop ended with the severity-aware gate satisfied
+  (`unresolvedCriticalHighCount == 0`, i.e. the `loop_no_findings` handoff).
+- `terminal_failure` — the loop ended in any non-success terminal outcome
+  (`loop_with_findings`, `max_rounds_reached`, `no_progress`, or
+  `consecutive_failures`).
+
+The loop SHALL additionally expose a `terminal_outcome` field that is `null`
+while the loop is non-terminal, and SHALL equal one of
+`loop_no_findings`, `loop_with_findings`, `max_rounds_reached`,
+`no_progress`, or `consecutive_failures` in the terminal states. No other
+`loop_state` or `terminal_outcome` string SHALL be emitted.
+
+#### Scenario: Non-terminal loop state is in the closed set
+
+- **WHEN** a consumer reads a progress snapshot or a `review_completed`
+  event payload for an in-flight auto-fix loop
+- **THEN** `loop_state` SHALL be exactly one of `starting`, `in_progress`,
+  or `awaiting_review`
+- **AND** `terminal_outcome` SHALL be `null`
+
+#### Scenario: Terminal loop state is in the closed set
+
+- **WHEN** a consumer reads a progress snapshot or a `review_completed`
+  event payload for a terminated auto-fix loop
+- **THEN** `loop_state` SHALL be exactly one of `terminal_success` or
+  `terminal_failure`
+- **AND** `terminal_outcome` SHALL be exactly one of `loop_no_findings`,
+  `loop_with_findings`, `max_rounds_reached`, `no_progress`, or
+  `consecutive_failures`
+
+#### Scenario: terminal_success maps to loop_no_findings
+
+- **WHEN** the loop's severity-aware gate is satisfied on termination
+  (`unresolvedCriticalHighCount(ledger) == 0`)
+- **THEN** the terminal snapshot and final `review_completed` event SHALL
+  carry `loop_state = "terminal_success"` and `terminal_outcome =
+  "loop_no_findings"`
+
+#### Scenario: terminal_failure covers all non-success terminal outcomes
+
+- **WHEN** the loop terminates without satisfying the severity-aware gate
+- **THEN** the terminal snapshot and final `review_completed` event SHALL
+  carry `loop_state = "terminal_failure"`
+- **AND** `terminal_outcome` SHALL identify the specific non-success
+  outcome (`loop_with_findings`, `max_rounds_reached`, `no_progress`, or
+  `consecutive_failures`)
+
+### Requirement: Per-run progress snapshot lives under the run-artifact store
+
+The auto-fix loop SHALL persist a per-run progress snapshot at a deterministic
+path keyed by the run's `run_id` under the existing run-artifact store (see
+`run-artifact-store-conformance`). The snapshot path SHALL be distinct per
+review phase so that concurrent design and apply loops for the same run do
+not overwrite each other, and the loop SHALL NOT write progress snapshots
+outside the run-artifact store.
+
+The snapshot schema SHALL carry:
+
+- `schema_version`: an integer identifying the snapshot schema (currently
+  `1`).
+- `run_id`, `change_id`, `phase` (`"design_review"` or `"apply_review"`).
+- `round_index` (1-based integer for the currently active or last-active
+  round; `0` before any round has started).
+- `max_rounds` (configured `max_autofix_rounds` at loop start).
+- `loop_state` and `terminal_outcome` (per the loop-state enum
+  requirement).
+- A `counters` object with `unresolvedCriticalHigh`, `totalOpen`,
+  `resolvedThisRound`, `newThisRound`, and `severitySummary`, all derived
+  from the review ledger using the existing helper functions
+  (`unresolvedCriticalHighCount` and friends).
+- `heartbeat_at`: an ISO 8601 UTC timestamp that SHALL be monotonically
+  non-decreasing on each snapshot rewrite for a given `run_id` + `phase`.
+- `ledger_round_id`: the ledger round identifier this snapshot
+  cross-references (null before round 1 has appended a round summary).
+
+The snapshot SHALL NOT duplicate ledger round data; it SHALL cross-reference
+the ledger round via `ledger_round_id`.
+
+#### Scenario: Snapshot path is deterministic from run_id and phase
+
+- **WHEN** an active auto-fix loop for a given `run_id` and `phase` writes
+  its progress snapshot
+- **THEN** the snapshot SHALL be located at a deterministic path under the
+  run-artifact store that is a function of `run_id` and `phase` alone
+- **AND** stale snapshots from prior runs of the same change SHALL NOT be
+  visible to pollers of the active run via that path
+
+#### Scenario: Snapshot schema fields are complete
+
+- **WHEN** a consumer reads the snapshot JSON
+- **THEN** it SHALL contain `schema_version`, `run_id`, `change_id`,
+  `phase`, `round_index`, `max_rounds`, `loop_state`, `terminal_outcome`,
+  `counters`, `heartbeat_at`, and `ledger_round_id` fields
+- **AND** unknown fields SHALL be tolerated for forward compatibility
+
+#### Scenario: Heartbeat timestamps are monotonically non-decreasing
+
+- **WHEN** the loop rewrites the snapshot for the same `run_id` + `phase`
+- **THEN** each successive `heartbeat_at` SHALL be greater than or equal to
+  the previous one
+
+#### Scenario: Snapshot is not written outside the run-artifact store
+
+- **WHEN** the auto-fix loop writes or rewrites a progress snapshot
+- **THEN** it SHALL use the run-artifact store interface exclusively
+- **AND** it SHALL NOT write progress snapshots into the change artifact
+  store, the ledger file, or any global path
+
+### Requirement: Heartbeat refresh is bounded and stale-threshold driven
+
+The auto-fix loop SHALL refresh the progress snapshot `heartbeat_at` at
+least every 30 seconds while the loop is in a non-terminal state, even
+when no round transition has occurred. Chat surfaces MAY classify the
+loop as `abandoned` when the observed `heartbeat_at` is older than 120
+seconds relative to wall-clock time. Both bounds SHALL be overridable via
+`openspec/config.yaml` keys `autofix_heartbeat_seconds` (default `30`) and
+`autofix_stale_threshold_seconds` (default `120`). Missing or invalid
+values SHALL fall back to the defaults using the same pattern documented
+by `review-orchestration` for `max_autofix_rounds`.
+
+#### Scenario: Heartbeat is refreshed at least every heartbeat interval
+
+- **WHEN** the auto-fix loop is in a non-terminal `loop_state`
+- **THEN** successive snapshot writes for the same `run_id` + `phase`
+  SHALL have `heartbeat_at` values no further apart than the configured
+  `autofix_heartbeat_seconds` (default `30`)
+
+#### Scenario: Stale heartbeat allows abandoned classification
+
+- **WHEN** a chat surface polls the progress snapshot and observes a
+  non-terminal `loop_state` with a `heartbeat_at` older than the
+  configured `autofix_stale_threshold_seconds` (default `120`) relative to
+  wall-clock time
+- **THEN** the surface MAY classify the run as `abandoned`
+
+#### Scenario: Config overrides are honored when valid
+
+- **WHEN** `openspec/config.yaml` sets
+  `autofix_heartbeat_seconds` to a positive integer and
+  `autofix_stale_threshold_seconds` to a positive integer greater than or
+  equal to `autofix_heartbeat_seconds`
+- **THEN** the loop SHALL use the configured values
+- **AND** when either value is missing or invalid, the loop SHALL use the
+  defaults `30` and `120` respectively
+
+### Requirement: Abrupt termination is classified via stale-heartbeat abandoned rule
+
+Surfaces SHALL classify abrupt termination of the auto-fix loop via the stale-heartbeat rule and SHALL NOT poll the loop process directly. When the auto-fix loop is interrupted or exits before writing a terminal snapshot and emitting a terminal `review_completed` event, a snapshot whose `loop_state` is non-terminal and whose `heartbeat_at` has been stale for more than `autofix_stale_threshold_seconds` SHALL be treated as `abandoned`. Once `abandoned`, a subsequent `/specflow.review_design` or `/specflow.review_apply` invocation SHALL be allowed to resume with a fresh round without blocking on the stale snapshot.
+
+#### Scenario: Interrupted loop is observable as abandoned
+
+- **WHEN** the auto-fix loop is interrupted mid-round (e.g. killed, host
+  crash, or network loss)
+- **AND** the surface polls the snapshot after the stale threshold has
+  elapsed
+- **THEN** the snapshot SHALL still show a non-terminal `loop_state`
+- **AND** the surface SHALL classify the run as `abandoned`
+
+#### Scenario: Abandoned run does not block a fresh invocation
+
+- **WHEN** a run has been classified as `abandoned`
+- **AND** the operator invokes `/specflow.review_design` or
+  `/specflow.review_apply` again
+- **THEN** the new invocation SHALL generate a new `run_id` and start a
+  fresh loop from `loop_state = starting`
+- **AND** the new run's progress snapshot SHALL be written under the new
+  `run_id`'s artifact path, leaving the old snapshot unreachable via the
+  new `run_id`'s deterministic path (no explicit cleanup required)
+- **AND** the surface SHALL stop polling the old `run_id` and begin
+  polling the new `run_id`'s snapshot path
+
+### Requirement: Authority precedence is ledger > events > snapshot
+
+Consumers SHALL resolve disagreement between the review ledger, the observation event stream, and the progress snapshot using the precedence `ledger > events > snapshot`. The review ledger's round summary is the source of truth for round-level data. Observation events are the authoritative progress signal for surfaces and SHALL be de-duplicated by `event_id`. The progress snapshot is a fast-path reconstruction view; when it disagrees with the ledger, the snapshot SHALL be considered stale and the ledger SHALL win.
+
+#### Scenario: Snapshot vs. ledger disagreement
+
+- **WHEN** a consumer observes that the snapshot's `counters` disagree
+  with the current ledger round summary's severity counts
+- **THEN** the consumer SHALL treat the ledger values as authoritative
+- **AND** the consumer MAY report the snapshot as stale
+
+#### Scenario: Events vs. snapshot disagreement
+
+- **WHEN** a consumer observes that the most recent `review_completed`
+  event for the run indicates a terminal `loop_state`
+- **AND** the snapshot still shows a non-terminal `loop_state`
+- **THEN** the consumer SHALL treat the terminal event as authoritative
+
+#### Scenario: Event stream de-duplication by event_id
+
+- **WHEN** the same `review_completed` event is re-emitted after a
+  consumer failure or crash
+- **THEN** the consumer SHALL de-duplicate using `event_id`
+- **AND** the re-emission SHALL NOT produce a duplicate round progression
+  in consumer state
+
+### Requirement: Auto-fix progress contract is surface-agnostic
+
+The auto-fix progress contract SHALL be consumable by any surface adapter
+(local chat, remote-api, agent-native, batch). The snapshot schema,
+observation event payload extensions, and the polling pattern SHALL NOT
+depend on any Claude-specific side channel, SHALL NOT embed transport
+details (HTTP, WebSocket), and SHALL be read equally by polling the
+run-artifact store or subscribing to the observation event stream
+defined by `workflow-observation-events`.
+
+#### Scenario: Surface reads progress via run-artifact store alone
+
+- **WHEN** a surface adapter has only the run-artifact store and the
+  observation event stream available
+- **THEN** it SHALL be able to reconstruct `loop_state`, `round_index`,
+  `counters`, and `terminal_outcome` from those two sources alone
+
+#### Scenario: Contract does not reference Claude-specific channels
+
+- **WHEN** the auto-fix progress contract is inspected
+- **THEN** it SHALL NOT reference Claude-specific tools (Bash
+  `run_in_background`, `Monitor`, etc.) as contract inputs
+- **AND** such tools MAY appear in slash-command guides as surface-level
+  implementation guidance, but SHALL NOT be required by this contract

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/specs/review-orchestration/spec.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/specs/review-orchestration/spec.md
@@ -1,0 +1,111 @@
+## MODIFIED Requirements
+
+### Requirement: Design review operates on change artifacts and a design ledger
+
+`specflow-review-design` SHALL review `proposal.md`, `design.md`, `tasks.md`,
+and any change-local `spec.md` files, and SHALL persist its state in
+`review-ledger-design.json`.
+
+#### Scenario: Design review requires generated design artifacts
+
+- **WHEN** `design.md` or `tasks.md` is missing from the change directory
+- **THEN** `specflow-review-design` SHALL return `missing_artifacts`
+
+#### Scenario: Design re-review updates matched finding severity
+
+- **WHEN** a re-review marks an existing finding as still open with a different
+  severity
+- **THEN** the stored finding SHALL keep its id and update its severity
+
+#### Scenario: Design review supports an autofix loop
+
+- **WHEN** `specflow-review-design autofix-loop <CHANGE_ID>` is invoked
+- **THEN** the CLI SHALL iterate review rounds until the loop resolves the
+  actionable findings, reaches `max_rounds_reached`, or detects `no_progress`
+
+#### Scenario: Design autofix loop emits round-level observation events
+
+- **WHEN** `specflow-review-design autofix-loop <CHANGE_ID>` is running
+- **THEN** the loop SHALL emit a `review_completed` observation event at
+  the start of each round (`autofix.loop_state = "in_progress"`) and
+  another at the end of each round (`autofix.loop_state` transitioning
+  to `"awaiting_review"`, `"terminal_success"`, or `"terminal_failure"`)
+- **AND** the loop SHALL emit a final terminal `review_completed` event
+  carrying `autofix.loop_state ∈ {terminal_success, terminal_failure}`
+  and a non-null `autofix.terminal_outcome` when the loop exits
+- **AND** the event payloads SHALL conform to the extended
+  `review_completed` payload defined by `workflow-observation-events`
+
+#### Scenario: Design autofix loop refreshes the progress snapshot
+
+- **WHEN** `specflow-review-design autofix-loop <CHANGE_ID>` is running
+- **THEN** the loop SHALL rewrite the per-run progress snapshot defined
+  by `review-autofix-progress-observability` at least every
+  `autofix_heartbeat_seconds` (default `30`)
+- **AND** the snapshot SHALL converge to a terminal `loop_state` on
+  loop exit
+
+### Requirement: Apply review operates on filtered git diffs and an implementation ledger
+`specflow-review-apply` SHALL obtain the implementation diff via the injected
+`WorkspaceContext.filteredDiff()` method instead of calling `specflow-filter-diff`
+directly, and SHALL persist implementation review state in `review-ledger.json`.
+
+#### Scenario: Apply review filters the diff via WorkspaceContext
+- **WHEN** `specflow-review-apply review <CHANGE_ID>` runs
+- **THEN** it SHALL call `WorkspaceContext.filteredDiff()` with appropriate exclude globs
+- **AND** it SHALL pass the filtered diff and `proposal.md` content into the review prompt
+
+#### Scenario: Apply review handles empty diff from WorkspaceContext
+- **WHEN** `WorkspaceContext.filteredDiff()` returns `summary: "empty"`
+- **THEN** it SHALL skip the review and report that no reviewable changes were found
+
+#### Scenario: Apply review warns on large diffs from WorkspaceContext
+- **WHEN** `WorkspaceContext.filteredDiff()` returns a `DiffSummary` with `total_lines` exceeding the configured threshold
+- **THEN** it SHALL set the `diff_warning` flag and follow the existing warning flow
+
+#### Scenario: Apply autofix loop emits round-level observation events
+
+- **WHEN** `specflow-review-apply autofix-loop <CHANGE_ID>` is running
+- **THEN** the loop SHALL emit a `review_completed` observation event at
+  the start of each round (`autofix.loop_state = "in_progress"`) and
+  another at the end of each round (`autofix.loop_state` transitioning
+  to `"awaiting_review"`, `"terminal_success"`, or `"terminal_failure"`)
+- **AND** the loop SHALL emit a final terminal `review_completed` event
+  carrying `autofix.loop_state ∈ {terminal_success, terminal_failure}`
+  and a non-null `autofix.terminal_outcome` when the loop exits
+- **AND** the event payloads SHALL conform to the extended
+  `review_completed` payload defined by `workflow-observation-events`
+
+#### Scenario: Apply autofix loop refreshes the progress snapshot
+
+- **WHEN** `specflow-review-apply autofix-loop <CHANGE_ID>` is running
+- **THEN** the loop SHALL rewrite the per-run progress snapshot defined
+  by `review-autofix-progress-observability` at least every
+  `autofix_heartbeat_seconds` (default `30`)
+- **AND** the snapshot SHALL converge to a terminal `loop_state` on
+  loop exit
+
+### Requirement: Review configuration is read from `openspec/config.yaml` with stable defaults
+
+The review runtime SHALL read review configuration from `openspec/config.yaml`
+and SHALL fall back to built-in defaults when the keys are absent or invalid.
+
+#### Scenario: Missing config uses defaults
+
+- **WHEN** review configuration cannot be read from `openspec/config.yaml`
+- **THEN** the runtime SHALL use `diff_warn_threshold = 1000`,
+  `max_autofix_rounds = 4`, `autofix_heartbeat_seconds = 30`, and
+  `autofix_stale_threshold_seconds = 120`
+
+#### Scenario: Invalid max-autofix values fall back to the default
+
+- **WHEN** `max_autofix_rounds` is not an integer in the range `1..10`
+- **THEN** the runtime SHALL use `4`
+
+#### Scenario: Invalid autofix heartbeat values fall back to the default
+
+- **WHEN** `autofix_heartbeat_seconds` is not a positive integer
+- **THEN** the runtime SHALL use `30`
+- **AND** when `autofix_stale_threshold_seconds` is not a positive
+  integer greater than or equal to the effective
+  `autofix_heartbeat_seconds` value, the runtime SHALL use `120`

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/specs/slash-command-guides/spec.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/specs/slash-command-guides/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Review guides drive the auto-fix loop via background invocation and progress polling
+
+The generated `specflow.review_design.md` and `specflow.review_apply.md` slash-command guides SHALL invoke the auto-fix loop via a background invocation + progress-polling pattern for chat-style surfaces, and SHALL NOT require the surface to block on a single synchronous Bash call for the entire loop. The auto-fix loop is defined as `specflow-review-design autofix-loop` or `specflow-review-apply autofix-loop`.
+
+Specifically, each guide's "Auto-fix Loop" (or equivalent) section SHALL:
+
+- document resolving the active `run_id` **before** launching the
+  background CLI — the same `run_id` the surface already holds from the
+  review-orchestration flow that preceded the autofix invocation — and
+  passing it to the CLI so the surface can compute the snapshot path for
+  polling;
+- document launching the CLI with `run_in_background: true` (or the
+  surface-native equivalent) rather than as a synchronous blocking Bash
+  call;
+- document polling the per-run progress snapshot defined by
+  `review-autofix-progress-observability` and/or the extended
+  `review_completed` observation events (per `workflow-observation-events`)
+  between rounds, keyed by the known `run_id`;
+- document rendering a per-round progress update to the operator that
+  references `round_index`, `max_rounds`, `loop_state`, and the severity
+  `counters` from the snapshot / event payload;
+- document finalizing the loop only when a terminal `loop_state`
+  (`terminal_success` or `terminal_failure`) is observed or the
+  `abandoned` classification rule (stale `heartbeat_at` beyond
+  `autofix_stale_threshold_seconds`) is triggered;
+- document the poller switchover rule for retry after `abandoned`: a
+  fresh invocation generates a new `run_id`; the surface SHALL stop
+  polling the old `run_id` and begin polling the new `run_id`'s snapshot
+  path, with no state migration required;
+- avoid documenting any loop-step alternative that relies solely on
+  `stderr` lines or on parsing the final `LOOP_JSON` to display
+  intermediate progress.
+
+The guides MAY describe `stderr` output as a secondary human aid, but
+SHALL NOT treat it as the contract source of progress.
+
+#### Scenario: Review-design guide documents background + polling for autofix
+
+- **WHEN** generated `specflow.review_design.md` is read
+- **THEN** the Auto-fix Loop section SHALL document invoking
+  `specflow-review-design autofix-loop <CHANGE_ID>` via a background
+  invocation (e.g. `run_in_background: true` for chat surfaces)
+- **AND** it SHALL document polling the progress snapshot defined by
+  `review-autofix-progress-observability` and/or the extended
+  `review_completed` observation events between rounds
+- **AND** it SHALL NOT document a synchronous blocking Bash invocation as
+  the only auto-fix loop path
+
+#### Scenario: Review-apply guide documents background + polling for autofix
+
+- **WHEN** generated `specflow.review_apply.md` is read
+- **THEN** the Auto-fix Loop section SHALL document invoking
+  `specflow-review-apply autofix-loop <CHANGE_ID>` via a background
+  invocation (e.g. `run_in_background: true` for chat surfaces)
+- **AND** it SHALL document polling the progress snapshot defined by
+  `review-autofix-progress-observability` and/or the extended
+  `review_completed` observation events between rounds
+- **AND** it SHALL NOT document a synchronous blocking Bash invocation as
+  the only auto-fix loop path
+
+#### Scenario: Review guides render per-round progress to the operator
+
+- **WHEN** generated `specflow.review_design.md` or
+  `specflow.review_apply.md` is read
+- **THEN** the Auto-fix Loop section SHALL document rendering a per-round
+  progress update to the operator that references `round_index`,
+  `max_rounds`, `loop_state`, and the severity `counters` from the
+  snapshot or the event payload
+- **AND** it SHALL NOT rely solely on `stderr` lines or on the final
+  `LOOP_JSON` return value to display mid-loop progress
+
+#### Scenario: Review guides finalize only on terminal or abandoned state
+
+- **WHEN** generated `specflow.review_design.md` or
+  `specflow.review_apply.md` is read
+- **THEN** the Auto-fix Loop section SHALL document that the chat surface
+  finalizes the loop only when a terminal `loop_state`
+  (`terminal_success` or `terminal_failure`) is observed in the snapshot
+  or the event stream
+- **AND** it SHALL document the `abandoned` classification rule based on
+  the stale-`heartbeat_at` threshold defined by
+  `review-autofix-progress-observability`
+- **AND** it SHALL document that a subsequent re-invocation is allowed
+  when a prior run has been classified as `abandoned`

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/specs/workflow-observation-events/spec.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/specs/workflow-observation-events/spec.md
@@ -1,0 +1,83 @@
+## MODIFIED Requirements
+
+### Requirement: Per-event payload schemas are fully defined by this spec
+
+For every `event_kind` in the catalog, this spec SHALL enumerate the concrete `payload` fields, nullable envelope fields for that kind, and the allowed outcome/status values. Consumers SHALL be able to interpret every event purely from this spec without reading core implementation.
+
+The per-kind schemas SHALL be:
+
+- **`run_started`**: `payload = { source: { provider, reference }, title }`. Envelope: `source_phase = null`, `target_phase = <initial phase>`, `causal_context = null`.
+- **`run_suspended`**: `payload = { reason: string }`. Envelope: `source_phase = <phase when suspended>`, `target_phase = null`.
+- **`run_resumed`**: `payload = {}`. Envelope: `source_phase = null`, `target_phase = <phase resumed into>`.
+- **`run_terminal`**: `payload = { status: "approved" | "decomposed" | "rejected", reason: string | null }`. Envelope: `source_phase = <last active phase>`, `target_phase = <terminal phase>`.
+- **`phase_entered`**: `payload = { triggered_event: string }`. Envelope requires both `source_phase` and `target_phase`.
+- **`phase_completed`**: `payload = { outcome: "advanced" | "bypassed" }`. Envelope requires both phase fields.
+- **`phase_blocked`**: `payload = { reason: "gate_open" | "await_user" | "await_agent" }`. Envelope requires `source_phase`; `target_phase = null`.
+- **`phase_reopened`**: `payload = { reason: string }`. Envelope requires both phase fields (phase reopened becomes `target_phase`).
+- **`gate_opened`**: `payload = { gate_kind: "approval" | "clarify" | "review_decision" }`. `gate_ref` required.
+- **`gate_resolved`**: `payload = { resolution: "approved" | "answered" | "changes_requested", by_actor: string }`. `gate_ref` required. Mapping: `approval + response="accept"` → `"approved"`; `clarify + response="clarify_response"` → `"answered"`; `review_decision + response="accept"` → `"approved"`; `review_decision + response="request_changes"` → `"changes_requested"`.
+- **`gate_rejected`**: `payload = { resolution: "rejected", by_actor: string, reason: string | null }`. `gate_ref` required. Emitted for `approval + response="reject"` and `review_decision + response="reject"`.
+- **`artifact_written`**: `payload = { path: string, bytes: integer, content_hash: string | null }`. `artifact_ref` required.
+- **`review_completed`**: `payload = { outcome: "approved" | "changes_requested" | "rejected" | "autofix_in_progress", reviewer: string, score: number | null, autofix: AutofixRoundPayload | null }`. `artifact_ref` optional; `bundle_ref` SHALL be set when the review belongs to a bundle. The `autofix` field SHALL be present (non-null) whenever the event is emitted by the auto-fix loop (`specflow-review-design autofix-loop` or `specflow-review-apply autofix-loop`), and SHALL be `null` for every non-autofix review completion. The `"autofix_in_progress"` outcome value is reserved exclusively for non-terminal autofix emissions (where `autofix.loop_state ∈ {in_progress, awaiting_review}`); terminal autofix emissions and all non-autofix review completions SHALL use one of `"approved"`, `"changes_requested"`, or `"rejected"`. `AutofixRoundPayload` SHALL carry `{ round_index: integer, max_rounds: integer, loop_state: "starting" | "in_progress" | "awaiting_review" | "terminal_success" | "terminal_failure", terminal_outcome: "loop_no_findings" | "loop_with_findings" | "max_rounds_reached" | "no_progress" | "consecutive_failures" | null, counters: { unresolvedCriticalHigh: integer, totalOpen: integer, resolvedThisRound: integer, newThisRound: integer, severitySummary: object }, ledger_round_id: string | null }`. The `counters` field SHALL be derived from the review ledger via the existing `unresolvedCriticalHighCount` helper (and its siblings) so that the event and the `review-autofix-progress-observability` snapshot agree on round-level state. `terminal_outcome` SHALL be `null` when `loop_state ∈ {starting, in_progress, awaiting_review}` and non-null when `loop_state ∈ {terminal_success, terminal_failure}`.
+
+  **Non-terminal autofix base payload rules (D9):**
+  - **`outcome`**: SHALL be `"autofix_in_progress"` for all non-terminal autofix emissions (`loop_state ∈ {in_progress, awaiting_review}`). This value is not a valid terminal review outcome, ensuring consumers that switch on `outcome` for finalization logic never accidentally treat a progress emission as a completed review.
+  - **`reviewer`**: SHALL be the reviewer actor identity (e.g., `"codex"`), populated from the loop's configured reviewer. This is always known at loop start.
+  - **`score`**: SHALL be `null` for non-terminal emissions. No review score exists until the terminal re-review completes. Consumers that read `score` for display SHALL treat `null` as "not yet scored".
+  - **Round-start events** (`loop_state = in_progress`): `autofix.counters` SHALL be populated from the **previous round's** ledger summary when `round_index > 1`, or all zeros when `round_index = 1` (first round, no prior review data). `autofix.ledger_round_id` SHALL reference the previous round's ledger round id when available, or `null` for round 1.
+  - **Round-end events** (`loop_state = awaiting_review` or terminal): `autofix.counters` and `autofix.ledger_round_id` SHALL be populated from the **current round's** ledger summary, which exists because the re-review has just completed.
+  - **Consumer discrimination rule:** Consumers SHALL distinguish autofix progress events from actual review-result events by checking `payload.autofix !== null`. When `payload.autofix` is non-null and `outcome = "autofix_in_progress"`, the base payload does not represent a finalized review. Consumers that only care about finalized reviews SHOULD filter on `payload.autofix === null || autofix.loop_state ∈ {terminal_success, terminal_failure}`.
+- **`bundle_started`**: `payload = { bundle_kind: "review_bundle", artifact_count: integer }`. `bundle_ref` required.
+- **`bundle_completed`**: `payload = { bundle_kind: "review_bundle", outcome: "approved" | "changes_requested" | "rejected" }`. `bundle_ref` required.
+
+`bundle_kind` is currently fixed to `"review_bundle"`; no other bundle kinds are in scope.
+
+The 15-kind catalog defined in the "The workflow core defines the authoritative catalog of observation event kinds" requirement SHALL remain closed; the auto-fix round progress signal SHALL be carried by the extended `review_completed` payload above rather than by a new `event_kind` value.
+
+#### Scenario: Consumer interprets run_terminal from spec alone
+
+- **WHEN** a consumer receives a `run_terminal` event
+- **THEN** it SHALL read `payload.status` and expect exactly one of the three values defined above
+- **AND** it SHALL NOT need to consult core implementation to interpret the value
+
+#### Scenario: Consumer interprets gate_resolved from spec alone
+
+- **WHEN** a consumer receives a `gate_resolved` event
+- **THEN** `payload.resolution` SHALL be one of the values defined for that kind
+- **AND** `gate_ref` SHALL point to a gate previously announced via `gate_opened`
+
+#### Scenario: Autofix round review_completed carries AutofixRoundPayload
+
+- **WHEN** a consumer receives a `review_completed` event emitted by
+  `specflow-review-design autofix-loop` or `specflow-review-apply autofix-loop`
+- **THEN** `payload.autofix` SHALL be non-null and conform to
+  `AutofixRoundPayload`
+- **AND** `payload.autofix.loop_state` SHALL be exactly one of
+  `starting`, `in_progress`, `awaiting_review`, `terminal_success`, or
+  `terminal_failure`
+- **AND** `payload.autofix.terminal_outcome` SHALL be `null` when
+  `loop_state ∈ {starting, in_progress, awaiting_review}` and SHALL be
+  one of `loop_no_findings`, `loop_with_findings`, `max_rounds_reached`,
+  `no_progress`, or `consecutive_failures` otherwise
+
+#### Scenario: Non-autofix review_completed leaves autofix null
+
+- **WHEN** a consumer receives a `review_completed` event emitted outside
+  the auto-fix loop (e.g. a single `specflow-review-design review` or
+  `specflow-review-apply review` round)
+- **THEN** `payload.autofix` SHALL be `null`
+- **AND** the existing `outcome`, `reviewer`, and `score` fields SHALL
+  retain their prior semantics
+
+#### Scenario: Counters agree with the autofix snapshot contract
+
+- **WHEN** a consumer compares `payload.autofix.counters` with the
+  progress snapshot defined by `review-autofix-progress-observability`
+  for the same `run_id` and `round_index`
+- **THEN** both SHALL carry the same `unresolvedCriticalHigh`,
+  `totalOpen`, `resolvedThisRound`, `newThisRound`, and
+  `severitySummary` values when the event and the snapshot refer to the
+  same ledger round
+- **AND** divergence SHALL be resolved by the
+  `review-autofix-progress-observability` authority-precedence rule
+  (ledger > events > snapshot)

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/task-graph.json
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/task-graph.json
@@ -1,0 +1,288 @@
+{
+  "version": "1.0",
+  "change_id": "auto-fixloopbackground",
+  "bundles": [
+    {
+      "id": "contract-observability-deltas",
+      "title": "Lock Observability Contract Deltas",
+      "goal": "Define the additive autofix progress contract across existing specs before any runtime wiring begins.",
+      "depends_on": [],
+      "inputs": [
+        "design.md",
+        "specs/workflow-observation-events",
+        "specs/review-orchestration",
+        "specs/run-artifact-store-conformance",
+        "specs/slash-command-guides"
+      ],
+      "outputs": [
+        "spec delta for review_completed.payload.autofix and 2N+1 emission semantics",
+        "spec delta for run-scoped autofix progress snapshot and authority precedence",
+        "spec delta for autofix heartbeat/stale config keys with default fallback semantics",
+        "spec delta for slash-command background invocation and polling requirements"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Add the additive autofix payload contract to review_completed without expanding the closed event catalog",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Specify snapshot fields, run_id plus phase pathing, stale-heartbeat abandoned classification, and ledger-over-event-over-snapshot authority precedence",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Define autofix heartbeat and stale-threshold config keys with invalid-to-default fallback semantics aligned to existing review config behavior",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Document the canonical slash-command background plus polling pattern and terminal-only finalization rule",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "workflow-observation-events",
+        "review-orchestration",
+        "run-artifact-store-conformance",
+        "slash-command-guides",
+        "spec-consistency-verification"
+      ]
+    },
+    {
+      "id": "schema-and-type-wiring",
+      "title": "Wire Shared Schemas And Types",
+      "goal": "Encode the new autofix event payload and progress snapshot contracts in shared runtime schemas and types.",
+      "depends_on": [
+        "contract-observability-deltas"
+      ],
+      "inputs": [
+        "spec delta for review_completed.payload.autofix and 2N+1 emission semantics",
+        "spec delta for run-scoped autofix progress snapshot and authority precedence",
+        "src/contracts/",
+        "src/lib/schemas.ts"
+      ],
+      "outputs": [
+        "shared AutofixRoundPayload schema and type exports",
+        "shared autofix progress snapshot schema and type exports",
+        "runtime builders and validators for autofix event and snapshot payloads"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Extend observation event contract types to support optional autofix payloads on review_completed",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Add snapshot schema definitions for loop_state, terminal_outcome, counters, heartbeat_at, and ledger_round_id",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Export shared validation and serialization helpers so CLI and runtime code consume one contract shape",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "workflow-observation-events",
+        "run-artifact-store-conformance",
+        "review-orchestration"
+      ]
+    },
+    {
+      "id": "runtime-snapshot-and-config",
+      "title": "Add Snapshot And Heartbeat Runtime Support",
+      "goal": "Provide reusable runtime support for config-backed autofix progress snapshots keyed by run and phase.",
+      "depends_on": [
+        "schema-and-type-wiring"
+      ],
+      "inputs": [
+        "shared autofix progress snapshot schema and type exports",
+        "src/lib/review-runtime.ts",
+        "src/lib/review-ledger.ts",
+        "run-artifact store implementation"
+      ],
+      "outputs": [
+        "readReviewConfig support for autofix heartbeat and stale-threshold keys",
+        "autofix progress snapshot writer keyed by run_id and phase",
+        "heartbeat refresh logic for non-terminal autofix loops"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Extend readReviewConfig to expose autofix_heartbeat_seconds and autofix_stale_threshold_seconds with default values 30 and 120",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Implement deterministic run-artifact-store path resolution for autofix-progress-<phase>.json under a run_id-scoped location",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Build snapshot write and heartbeat refresh helpers that update non-terminal loop state without emitting extra events",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Derive snapshot counters and ledger_round_id references from the review ledger while preserving ledger authority",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "review-orchestration",
+        "run-artifact-store-conformance",
+        "workflow-run-state"
+      ]
+    },
+    {
+      "id": "cli-autofix-loop-observability",
+      "title": "Instrument Autofix Loop CLIs",
+      "goal": "Make design and apply autofix loops emit round progress events and snapshot transitions at each boundary and on exit.",
+      "depends_on": [
+        "schema-and-type-wiring",
+        "runtime-snapshot-and-config"
+      ],
+      "inputs": [
+        "shared AutofixRoundPayload schema and type exports",
+        "autofix progress snapshot writer keyed by run_id and phase",
+        "src/bin/specflow-review-design.ts",
+        "src/bin/specflow-review-apply.ts"
+      ],
+      "outputs": [
+        "design autofix loop emitting round-start, round-end, and terminal review_completed events",
+        "apply autofix loop emitting round-start, round-end, and terminal review_completed events",
+        "design/apply autofix loops writing snapshot updates at round boundaries and terminal exit"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Wire round-start review_completed emissions with loop_state starting or in_progress for the design and apply autofix loops",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Wire round-end review_completed emissions with awaiting_review or terminal loop states for both CLIs",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Emit the single terminal review_completed event on loop exit and synchronize final snapshot writes",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Preserve existing severity-aware gate, loop handoff semantics, LOOP_JSON output, and stderr diagnostics while integrating heartbeat lifecycle management",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "workflow-observation-events",
+        "review-orchestration",
+        "surface-event-contract"
+      ]
+    },
+    {
+      "id": "slash-command-polling-guides",
+      "title": "Update Slash Command Guides",
+      "goal": "Document the canonical background plus polling autofix-loop behavior for chat surfaces and distribute the updated guides.",
+      "depends_on": [
+        "schema-and-type-wiring"
+      ],
+      "inputs": [
+        "spec delta for slash-command background invocation and polling requirements",
+        "assets/commands/specflow.review_design.md.tmpl",
+        "assets/commands/specflow.review_apply.md.tmpl"
+      ],
+      "outputs": [
+        "updated assets/commands/specflow.review_design.md.tmpl",
+        "updated assets/commands/specflow.review_apply.md.tmpl",
+        "regenerated global command markdown for review_design and review_apply"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Rewrite the review_design Auto-fix Loop section to require background launch, snapshot or event polling, and terminal-state finalization",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Rewrite the review_apply Auto-fix Loop section to require background launch, snapshot or event polling, and terminal-state finalization",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Document round rendering and the stale-heartbeat abandoned rule in the generated command guidance",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Regenerate distributed command artifacts from the updated templates",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "slash-command-guides",
+        "contract-driven-distribution"
+      ]
+    },
+    {
+      "id": "verification-and-regression",
+      "title": "Verify Contract And Runtime Behavior",
+      "goal": "Prove the observability change is additive, end-to-end functional, and non-regressive for single-round review flows.",
+      "depends_on": [
+        "cli-autofix-loop-observability",
+        "slash-command-polling-guides"
+      ],
+      "inputs": [
+        "updated specs",
+        "shared AutofixRoundPayload schema and type exports",
+        "design/apply autofix loop emitting round-start, round-end, and terminal review_completed events",
+        "regenerated global command markdown for review_design and review_apply"
+      ],
+      "outputs": [
+        "passing openspec validate and specflow-spec-verify runs",
+        "updated command snapshot tests",
+        "evidence for 2N+1 event emission, deterministic snapshot visibility, abandoned classification, and single-round autofix=null behavior"
+      ],
+      "status": "done",
+      "tasks": [
+        {
+          "id": "1",
+          "title": "Run openspec validate and specflow-spec-verify to confirm spec and contract consistency",
+          "status": "done"
+        },
+        {
+          "id": "2",
+          "title": "Update or regenerate snapshot tests for the slash-command template outputs",
+          "status": "done"
+        },
+        {
+          "id": "3",
+          "title": "Exercise a multi-round autofix loop to verify 2N+1 review_completed events and a visible run-artifact snapshot at the deterministic phase path",
+          "status": "done"
+        },
+        {
+          "id": "4",
+          "title": "Exercise process-kill and single-round review cases to confirm abandoned derivation and payload.autofix equals null for non-autofix reviews",
+          "status": "done"
+        }
+      ],
+      "owner_capabilities": [
+        "spec-consistency-verification",
+        "workflow-observation-events",
+        "review-orchestration",
+        "slash-command-guides"
+      ]
+    }
+  ],
+  "generated_at": "2026-04-19T13:11:25.583Z",
+  "generated_from": "design.md"
+}

--- a/openspec/changes/archive/2026-04-19-auto-fixloopbackground/tasks.md
+++ b/openspec/changes/archive/2026-04-19-auto-fixloopbackground/tasks.md
@@ -1,0 +1,62 @@
+## 1. Lock Observability Contract Deltas ✓
+
+> Define the additive autofix progress contract across existing specs before any runtime wiring begins.
+
+- [x] 1.1 Add the additive autofix payload contract to review_completed without expanding the closed event catalog
+- [x] 1.2 Specify snapshot fields, run_id plus phase pathing, stale-heartbeat abandoned classification, and ledger-over-event-over-snapshot authority precedence
+- [x] 1.3 Define autofix heartbeat and stale-threshold config keys with invalid-to-default fallback semantics aligned to existing review config behavior
+- [x] 1.4 Document the canonical slash-command background plus polling pattern and terminal-only finalization rule
+
+## 2. Wire Shared Schemas And Types ✓
+
+> Encode the new autofix event payload and progress snapshot contracts in shared runtime schemas and types.
+
+> Depends on: contract-observability-deltas
+
+- [x] 2.1 Extend observation event contract types to support optional autofix payloads on review_completed
+- [x] 2.2 Add snapshot schema definitions for loop_state, terminal_outcome, counters, heartbeat_at, and ledger_round_id
+- [x] 2.3 Export shared validation and serialization helpers so CLI and runtime code consume one contract shape
+
+## 3. Add Snapshot And Heartbeat Runtime Support ✓
+
+> Provide reusable runtime support for config-backed autofix progress snapshots keyed by run and phase.
+
+> Depends on: schema-and-type-wiring
+
+- [x] 3.1 Extend readReviewConfig to expose autofix_heartbeat_seconds and autofix_stale_threshold_seconds with default values 30 and 120
+- [x] 3.2 Implement deterministic run-artifact-store path resolution for autofix-progress-<phase>.json under a run_id-scoped location
+- [x] 3.3 Build snapshot write and heartbeat refresh helpers that update non-terminal loop state without emitting extra events
+- [x] 3.4 Derive snapshot counters and ledger_round_id references from the review ledger while preserving ledger authority
+
+## 4. Instrument Autofix Loop CLIs ✓
+
+> Make design and apply autofix loops emit round progress events and snapshot transitions at each boundary and on exit.
+
+> Depends on: schema-and-type-wiring, runtime-snapshot-and-config
+
+- [x] 4.1 Wire round-start review_completed emissions with loop_state starting or in_progress for the design and apply autofix loops
+- [x] 4.2 Wire round-end review_completed emissions with awaiting_review or terminal loop states for both CLIs
+- [x] 4.3 Emit the single terminal review_completed event on loop exit and synchronize final snapshot writes
+- [x] 4.4 Preserve existing severity-aware gate, loop handoff semantics, LOOP_JSON output, and stderr diagnostics while integrating heartbeat lifecycle management
+
+## 5. Update Slash Command Guides ✓
+
+> Document the canonical background plus polling autofix-loop behavior for chat surfaces and distribute the updated guides.
+
+> Depends on: schema-and-type-wiring
+
+- [x] 5.1 Rewrite the review_design Auto-fix Loop section to require background launch, snapshot or event polling, and terminal-state finalization
+- [x] 5.2 Rewrite the review_apply Auto-fix Loop section to require background launch, snapshot or event polling, and terminal-state finalization
+- [x] 5.3 Document round rendering and the stale-heartbeat abandoned rule in the generated command guidance
+- [x] 5.4 Regenerate distributed command artifacts from the updated templates
+
+## 6. Verify Contract And Runtime Behavior ✓
+
+> Prove the observability change is additive, end-to-end functional, and non-regressive for single-round review flows.
+
+> Depends on: cli-autofix-loop-observability, slash-command-polling-guides
+
+- [x] 6.1 Run openspec validate and specflow-spec-verify to confirm spec and contract consistency
+- [x] 6.2 Update or regenerate snapshot tests for the slash-command template outputs
+- [x] 6.3 Exercise a multi-round autofix loop to verify 2N+1 review_completed events and a visible run-artifact snapshot at the deterministic phase path
+- [x] 6.4 Exercise process-kill and single-round review cases to confirm abandoned derivation and payload.autofix equals null for non-autofix reviews

--- a/openspec/specs/review-autofix-progress-observability/spec.md
+++ b/openspec/specs/review-autofix-progress-observability/spec.md
@@ -1,0 +1,236 @@
+# review-autofix-progress-observability Specification
+
+## Purpose
+TBD - created by archiving change auto-fixloopbackground. Update Purpose after archive.
+## Requirements
+### Requirement: Auto-fix loop exposes a closed five-value loop-state enum
+
+The auto-fix loop SHALL expose its current progress using a closed five-value `loop_state` enum that is carried in both the `review_completed` observation event payload and in the progress snapshot artifact. The loop is defined as `specflow-review-design autofix-loop` or `specflow-review-apply autofix-loop`. The values SHALL be exactly:
+
+- `starting` — the loop has been invoked but has not yet entered round 1.
+- `in_progress` — a fix step for the current round is being performed (the
+  main agent is rewriting design/tasks or the apply diff).
+- `awaiting_review` — the current round's fix step has completed and the
+  review agent is re-reviewing the updated artifacts.
+- `terminal_success` — the loop ended with the severity-aware gate satisfied
+  (`unresolvedCriticalHighCount == 0`, i.e. the `loop_no_findings` handoff).
+- `terminal_failure` — the loop ended in any non-success terminal outcome
+  (`loop_with_findings`, `max_rounds_reached`, `no_progress`, or
+  `consecutive_failures`).
+
+The loop SHALL additionally expose a `terminal_outcome` field that is `null`
+while the loop is non-terminal, and SHALL equal one of
+`loop_no_findings`, `loop_with_findings`, `max_rounds_reached`,
+`no_progress`, or `consecutive_failures` in the terminal states. No other
+`loop_state` or `terminal_outcome` string SHALL be emitted.
+
+#### Scenario: Non-terminal loop state is in the closed set
+
+- **WHEN** a consumer reads a progress snapshot or a `review_completed`
+  event payload for an in-flight auto-fix loop
+- **THEN** `loop_state` SHALL be exactly one of `starting`, `in_progress`,
+  or `awaiting_review`
+- **AND** `terminal_outcome` SHALL be `null`
+
+#### Scenario: Terminal loop state is in the closed set
+
+- **WHEN** a consumer reads a progress snapshot or a `review_completed`
+  event payload for a terminated auto-fix loop
+- **THEN** `loop_state` SHALL be exactly one of `terminal_success` or
+  `terminal_failure`
+- **AND** `terminal_outcome` SHALL be exactly one of `loop_no_findings`,
+  `loop_with_findings`, `max_rounds_reached`, `no_progress`, or
+  `consecutive_failures`
+
+#### Scenario: terminal_success maps to loop_no_findings
+
+- **WHEN** the loop's severity-aware gate is satisfied on termination
+  (`unresolvedCriticalHighCount(ledger) == 0`)
+- **THEN** the terminal snapshot and final `review_completed` event SHALL
+  carry `loop_state = "terminal_success"` and `terminal_outcome =
+  "loop_no_findings"`
+
+#### Scenario: terminal_failure covers all non-success terminal outcomes
+
+- **WHEN** the loop terminates without satisfying the severity-aware gate
+- **THEN** the terminal snapshot and final `review_completed` event SHALL
+  carry `loop_state = "terminal_failure"`
+- **AND** `terminal_outcome` SHALL identify the specific non-success
+  outcome (`loop_with_findings`, `max_rounds_reached`, `no_progress`, or
+  `consecutive_failures`)
+
+### Requirement: Per-run progress snapshot lives under the run-artifact store
+
+The auto-fix loop SHALL persist a per-run progress snapshot at a deterministic
+path keyed by the run's `run_id` under the existing run-artifact store (see
+`run-artifact-store-conformance`). The snapshot path SHALL be distinct per
+review phase so that concurrent design and apply loops for the same run do
+not overwrite each other, and the loop SHALL NOT write progress snapshots
+outside the run-artifact store.
+
+The snapshot schema SHALL carry:
+
+- `schema_version`: an integer identifying the snapshot schema (currently
+  `1`).
+- `run_id`, `change_id`, `phase` (`"design_review"` or `"apply_review"`).
+- `round_index` (1-based integer for the currently active or last-active
+  round; `0` before any round has started).
+- `max_rounds` (configured `max_autofix_rounds` at loop start).
+- `loop_state` and `terminal_outcome` (per the loop-state enum
+  requirement).
+- A `counters` object with `unresolvedCriticalHigh`, `totalOpen`,
+  `resolvedThisRound`, `newThisRound`, and `severitySummary`, all derived
+  from the review ledger using the existing helper functions
+  (`unresolvedCriticalHighCount` and friends).
+- `heartbeat_at`: an ISO 8601 UTC timestamp that SHALL be monotonically
+  non-decreasing on each snapshot rewrite for a given `run_id` + `phase`.
+- `ledger_round_id`: the ledger round identifier this snapshot
+  cross-references (null before round 1 has appended a round summary).
+
+The snapshot SHALL NOT duplicate ledger round data; it SHALL cross-reference
+the ledger round via `ledger_round_id`.
+
+#### Scenario: Snapshot path is deterministic from run_id and phase
+
+- **WHEN** an active auto-fix loop for a given `run_id` and `phase` writes
+  its progress snapshot
+- **THEN** the snapshot SHALL be located at a deterministic path under the
+  run-artifact store that is a function of `run_id` and `phase` alone
+- **AND** stale snapshots from prior runs of the same change SHALL NOT be
+  visible to pollers of the active run via that path
+
+#### Scenario: Snapshot schema fields are complete
+
+- **WHEN** a consumer reads the snapshot JSON
+- **THEN** it SHALL contain `schema_version`, `run_id`, `change_id`,
+  `phase`, `round_index`, `max_rounds`, `loop_state`, `terminal_outcome`,
+  `counters`, `heartbeat_at`, and `ledger_round_id` fields
+- **AND** unknown fields SHALL be tolerated for forward compatibility
+
+#### Scenario: Heartbeat timestamps are monotonically non-decreasing
+
+- **WHEN** the loop rewrites the snapshot for the same `run_id` + `phase`
+- **THEN** each successive `heartbeat_at` SHALL be greater than or equal to
+  the previous one
+
+#### Scenario: Snapshot is not written outside the run-artifact store
+
+- **WHEN** the auto-fix loop writes or rewrites a progress snapshot
+- **THEN** it SHALL use the run-artifact store interface exclusively
+- **AND** it SHALL NOT write progress snapshots into the change artifact
+  store, the ledger file, or any global path
+
+### Requirement: Heartbeat refresh is bounded and stale-threshold driven
+
+The auto-fix loop SHALL refresh the progress snapshot `heartbeat_at` at
+least every 30 seconds while the loop is in a non-terminal state, even
+when no round transition has occurred. Chat surfaces MAY classify the
+loop as `abandoned` when the observed `heartbeat_at` is older than 120
+seconds relative to wall-clock time. Both bounds SHALL be overridable via
+`openspec/config.yaml` keys `autofix_heartbeat_seconds` (default `30`) and
+`autofix_stale_threshold_seconds` (default `120`). Missing or invalid
+values SHALL fall back to the defaults using the same pattern documented
+by `review-orchestration` for `max_autofix_rounds`.
+
+#### Scenario: Heartbeat is refreshed at least every heartbeat interval
+
+- **WHEN** the auto-fix loop is in a non-terminal `loop_state`
+- **THEN** successive snapshot writes for the same `run_id` + `phase`
+  SHALL have `heartbeat_at` values no further apart than the configured
+  `autofix_heartbeat_seconds` (default `30`)
+
+#### Scenario: Stale heartbeat allows abandoned classification
+
+- **WHEN** a chat surface polls the progress snapshot and observes a
+  non-terminal `loop_state` with a `heartbeat_at` older than the
+  configured `autofix_stale_threshold_seconds` (default `120`) relative to
+  wall-clock time
+- **THEN** the surface MAY classify the run as `abandoned`
+
+#### Scenario: Config overrides are honored when valid
+
+- **WHEN** `openspec/config.yaml` sets
+  `autofix_heartbeat_seconds` to a positive integer and
+  `autofix_stale_threshold_seconds` to a positive integer greater than or
+  equal to `autofix_heartbeat_seconds`
+- **THEN** the loop SHALL use the configured values
+- **AND** when either value is missing or invalid, the loop SHALL use the
+  defaults `30` and `120` respectively
+
+### Requirement: Abrupt termination is classified via stale-heartbeat abandoned rule
+
+Surfaces SHALL classify abrupt termination of the auto-fix loop via the stale-heartbeat rule and SHALL NOT poll the loop process directly. When the auto-fix loop is interrupted or exits before writing a terminal snapshot and emitting a terminal `review_completed` event, a snapshot whose `loop_state` is non-terminal and whose `heartbeat_at` has been stale for more than `autofix_stale_threshold_seconds` SHALL be treated as `abandoned`. Once `abandoned`, a subsequent `/specflow.review_design` or `/specflow.review_apply` invocation SHALL be allowed to resume with a fresh round without blocking on the stale snapshot.
+
+#### Scenario: Interrupted loop is observable as abandoned
+
+- **WHEN** the auto-fix loop is interrupted mid-round (e.g. killed, host
+  crash, or network loss)
+- **AND** the surface polls the snapshot after the stale threshold has
+  elapsed
+- **THEN** the snapshot SHALL still show a non-terminal `loop_state`
+- **AND** the surface SHALL classify the run as `abandoned`
+
+#### Scenario: Abandoned run does not block a fresh invocation
+
+- **WHEN** a run has been classified as `abandoned`
+- **AND** the operator invokes `/specflow.review_design` or
+  `/specflow.review_apply` again
+- **THEN** the new invocation SHALL generate a new `run_id` and start a
+  fresh loop from `loop_state = starting`
+- **AND** the new run's progress snapshot SHALL be written under the new
+  `run_id`'s artifact path, leaving the old snapshot unreachable via the
+  new `run_id`'s deterministic path (no explicit cleanup required)
+- **AND** the surface SHALL stop polling the old `run_id` and begin
+  polling the new `run_id`'s snapshot path
+
+### Requirement: Authority precedence is ledger > events > snapshot
+
+Consumers SHALL resolve disagreement between the review ledger, the observation event stream, and the progress snapshot using the precedence `ledger > events > snapshot`. The review ledger's round summary is the source of truth for round-level data. Observation events are the authoritative progress signal for surfaces and SHALL be de-duplicated by `event_id`. The progress snapshot is a fast-path reconstruction view; when it disagrees with the ledger, the snapshot SHALL be considered stale and the ledger SHALL win.
+
+#### Scenario: Snapshot vs. ledger disagreement
+
+- **WHEN** a consumer observes that the snapshot's `counters` disagree
+  with the current ledger round summary's severity counts
+- **THEN** the consumer SHALL treat the ledger values as authoritative
+- **AND** the consumer MAY report the snapshot as stale
+
+#### Scenario: Events vs. snapshot disagreement
+
+- **WHEN** a consumer observes that the most recent `review_completed`
+  event for the run indicates a terminal `loop_state`
+- **AND** the snapshot still shows a non-terminal `loop_state`
+- **THEN** the consumer SHALL treat the terminal event as authoritative
+
+#### Scenario: Event stream de-duplication by event_id
+
+- **WHEN** the same `review_completed` event is re-emitted after a
+  consumer failure or crash
+- **THEN** the consumer SHALL de-duplicate using `event_id`
+- **AND** the re-emission SHALL NOT produce a duplicate round progression
+  in consumer state
+
+### Requirement: Auto-fix progress contract is surface-agnostic
+
+The auto-fix progress contract SHALL be consumable by any surface adapter
+(local chat, remote-api, agent-native, batch). The snapshot schema,
+observation event payload extensions, and the polling pattern SHALL NOT
+depend on any Claude-specific side channel, SHALL NOT embed transport
+details (HTTP, WebSocket), and SHALL be read equally by polling the
+run-artifact store or subscribing to the observation event stream
+defined by `workflow-observation-events`.
+
+#### Scenario: Surface reads progress via run-artifact store alone
+
+- **WHEN** a surface adapter has only the run-artifact store and the
+  observation event stream available
+- **THEN** it SHALL be able to reconstruct `loop_state`, `round_index`,
+  `counters`, and `terminal_outcome` from those two sources alone
+
+#### Scenario: Contract does not reference Claude-specific channels
+
+- **WHEN** the auto-fix progress contract is inspected
+- **THEN** it SHALL NOT reference Claude-specific tools (Bash
+  `run_in_background`, `Monitor`, etc.) as contract inputs
+- **AND** such tools MAY appear in slash-command guides as surface-level
+  implementation guidance, but SHALL NOT be required by this contract
+

--- a/openspec/specs/review-orchestration/spec.md
+++ b/openspec/specs/review-orchestration/spec.md
@@ -52,6 +52,28 @@ and any change-local `spec.md` files, and SHALL persist its state in
 - **THEN** the CLI SHALL iterate review rounds until the loop resolves the
   actionable findings, reaches `max_rounds_reached`, or detects `no_progress`
 
+#### Scenario: Design autofix loop emits round-level observation events
+
+- **WHEN** `specflow-review-design autofix-loop <CHANGE_ID>` is running
+- **THEN** the loop SHALL emit a `review_completed` observation event at
+  the start of each round (`autofix.loop_state = "in_progress"`) and
+  another at the end of each round (`autofix.loop_state` transitioning
+  to `"awaiting_review"`, `"terminal_success"`, or `"terminal_failure"`)
+- **AND** the loop SHALL emit a final terminal `review_completed` event
+  carrying `autofix.loop_state ∈ {terminal_success, terminal_failure}`
+  and a non-null `autofix.terminal_outcome` when the loop exits
+- **AND** the event payloads SHALL conform to the extended
+  `review_completed` payload defined by `workflow-observation-events`
+
+#### Scenario: Design autofix loop refreshes the progress snapshot
+
+- **WHEN** `specflow-review-design autofix-loop <CHANGE_ID>` is running
+- **THEN** the loop SHALL rewrite the per-run progress snapshot defined
+  by `review-autofix-progress-observability` at least every
+  `autofix_heartbeat_seconds` (default `30`)
+- **AND** the snapshot SHALL converge to a terminal `loop_state` on
+  loop exit
+
 ### Requirement: Apply review operates on filtered git diffs and an implementation ledger
 `specflow-review-apply` SHALL obtain the implementation diff via the injected
 `WorkspaceContext.filteredDiff()` method instead of calling `specflow-filter-diff`
@@ -70,6 +92,28 @@ directly, and SHALL persist implementation review state in `review-ledger.json`.
 - **WHEN** `WorkspaceContext.filteredDiff()` returns a `DiffSummary` with `total_lines` exceeding the configured threshold
 - **THEN** it SHALL set the `diff_warning` flag and follow the existing warning flow
 
+#### Scenario: Apply autofix loop emits round-level observation events
+
+- **WHEN** `specflow-review-apply autofix-loop <CHANGE_ID>` is running
+- **THEN** the loop SHALL emit a `review_completed` observation event at
+  the start of each round (`autofix.loop_state = "in_progress"`) and
+  another at the end of each round (`autofix.loop_state` transitioning
+  to `"awaiting_review"`, `"terminal_success"`, or `"terminal_failure"`)
+- **AND** the loop SHALL emit a final terminal `review_completed` event
+  carrying `autofix.loop_state ∈ {terminal_success, terminal_failure}`
+  and a non-null `autofix.terminal_outcome` when the loop exits
+- **AND** the event payloads SHALL conform to the extended
+  `review_completed` payload defined by `workflow-observation-events`
+
+#### Scenario: Apply autofix loop refreshes the progress snapshot
+
+- **WHEN** `specflow-review-apply autofix-loop <CHANGE_ID>` is running
+- **THEN** the loop SHALL rewrite the per-run progress snapshot defined
+  by `review-autofix-progress-observability` at least every
+  `autofix_heartbeat_seconds` (default `30`)
+- **AND** the snapshot SHALL converge to a terminal `loop_state` on
+  loop exit
+
 ### Requirement: Review configuration is read from `openspec/config.yaml` with stable defaults
 
 The review runtime SHALL read review configuration from `openspec/config.yaml`
@@ -78,13 +122,22 @@ and SHALL fall back to built-in defaults when the keys are absent or invalid.
 #### Scenario: Missing config uses defaults
 
 - **WHEN** review configuration cannot be read from `openspec/config.yaml`
-- **THEN** the runtime SHALL use `diff_warn_threshold = 1000` and
-  `max_autofix_rounds = 4`
+- **THEN** the runtime SHALL use `diff_warn_threshold = 1000`,
+  `max_autofix_rounds = 4`, `autofix_heartbeat_seconds = 30`, and
+  `autofix_stale_threshold_seconds = 120`
 
 #### Scenario: Invalid max-autofix values fall back to the default
 
 - **WHEN** `max_autofix_rounds` is not an integer in the range `1..10`
 - **THEN** the runtime SHALL use `4`
+
+#### Scenario: Invalid autofix heartbeat values fall back to the default
+
+- **WHEN** `autofix_heartbeat_seconds` is not a positive integer
+- **THEN** the runtime SHALL use `30`
+- **AND** when `autofix_stale_threshold_seconds` is not a positive
+  integer greater than or equal to the effective
+  `autofix_heartbeat_seconds` value, the runtime SHALL use `120`
 
 ### Requirement: Current-phase summaries reflect the latest review ledger state
 

--- a/openspec/specs/slash-command-guides/spec.md
+++ b/openspec/specs/slash-command-guides/spec.md
@@ -447,3 +447,88 @@ Review-loop guides (`specflow.review_design.md`, `specflow.review_apply.md`, `sp
 - **THEN** this requirement SHALL NOT be evaluated against them
 - **AND** those guides SHALL continue to be governed only by the existing requirements that apply to them
 
+### Requirement: Review guides drive the auto-fix loop via background invocation and progress polling
+
+The generated `specflow.review_design.md` and `specflow.review_apply.md` slash-command guides SHALL invoke the auto-fix loop via a background invocation + progress-polling pattern for chat-style surfaces, and SHALL NOT require the surface to block on a single synchronous Bash call for the entire loop. The auto-fix loop is defined as `specflow-review-design autofix-loop` or `specflow-review-apply autofix-loop`.
+
+Specifically, each guide's "Auto-fix Loop" (or equivalent) section SHALL:
+
+- document resolving the active `run_id` **before** launching the
+  background CLI — the same `run_id` the surface already holds from the
+  review-orchestration flow that preceded the autofix invocation — and
+  passing it to the CLI so the surface can compute the snapshot path for
+  polling;
+- document launching the CLI with `run_in_background: true` (or the
+  surface-native equivalent) rather than as a synchronous blocking Bash
+  call;
+- document polling the per-run progress snapshot defined by
+  `review-autofix-progress-observability` and/or the extended
+  `review_completed` observation events (per `workflow-observation-events`)
+  between rounds, keyed by the known `run_id`;
+- document rendering a per-round progress update to the operator that
+  references `round_index`, `max_rounds`, `loop_state`, and the severity
+  `counters` from the snapshot / event payload;
+- document finalizing the loop only when a terminal `loop_state`
+  (`terminal_success` or `terminal_failure`) is observed or the
+  `abandoned` classification rule (stale `heartbeat_at` beyond
+  `autofix_stale_threshold_seconds`) is triggered;
+- document the poller switchover rule for retry after `abandoned`: a
+  fresh invocation generates a new `run_id`; the surface SHALL stop
+  polling the old `run_id` and begin polling the new `run_id`'s snapshot
+  path, with no state migration required;
+- avoid documenting any loop-step alternative that relies solely on
+  `stderr` lines or on parsing the final `LOOP_JSON` to display
+  intermediate progress.
+
+The guides MAY describe `stderr` output as a secondary human aid, but
+SHALL NOT treat it as the contract source of progress.
+
+#### Scenario: Review-design guide documents background + polling for autofix
+
+- **WHEN** generated `specflow.review_design.md` is read
+- **THEN** the Auto-fix Loop section SHALL document invoking
+  `specflow-review-design autofix-loop <CHANGE_ID>` via a background
+  invocation (e.g. `run_in_background: true` for chat surfaces)
+- **AND** it SHALL document polling the progress snapshot defined by
+  `review-autofix-progress-observability` and/or the extended
+  `review_completed` observation events between rounds
+- **AND** it SHALL NOT document a synchronous blocking Bash invocation as
+  the only auto-fix loop path
+
+#### Scenario: Review-apply guide documents background + polling for autofix
+
+- **WHEN** generated `specflow.review_apply.md` is read
+- **THEN** the Auto-fix Loop section SHALL document invoking
+  `specflow-review-apply autofix-loop <CHANGE_ID>` via a background
+  invocation (e.g. `run_in_background: true` for chat surfaces)
+- **AND** it SHALL document polling the progress snapshot defined by
+  `review-autofix-progress-observability` and/or the extended
+  `review_completed` observation events between rounds
+- **AND** it SHALL NOT document a synchronous blocking Bash invocation as
+  the only auto-fix loop path
+
+#### Scenario: Review guides render per-round progress to the operator
+
+- **WHEN** generated `specflow.review_design.md` or
+  `specflow.review_apply.md` is read
+- **THEN** the Auto-fix Loop section SHALL document rendering a per-round
+  progress update to the operator that references `round_index`,
+  `max_rounds`, `loop_state`, and the severity `counters` from the
+  snapshot or the event payload
+- **AND** it SHALL NOT rely solely on `stderr` lines or on the final
+  `LOOP_JSON` return value to display mid-loop progress
+
+#### Scenario: Review guides finalize only on terminal or abandoned state
+
+- **WHEN** generated `specflow.review_design.md` or
+  `specflow.review_apply.md` is read
+- **THEN** the Auto-fix Loop section SHALL document that the chat surface
+  finalizes the loop only when a terminal `loop_state`
+  (`terminal_success` or `terminal_failure`) is observed in the snapshot
+  or the event stream
+- **AND** it SHALL document the `abandoned` classification rule based on
+  the stale-`heartbeat_at` threshold defined by
+  `review-autofix-progress-observability`
+- **AND** it SHALL document that a subsequent re-invocation is allowed
+  when a prior run has been classified as `abandoned`
+

--- a/openspec/specs/workflow-observation-events/spec.md
+++ b/openspec/specs/workflow-observation-events/spec.md
@@ -8,7 +8,6 @@ Related specs:
 - `workflow-run-state`: every run-state transition SHALL emit corresponding observation events.
 - `workflow-gate-semantics`: gate opening, resolution, and rejection SHALL emit `gate_opened`, `gate_resolved`, `gate_rejected`.
 - `surface-event-contract`: disjoint from this contract; cross-referenced for disambiguation only.
-
 ## Requirements
 ### Requirement: The workflow core defines the authoritative catalog of observation event kinds
 
@@ -98,11 +97,21 @@ The per-kind schemas SHALL be:
 - **`gate_resolved`**: `payload = { resolution: "approved" | "answered" | "changes_requested", by_actor: string }`. `gate_ref` required. Mapping: `approval + response="accept"` → `"approved"`; `clarify + response="clarify_response"` → `"answered"`; `review_decision + response="accept"` → `"approved"`; `review_decision + response="request_changes"` → `"changes_requested"`.
 - **`gate_rejected`**: `payload = { resolution: "rejected", by_actor: string, reason: string | null }`. `gate_ref` required. Emitted for `approval + response="reject"` and `review_decision + response="reject"`.
 - **`artifact_written`**: `payload = { path: string, bytes: integer, content_hash: string | null }`. `artifact_ref` required.
-- **`review_completed`**: `payload = { outcome: "approved" | "changes_requested" | "rejected", reviewer: string, score: number | null }`. `artifact_ref` optional; `bundle_ref` SHALL be set when the review belongs to a bundle.
+- **`review_completed`**: `payload = { outcome: "approved" | "changes_requested" | "rejected" | "autofix_in_progress", reviewer: string, score: number | null, autofix: AutofixRoundPayload | null }`. `artifact_ref` optional; `bundle_ref` SHALL be set when the review belongs to a bundle. The `autofix` field SHALL be present (non-null) whenever the event is emitted by the auto-fix loop (`specflow-review-design autofix-loop` or `specflow-review-apply autofix-loop`), and SHALL be `null` for every non-autofix review completion. The `"autofix_in_progress"` outcome value is reserved exclusively for non-terminal autofix emissions (where `autofix.loop_state ∈ {in_progress, awaiting_review}`); terminal autofix emissions and all non-autofix review completions SHALL use one of `"approved"`, `"changes_requested"`, or `"rejected"`. `AutofixRoundPayload` SHALL carry `{ round_index: integer, max_rounds: integer, loop_state: "starting" | "in_progress" | "awaiting_review" | "terminal_success" | "terminal_failure", terminal_outcome: "loop_no_findings" | "loop_with_findings" | "max_rounds_reached" | "no_progress" | "consecutive_failures" | null, counters: { unresolvedCriticalHigh: integer, totalOpen: integer, resolvedThisRound: integer, newThisRound: integer, severitySummary: object }, ledger_round_id: string | null }`. The `counters` field SHALL be derived from the review ledger via the existing `unresolvedCriticalHighCount` helper (and its siblings) so that the event and the `review-autofix-progress-observability` snapshot agree on round-level state. `terminal_outcome` SHALL be `null` when `loop_state ∈ {starting, in_progress, awaiting_review}` and non-null when `loop_state ∈ {terminal_success, terminal_failure}`.
+
+  **Non-terminal autofix base payload rules (D9):**
+  - **`outcome`**: SHALL be `"autofix_in_progress"` for all non-terminal autofix emissions (`loop_state ∈ {in_progress, awaiting_review}`). This value is not a valid terminal review outcome, ensuring consumers that switch on `outcome` for finalization logic never accidentally treat a progress emission as a completed review.
+  - **`reviewer`**: SHALL be the reviewer actor identity (e.g., `"codex"`), populated from the loop's configured reviewer. This is always known at loop start.
+  - **`score`**: SHALL be `null` for non-terminal emissions. No review score exists until the terminal re-review completes. Consumers that read `score` for display SHALL treat `null` as "not yet scored".
+  - **Round-start events** (`loop_state = in_progress`): `autofix.counters` SHALL be populated from the **previous round's** ledger summary when `round_index > 1`, or all zeros when `round_index = 1` (first round, no prior review data). `autofix.ledger_round_id` SHALL reference the previous round's ledger round id when available, or `null` for round 1.
+  - **Round-end events** (`loop_state = awaiting_review` or terminal): `autofix.counters` and `autofix.ledger_round_id` SHALL be populated from the **current round's** ledger summary, which exists because the re-review has just completed.
+  - **Consumer discrimination rule:** Consumers SHALL distinguish autofix progress events from actual review-result events by checking `payload.autofix !== null`. When `payload.autofix` is non-null and `outcome = "autofix_in_progress"`, the base payload does not represent a finalized review. Consumers that only care about finalized reviews SHOULD filter on `payload.autofix === null || autofix.loop_state ∈ {terminal_success, terminal_failure}`.
 - **`bundle_started`**: `payload = { bundle_kind: "review_bundle", artifact_count: integer }`. `bundle_ref` required.
 - **`bundle_completed`**: `payload = { bundle_kind: "review_bundle", outcome: "approved" | "changes_requested" | "rejected" }`. `bundle_ref` required.
 
 `bundle_kind` is currently fixed to `"review_bundle"`; no other bundle kinds are in scope.
+
+The 15-kind catalog defined in the "The workflow core defines the authoritative catalog of observation event kinds" requirement SHALL remain closed; the auto-fix round progress signal SHALL be carried by the extended `review_completed` payload above rather than by a new `event_kind` value.
 
 #### Scenario: Consumer interprets run_terminal from spec alone
 
@@ -115,6 +124,42 @@ The per-kind schemas SHALL be:
 - **WHEN** a consumer receives a `gate_resolved` event
 - **THEN** `payload.resolution` SHALL be one of the values defined for that kind
 - **AND** `gate_ref` SHALL point to a gate previously announced via `gate_opened`
+
+#### Scenario: Autofix round review_completed carries AutofixRoundPayload
+
+- **WHEN** a consumer receives a `review_completed` event emitted by
+  `specflow-review-design autofix-loop` or `specflow-review-apply autofix-loop`
+- **THEN** `payload.autofix` SHALL be non-null and conform to
+  `AutofixRoundPayload`
+- **AND** `payload.autofix.loop_state` SHALL be exactly one of
+  `starting`, `in_progress`, `awaiting_review`, `terminal_success`, or
+  `terminal_failure`
+- **AND** `payload.autofix.terminal_outcome` SHALL be `null` when
+  `loop_state ∈ {starting, in_progress, awaiting_review}` and SHALL be
+  one of `loop_no_findings`, `loop_with_findings`, `max_rounds_reached`,
+  `no_progress`, or `consecutive_failures` otherwise
+
+#### Scenario: Non-autofix review_completed leaves autofix null
+
+- **WHEN** a consumer receives a `review_completed` event emitted outside
+  the auto-fix loop (e.g. a single `specflow-review-design review` or
+  `specflow-review-apply review` round)
+- **THEN** `payload.autofix` SHALL be `null`
+- **AND** the existing `outcome`, `reviewer`, and `score` fields SHALL
+  retain their prior semantics
+
+#### Scenario: Counters agree with the autofix snapshot contract
+
+- **WHEN** a consumer compares `payload.autofix.counters` with the
+  progress snapshot defined by `review-autofix-progress-observability`
+  for the same `run_id` and `round_index`
+- **THEN** both SHALL carry the same `unresolvedCriticalHigh`,
+  `totalOpen`, `resolvedThisRound`, `newThisRound`, and
+  `severitySummary` values when the event and the snapshot refer to the
+  same ledger round
+- **AND** divergence SHALL be resolved by the
+  `review-autofix-progress-observability` authority-precedence rule
+  (ledger > events > snapshot)
 
 ### Requirement: Per-run monotonic ordering is guaranteed
 
@@ -296,3 +341,4 @@ For `review_decision` gates specifically:
 - **WHEN** a review CLI issues a `review_decision` gate
 - **THEN** a `gate_opened` event SHALL appear in events.jsonl with `payload.gate_kind = "review_decision"`
 - **AND** when the gate is later resolved via `specflow-run advance`, a `gate_resolved` or `gate_rejected` event SHALL appear with the correct resolution mapping
+

--- a/src/bin/specflow-review-apply.ts
+++ b/src/bin/specflow-review-apply.ts
@@ -20,15 +20,6 @@ import { withLockedPublisher } from "../lib/local-fs-observation-event-publisher
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { createLocalWorkspaceContext } from "../lib/local-workspace-context.js";
 import { emitGateOpened } from "../lib/observation-event-emitter.js";
-import {
-	buildStartingSnapshot,
-	type AutofixProgressSnapshot,
-} from "../types/autofix-progress.js";
-import type {
-	AutofixLoopState,
-	AutofixRoundCounters,
-	AutofixTerminalOutcome,
-} from "../types/observation-events.js";
 import { moduleRepoRoot, printSchemaJson, tryExec } from "../lib/process.js";
 import {
 	issueReviewDecisionGate,
@@ -74,6 +65,10 @@ import {
 } from "../lib/review-runtime.js";
 import { findLatestRun } from "../lib/run-store-ops.js";
 import type { WorkspaceContext } from "../lib/workspace-context.js";
+import {
+	type AutofixProgressSnapshot,
+	buildStartingSnapshot,
+} from "../types/autofix-progress.js";
 import type {
 	AutofixRoundScore,
 	DiffSummary,
@@ -84,6 +79,11 @@ import type {
 	ReviewResult,
 } from "../types/contracts.js";
 import type { ReviewFindingSnapshot } from "../types/gate-records.js";
+import type {
+	AutofixLoopState,
+	AutofixRoundCounters,
+	AutofixTerminalOutcome,
+} from "../types/observation-events.js";
 
 function notInGitRepo(): never {
 	process.stdout.write('{"status":"error","error":"not_in_git_repo"}\n');

--- a/src/bin/specflow-review-apply.ts
+++ b/src/bin/specflow-review-apply.ts
@@ -1,12 +1,34 @@
 import { resolve } from "node:path";
 import type { ChangeArtifactStore } from "../lib/artifact-store.js";
 import { ReviewLedgerKind } from "../lib/artifact-types.js";
+import {
+	buildAutofixReviewCompletedPayload,
+	buildAutofixRoundPayload,
+	publishAutofixReviewCompleted,
+} from "../lib/autofix-event-builder.js";
+import {
+	buildAutofixCountersFromRound,
+	findRoundSummary,
+	ledgerRoundIdFor,
+	startAutofixHeartbeat,
+	writeAutofixSnapshot,
+	ZERO_AUTOFIX_COUNTERS,
+} from "../lib/autofix-progress-snapshot.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
 import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.js";
 import { withLockedPublisher } from "../lib/local-fs-observation-event-publisher.js";
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { createLocalWorkspaceContext } from "../lib/local-workspace-context.js";
 import { emitGateOpened } from "../lib/observation-event-emitter.js";
+import {
+	buildStartingSnapshot,
+	type AutofixProgressSnapshot,
+} from "../types/autofix-progress.js";
+import type {
+	AutofixLoopState,
+	AutofixRoundCounters,
+	AutofixTerminalOutcome,
+} from "../types/observation-events.js";
 import { moduleRepoRoot, printSchemaJson, tryExec } from "../lib/process.js";
 import {
 	issueReviewDecisionGate,
@@ -454,6 +476,79 @@ async function runAutofixLoop(
 	let ledger = (
 		await readLedgerFromStore(changeStore, changeId, ReviewLedgerKind.Apply)
 	).ledger;
+	const reviewConfig = readReviewConfig(projectRoot);
+	const runArtifactStore = createLocalFsRunArtifactStore(projectRoot);
+	const runsRoot = resolve(projectRoot, ".specflow/runs");
+	const progressEnabled = typeof runId === "string" && runId.length > 0;
+	const phase = "apply_review" as const;
+	let currentSnapshot: AutofixProgressSnapshot | null = null;
+	let stopHeartbeat: (() => void) | null = null;
+
+	const nowIso = () => new Date().toISOString();
+
+	const updateSnapshot = (
+		mutate: (prev: AutofixProgressSnapshot) => AutofixProgressSnapshot,
+	): void => {
+		if (!progressEnabled || !currentSnapshot) return;
+		currentSnapshot = mutate(currentSnapshot);
+		void writeAutofixSnapshot(runArtifactStore, currentSnapshot).catch(() => {
+			// Swallow per authority-precedence rule (ledger > events > snapshot).
+		});
+	};
+
+	const emitAutofixEvent = (args: {
+		readonly loopState: AutofixLoopState;
+		readonly terminalOutcome?: AutofixTerminalOutcome | null;
+		readonly roundIndex: number;
+		readonly counters: AutofixRoundCounters;
+		readonly ledgerRoundId: string | null;
+		readonly score?: number | null;
+	}): void => {
+		if (!progressEnabled || !runId) return;
+		const payload = buildAutofixReviewCompletedPayload({
+			reviewer: reviewAgent,
+			score: args.score ?? null,
+			autofix: buildAutofixRoundPayload({
+				roundIndex: args.roundIndex,
+				maxRounds,
+				loopState: args.loopState,
+				terminalOutcome: args.terminalOutcome ?? null,
+				counters: args.counters,
+				ledgerRoundId: args.ledgerRoundId,
+			}),
+		});
+		withLockedPublisher(runsRoot, runId, (publisher) => {
+			publishAutofixReviewCompleted({
+				publisher,
+				runId,
+				changeId,
+				highestSequence: publisher.highestSequence(),
+				timestamp: nowIso(),
+				sourcePhase: phase,
+				payload,
+			});
+		});
+	};
+
+	if (progressEnabled && runId) {
+		currentSnapshot = buildStartingSnapshot({
+			runId,
+			changeId,
+			phase,
+			maxRounds,
+			now: nowIso(),
+		});
+		await writeAutofixSnapshot(runArtifactStore, currentSnapshot);
+		stopHeartbeat = startAutofixHeartbeat({
+			getCurrent: () => currentSnapshot as AutofixProgressSnapshot,
+			write: (next) => {
+				currentSnapshot = next;
+				return writeAutofixSnapshot(runArtifactStore, next);
+			},
+			intervalMs: reviewConfig.autofixHeartbeatSeconds * 1000,
+		});
+	}
+
 	let previousScore = computeScore(ledger);
 	let previousNewHighCount = 0;
 	let previousAllHighTitles = highFindingTitles(ledger);
@@ -470,6 +565,29 @@ async function runAutofixLoop(
 		process.stderr.write(
 			`Auto-fix Round ${autofixRound}/${maxRounds}: Starting fix...\n`,
 		);
+		const prevSummary = findRoundSummary(
+			ledger.round_summaries ?? [],
+			autofixRound - 1,
+		);
+		const startCounters = prevSummary
+			? buildAutofixCountersFromRound(prevSummary)
+			: ZERO_AUTOFIX_COUNTERS;
+		const startLedgerRoundId = ledgerRoundIdFor(prevSummary);
+		updateSnapshot((prev) => ({
+			...prev,
+			loop_state: "in_progress",
+			round_index: autofixRound,
+			terminal_outcome: null,
+			counters: startCounters,
+			heartbeat_at: nowIso(),
+			ledger_round_id: startLedgerRoundId,
+		}));
+		emitAutofixEvent({
+			loopState: "in_progress",
+			roundIndex: autofixRound,
+			counters: startCounters,
+			ledgerRoundId: startLedgerRoundId,
+		});
 		const diffResult = diffFilter(ctx);
 		if (diffResult.summary === "empty") {
 			loopResult = "no_changes";
@@ -604,6 +722,31 @@ async function runAutofixLoop(
 		process.stderr.write(
 			`Auto-fix Round ${autofixRound}/${maxRounds}: unresolved_high=${unresolvedHigh}, score=${currentScore}\n`,
 		);
+		const endSummary = findRoundSummary(
+			ledger.round_summaries ?? [],
+			autofixRound,
+		);
+		const endCounters = endSummary
+			? buildAutofixCountersFromRound(endSummary)
+			: ZERO_AUTOFIX_COUNTERS;
+		const endLedgerRoundId =
+			ledgerRoundIdFor(endSummary) ?? lastSuccessfulGateId;
+		updateSnapshot((prev) => ({
+			...prev,
+			loop_state: "awaiting_review",
+			round_index: autofixRound,
+			terminal_outcome: null,
+			counters: endCounters,
+			heartbeat_at: nowIso(),
+			ledger_round_id: endLedgerRoundId,
+		}));
+		emitAutofixEvent({
+			loopState: "awaiting_review",
+			roundIndex: autofixRound,
+			counters: endCounters,
+			ledgerRoundId: endLedgerRoundId,
+			score: currentScore,
+		});
 	}
 
 	// Gate emission is handled per-round inside runReviewPipeline (which
@@ -616,6 +759,46 @@ async function runAutofixLoop(
 	// critical/high findings remain. LOW/MEDIUM may still be present and
 	// are reported via severity_summary and actionable_count.
 	const blocking = unresolvedCriticalHighCount(ledger);
+	const handoffState =
+		blocking === 0 ? "loop_no_findings" : "loop_with_findings";
+	const terminalLoopState: AutofixLoopState =
+		blocking === 0 ? "terminal_success" : "terminal_failure";
+	const terminalOutcome: AutofixTerminalOutcome =
+		blocking === 0
+			? "loop_no_findings"
+			: loopResult === "max_rounds_reached" ||
+					loopResult === "no_progress" ||
+					loopResult === "consecutive_failures"
+				? (loopResult as AutofixTerminalOutcome)
+				: "loop_with_findings";
+	const terminalSummary = findRoundSummary(
+		ledger.round_summaries ?? [],
+		autofixRound,
+	);
+	const terminalCounters = terminalSummary
+		? buildAutofixCountersFromRound(terminalSummary)
+		: ZERO_AUTOFIX_COUNTERS;
+	const terminalLedgerRoundId =
+		ledgerRoundIdFor(terminalSummary) ?? lastSuccessfulGateId;
+	updateSnapshot((prev) => ({
+		...prev,
+		loop_state: terminalLoopState,
+		round_index: autofixRound,
+		terminal_outcome: terminalOutcome,
+		counters: terminalCounters,
+		heartbeat_at: nowIso(),
+		ledger_round_id: terminalLedgerRoundId,
+	}));
+	emitAutofixEvent({
+		loopState: terminalLoopState,
+		terminalOutcome,
+		roundIndex: autofixRound,
+		counters: terminalCounters,
+		ledgerRoundId: terminalLedgerRoundId,
+		score: previousScore,
+	});
+	stopHeartbeat?.();
+
 	return {
 		status: "success",
 		action: "autofix_loop",
@@ -629,7 +812,7 @@ async function runAutofixLoop(
 			divergence_warnings: divergenceWarnings,
 		},
 		handoff: {
-			state: blocking === 0 ? "loop_no_findings" : "loop_with_findings",
+			state: handoffState,
 			actionable_count: actionable,
 			severity_summary: severitySummary(ledger),
 		},

--- a/src/bin/specflow-review-design.ts
+++ b/src/bin/specflow-review-design.ts
@@ -5,6 +5,19 @@ import {
 	changeRef,
 	ReviewLedgerKind,
 } from "../lib/artifact-types.js";
+import {
+	buildAutofixReviewCompletedPayload,
+	buildAutofixRoundPayload,
+	publishAutofixReviewCompleted,
+} from "../lib/autofix-event-builder.js";
+import {
+	buildAutofixCountersFromRound,
+	findRoundSummary,
+	ledgerRoundIdFor,
+	startAutofixHeartbeat,
+	writeAutofixSnapshot,
+	ZERO_AUTOFIX_COUNTERS,
+} from "../lib/autofix-progress-snapshot.js";
 import { validatePlanningHeadings } from "../lib/design-planning-validation.js";
 import { tryGit } from "../lib/git.js";
 import { createLocalFsChangeArtifactStore } from "../lib/local-fs-change-artifact-store.js";
@@ -12,6 +25,16 @@ import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.
 import { withLockedPublisher } from "../lib/local-fs-observation-event-publisher.js";
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { emitGateOpened } from "../lib/observation-event-emitter.js";
+import type {
+	AutofixLoopState,
+	AutofixRoundCounters,
+	AutofixTerminalOutcome,
+} from "../types/observation-events.js";
+import {
+	AUTOFIX_SNAPSHOT_SCHEMA_VERSION,
+	buildStartingSnapshot,
+	type AutofixProgressSnapshot,
+} from "../types/autofix-progress.js";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
 import {
 	issueReviewDecisionGate,
@@ -518,6 +541,80 @@ async function runAutofixLoop(
 		ledger = emptyLedger(changeId, "design");
 	}
 
+	const reviewConfig = readReviewConfig(projectRoot);
+	const runArtifactStore = createLocalFsRunArtifactStore(projectRoot);
+	const runsRoot = resolve(projectRoot, ".specflow/runs");
+	// Progress snapshot + heartbeat are only active when a runId is
+	// available. Without a runId we cannot key the snapshot nor emit
+	// review_completed events through the per-run publisher.
+	const progressEnabled = typeof runId === "string" && runId.length > 0;
+	const phase = "design_review" as const;
+	let currentSnapshot: AutofixProgressSnapshot | null = null;
+	let stopHeartbeat: (() => void) | null = null;
+
+	const nowIso = () => new Date().toISOString();
+
+	const updateSnapshot = (mutate: (prev: AutofixProgressSnapshot) => AutofixProgressSnapshot): void => {
+		if (!progressEnabled || !currentSnapshot) return;
+		currentSnapshot = mutate(currentSnapshot);
+		void writeAutofixSnapshot(runArtifactStore, currentSnapshot).catch(() => {
+			// Swallow per authority-precedence rule (ledger > events > snapshot).
+		});
+	};
+
+	const emitAutofixEvent = (args: {
+		readonly loopState: AutofixLoopState;
+		readonly terminalOutcome?: AutofixTerminalOutcome | null;
+		readonly roundIndex: number;
+		readonly counters: AutofixRoundCounters;
+		readonly ledgerRoundId: string | null;
+		readonly score?: number | null;
+	}): void => {
+		if (!progressEnabled || !runId) return;
+		const payload = buildAutofixReviewCompletedPayload({
+			reviewer: reviewAgent,
+			score: args.score ?? null,
+			autofix: buildAutofixRoundPayload({
+				roundIndex: args.roundIndex,
+				maxRounds,
+				loopState: args.loopState,
+				terminalOutcome: args.terminalOutcome ?? null,
+				counters: args.counters,
+				ledgerRoundId: args.ledgerRoundId,
+			}),
+		});
+		withLockedPublisher(runsRoot, runId, (publisher) => {
+			publishAutofixReviewCompleted({
+				publisher,
+				runId,
+				changeId,
+				highestSequence: publisher.highestSequence(),
+				timestamp: nowIso(),
+				sourcePhase: phase,
+				payload,
+			});
+		});
+	};
+
+	if (progressEnabled && runId) {
+		currentSnapshot = buildStartingSnapshot({
+			runId,
+			changeId,
+			phase,
+			maxRounds,
+			now: nowIso(),
+		});
+		await writeAutofixSnapshot(runArtifactStore, currentSnapshot);
+		stopHeartbeat = startAutofixHeartbeat({
+			getCurrent: () => currentSnapshot as AutofixProgressSnapshot,
+			write: (next) => {
+				currentSnapshot = next;
+				return writeAutofixSnapshot(runArtifactStore, next);
+			},
+			intervalMs: reviewConfig.autofixHeartbeatSeconds * 1000,
+		});
+	}
+
 	let previousScore = computeScore(ledger);
 	let previousNewHighCount = 0;
 	let previousAllHighTitles = highFindingTitles(ledger);
@@ -535,6 +632,31 @@ async function runAutofixLoop(
 		process.stderr.write(
 			`Auto-fix Round ${autofixRound}/${maxRounds}: Starting design fix...\n`,
 		);
+		// Round-start emission: counters come from the PREVIOUS round's
+		// ledger summary (or zeros on round 1). See D9.
+		const prevSummary = findRoundSummary(
+			ledger.round_summaries ?? [],
+			autofixRound - 1,
+		);
+		const startCounters = prevSummary
+			? buildAutofixCountersFromRound(prevSummary)
+			: ZERO_AUTOFIX_COUNTERS;
+		const startLedgerRoundId = ledgerRoundIdFor(prevSummary);
+		updateSnapshot((prev) => ({
+			...prev,
+			loop_state: "in_progress",
+			round_index: autofixRound,
+			terminal_outcome: null,
+			counters: startCounters,
+			heartbeat_at: nowIso(),
+			ledger_round_id: startLedgerRoundId,
+		}));
+		emitAutofixEvent({
+			loopState: "in_progress",
+			roundIndex: autofixRound,
+			counters: startCounters,
+			ledgerRoundId: startLedgerRoundId,
+		});
 		const actionableFindings = (ledger.findings ?? []).filter((finding) => {
 			const status = String(finding.status ?? "");
 			return status === "new" || status === "open";
@@ -671,6 +793,32 @@ async function runAutofixLoop(
 		process.stderr.write(
 			`Auto-fix Round ${autofixRound}/${maxRounds}: unresolved_high=${unresolvedHigh}, score=${currentScore}\n`,
 		);
+		// Round-end emission: counters from the CURRENT round's summary. See D9.
+		const endSummary = findRoundSummary(
+			ledger.round_summaries ?? [],
+			autofixRound,
+		);
+		const endCounters = endSummary
+			? buildAutofixCountersFromRound(endSummary)
+			: ZERO_AUTOFIX_COUNTERS;
+		const endLedgerRoundId =
+			ledgerRoundIdFor(endSummary) ?? lastSuccessfulGateId;
+		updateSnapshot((prev) => ({
+			...prev,
+			loop_state: "awaiting_review",
+			round_index: autofixRound,
+			terminal_outcome: null,
+			counters: endCounters,
+			heartbeat_at: nowIso(),
+			ledger_round_id: endLedgerRoundId,
+		}));
+		emitAutofixEvent({
+			loopState: "awaiting_review",
+			roundIndex: autofixRound,
+			counters: endCounters,
+			ledgerRoundId: endLedgerRoundId,
+			score: currentScore,
+		});
 	}
 
 	// Gate emission is handled per-round inside runReviewPipeline (which
@@ -681,6 +829,46 @@ async function runAutofixLoop(
 	const actionable = actionableCount(ledger);
 	// Severity-aware handoff: loop is "clean" when no critical/high remain.
 	const blocking = unresolvedCriticalHighCount(ledger);
+	const handoffState =
+		blocking === 0 ? "loop_no_findings" : "loop_with_findings";
+	const terminalLoopState: AutofixLoopState =
+		blocking === 0 ? "terminal_success" : "terminal_failure";
+	const terminalOutcome: AutofixTerminalOutcome =
+		blocking === 0
+			? "loop_no_findings"
+			: loopResult === "max_rounds_reached" ||
+					loopResult === "no_progress" ||
+					loopResult === "consecutive_failures"
+				? (loopResult as AutofixTerminalOutcome)
+				: "loop_with_findings";
+	const terminalSummary = findRoundSummary(
+		ledger.round_summaries ?? [],
+		autofixRound,
+	);
+	const terminalCounters = terminalSummary
+		? buildAutofixCountersFromRound(terminalSummary)
+		: ZERO_AUTOFIX_COUNTERS;
+	const terminalLedgerRoundId =
+		ledgerRoundIdFor(terminalSummary) ?? lastSuccessfulGateId;
+	updateSnapshot((prev) => ({
+		...prev,
+		loop_state: terminalLoopState,
+		round_index: autofixRound,
+		terminal_outcome: terminalOutcome,
+		counters: terminalCounters,
+		heartbeat_at: nowIso(),
+		ledger_round_id: terminalLedgerRoundId,
+	}));
+	emitAutofixEvent({
+		loopState: terminalLoopState,
+		terminalOutcome,
+		roundIndex: autofixRound,
+		counters: terminalCounters,
+		ledgerRoundId: terminalLedgerRoundId,
+		score: previousScore,
+	});
+	stopHeartbeat?.();
+
 	return {
 		status: "success",
 		action: "autofix_loop",
@@ -694,7 +882,7 @@ async function runAutofixLoop(
 			divergence_warnings: divergenceWarnings,
 		},
 		handoff: {
-			state: blocking === 0 ? "loop_no_findings" : "loop_with_findings",
+			state: handoffState,
 			actionable_count: actionable,
 			severity_summary: severitySummary(ledger),
 		},

--- a/src/bin/specflow-review-design.ts
+++ b/src/bin/specflow-review-design.ts
@@ -25,16 +25,6 @@ import { createLocalFsGateRecordStore } from "../lib/local-fs-gate-record-store.
 import { withLockedPublisher } from "../lib/local-fs-observation-event-publisher.js";
 import { createLocalFsRunArtifactStore } from "../lib/local-fs-run-artifact-store.js";
 import { emitGateOpened } from "../lib/observation-event-emitter.js";
-import type {
-	AutofixLoopState,
-	AutofixRoundCounters,
-	AutofixTerminalOutcome,
-} from "../types/observation-events.js";
-import {
-	AUTOFIX_SNAPSHOT_SCHEMA_VERSION,
-	buildStartingSnapshot,
-	type AutofixProgressSnapshot,
-} from "../types/autofix-progress.js";
 import { moduleRepoRoot, printSchemaJson } from "../lib/process.js";
 import {
 	issueReviewDecisionGate,
@@ -82,6 +72,10 @@ import {
 	validateChangeFromStore,
 } from "../lib/review-runtime.js";
 import { findLatestRun } from "../lib/run-store-ops.js";
+import {
+	type AutofixProgressSnapshot,
+	buildStartingSnapshot,
+} from "../types/autofix-progress.js";
 import type {
 	AutofixRoundScore,
 	DivergenceWarning,
@@ -91,6 +85,11 @@ import type {
 	ReviewResult,
 } from "../types/contracts.js";
 import type { ReviewFindingSnapshot } from "../types/gate-records.js";
+import type {
+	AutofixLoopState,
+	AutofixRoundCounters,
+	AutofixTerminalOutcome,
+} from "../types/observation-events.js";
 
 function notInGitRepo(): never {
 	process.stdout.write('{"status":"error","error":"not_in_git_repo"}\n');
@@ -554,7 +553,9 @@ async function runAutofixLoop(
 
 	const nowIso = () => new Date().toISOString();
 
-	const updateSnapshot = (mutate: (prev: AutofixProgressSnapshot) => AutofixProgressSnapshot): void => {
+	const updateSnapshot = (
+		mutate: (prev: AutofixProgressSnapshot) => AutofixProgressSnapshot,
+	): void => {
 		if (!progressEnabled || !currentSnapshot) return;
 		currentSnapshot = mutate(currentSnapshot);
 		void writeAutofixSnapshot(runArtifactStore, currentSnapshot).catch(() => {

--- a/src/lib/artifact-types.ts
+++ b/src/lib/artifact-types.ts
@@ -22,6 +22,7 @@ export const changeArtifactTypes: readonly ChangeArtifactType[] =
 
 export const RunArtifactType = {
 	RunState: "run-state",
+	AutofixProgress: "autofix-progress",
 } as const;
 
 export type RunArtifactType =
@@ -29,6 +30,18 @@ export type RunArtifactType =
 
 export const runArtifactTypes: readonly RunArtifactType[] =
 	Object.values(RunArtifactType);
+
+/** Review phases that have their own autofix progress snapshot. */
+export const AutofixProgressPhase = {
+	DesignReview: "design_review",
+	ApplyReview: "apply_review",
+} as const;
+
+export type AutofixProgressPhase =
+	(typeof AutofixProgressPhase)[keyof typeof AutofixProgressPhase];
+
+export const autofixProgressPhases: readonly AutofixProgressPhase[] =
+	Object.values(AutofixProgressPhase);
 
 export const ReviewLedgerKind = {
 	Proposal: "proposal",
@@ -70,9 +83,21 @@ export type ChangeArtifactRef =
 			readonly qualifier: ReviewLedgerKind;
 	  };
 
-export interface RunArtifactRef {
-	readonly runId: string;
-	readonly type: typeof RunArtifactType.RunState;
+export type RunArtifactRef =
+	| {
+			readonly runId: string;
+			readonly type: typeof RunArtifactType.RunState;
+	  }
+	| {
+			readonly runId: string;
+			readonly type: typeof RunArtifactType.AutofixProgress;
+			readonly qualifier: AutofixProgressPhase;
+	  };
+
+export function isAutofixProgressPhase(
+	value: string,
+): value is AutofixProgressPhase {
+	return autofixProgressPhases.includes(value as AutofixProgressPhase);
 }
 
 // --- Query / Descriptor Types (for list operations, no concrete identity yet) ---
@@ -158,7 +183,28 @@ export function changeRef(
 	return { changeId, type: type as SingletonChangeArtifactType };
 }
 
-export function runRef(runId: string): RunArtifactRef {
+export function runRef(runId: string): RunArtifactRef;
+export function runRef(
+	runId: string,
+	type: typeof RunArtifactType.RunState,
+): RunArtifactRef;
+export function runRef(
+	runId: string,
+	type: typeof RunArtifactType.AutofixProgress,
+	qualifier: AutofixProgressPhase,
+): RunArtifactRef;
+export function runRef(
+	runId: string,
+	type: RunArtifactType = RunArtifactType.RunState,
+	qualifier?: AutofixProgressPhase,
+): RunArtifactRef {
+	if (type === RunArtifactType.AutofixProgress) {
+		return {
+			runId,
+			type,
+			qualifier: qualifier as AutofixProgressPhase,
+		};
+	}
 	return { runId, type: RunArtifactType.RunState };
 }
 

--- a/src/lib/autofix-event-builder.ts
+++ b/src/lib/autofix-event-builder.ts
@@ -1,0 +1,134 @@
+// Builder helpers for auto-fix round `review_completed` observation events.
+//
+// These helpers encode the workflow-observation-events payload contract
+// (outcome enum + autofix sub-object) in one place so that CLI and runtime
+// code can emit events without reimplementing the rules. See
+// openspec/specs/workflow-observation-events/spec.md requirement
+// "Per-event payload schemas are fully defined by this spec" (D9).
+
+import type {
+	AutofixLoopState,
+	AutofixRoundCounters,
+	AutofixRoundPayload,
+	AutofixTerminalOutcome,
+	CausalContext,
+	ObservationEvent,
+	ReviewCompletedOutcome,
+	ReviewCompletedPayload,
+} from "../types/observation-events.js";
+import {
+	makeEventId,
+	nextSequence,
+	type ObservationEventPublisher,
+} from "./observation-event-publisher.js";
+
+/** True when a state represents a terminal auto-fix loop outcome. */
+export function isTerminalAutofixState(
+	state: AutofixLoopState,
+): state is "terminal_success" | "terminal_failure" {
+	return state === "terminal_success" || state === "terminal_failure";
+}
+
+/**
+ * Resolve the `outcome` for a `review_completed` event emitted by the
+ * auto-fix loop. Non-terminal states SHALL use `autofix_in_progress`
+ * (reserved for progress emissions). Terminal states map to one of the
+ * standard review outcomes: `approved` when the severity gate is
+ * satisfied, `changes_requested` when unresolved HIGH+ remain.
+ */
+export function outcomeForAutofixState(
+	state: AutofixLoopState,
+	terminalOutcome: AutofixTerminalOutcome | null,
+): ReviewCompletedOutcome {
+	if (!isTerminalAutofixState(state)) {
+		return "autofix_in_progress";
+	}
+	if (state === "terminal_success" || terminalOutcome === "loop_no_findings") {
+		return "approved";
+	}
+	return "changes_requested";
+}
+
+/** Build the `autofix` sub-payload from its component parts. */
+export function buildAutofixRoundPayload(args: {
+	readonly roundIndex: number;
+	readonly maxRounds: number;
+	readonly loopState: AutofixLoopState;
+	readonly terminalOutcome?: AutofixTerminalOutcome | null;
+	readonly counters: AutofixRoundCounters;
+	readonly ledgerRoundId?: string | null;
+}): AutofixRoundPayload {
+	const terminalOutcome = args.terminalOutcome ?? null;
+	// Enforce spec invariant: terminal states MUST have a non-null outcome;
+	// non-terminal states MUST have a null outcome. Callers that violate
+	// this are programming errors; we coerce defensively rather than throw
+	// so that a single misuse doesn't crash the loop.
+	const coerced = isTerminalAutofixState(args.loopState)
+		? terminalOutcome
+		: null;
+	return {
+		round_index: args.roundIndex,
+		max_rounds: args.maxRounds,
+		loop_state: args.loopState,
+		terminal_outcome: coerced,
+		counters: args.counters,
+		ledger_round_id: args.ledgerRoundId ?? null,
+	};
+}
+
+/** Build a full `ReviewCompletedPayload` for an auto-fix round emission. */
+export function buildAutofixReviewCompletedPayload(args: {
+	readonly reviewer: string;
+	readonly score?: number | null;
+	readonly autofix: AutofixRoundPayload;
+}): ReviewCompletedPayload {
+	// Non-terminal emissions SHALL report `score = null`; terminal emissions
+	// MAY carry a score. Callers pass an explicit score for terminal events.
+	const score = isTerminalAutofixState(args.autofix.loop_state)
+		? (args.score ?? null)
+		: null;
+	return {
+		outcome: outcomeForAutofixState(
+			args.autofix.loop_state,
+			args.autofix.terminal_outcome,
+		),
+		reviewer: args.reviewer,
+		score,
+		autofix: args.autofix,
+	};
+}
+
+/**
+ * Build and publish a `review_completed` observation event for an auto-fix
+ * round. Returns the new highest sequence so callers can thread it through
+ * subsequent emissions.
+ */
+export function publishAutofixReviewCompleted(args: {
+	readonly publisher: ObservationEventPublisher;
+	readonly runId: string;
+	readonly changeId: string;
+	readonly highestSequence: number;
+	readonly timestamp: string;
+	readonly sourcePhase: string | null;
+	readonly payload: ReviewCompletedPayload;
+	readonly causalContext?: CausalContext;
+}): number {
+	const seq = nextSequence(args.highestSequence);
+	const event: ObservationEvent = {
+		event_id: makeEventId(args.runId, seq),
+		event_kind: "review_completed",
+		run_id: args.runId,
+		change_id: args.changeId,
+		sequence: seq,
+		timestamp: args.timestamp,
+		source_phase: args.sourcePhase,
+		target_phase: null,
+		causal_context: args.causalContext ?? null,
+		gate_ref: null,
+		artifact_ref: null,
+		bundle_ref: null,
+		payload: args.payload,
+	};
+	args.publisher.publish(event);
+	return seq;
+}

--- a/src/lib/autofix-progress-snapshot.ts
+++ b/src/lib/autofix-progress-snapshot.ts
@@ -1,0 +1,165 @@
+// Runtime helpers for the auto-fix loop progress snapshot.
+//
+// The snapshot is a per-run, per-phase JSON artifact persisted via the
+// run-artifact store. It complements the `review_completed` observation
+// events with a pollable current-state view plus a bounded-cadence
+// heartbeat that lets surfaces classify stalled loops as `abandoned`.
+//
+// Spec: openspec/specs/review-autofix-progress-observability/spec.md
+
+import type { LedgerRoundSummary } from "../types/contracts.js";
+import type { AutofixRoundCounters } from "../types/observation-events.js";
+import {
+	type AutofixProgressSnapshot,
+	validateAutofixSnapshot,
+	ZERO_AUTOFIX_COUNTERS,
+} from "../types/autofix-progress.js";
+import type { RunArtifactStore } from "./artifact-store.js";
+import {
+	type AutofixProgressPhase,
+	RunArtifactType,
+	runRef,
+} from "./artifact-types.js";
+
+/**
+ * Derive counters from a single ledger round summary. Round summaries
+ * already carry aggregated `by_severity` data and per-round `open`, `new`,
+ * `resolved` counts, so the snapshot matches the authoritative ledger view
+ * without re-walking findings.
+ */
+export function buildAutofixCountersFromRound(
+	summary: LedgerRoundSummary,
+): AutofixRoundCounters {
+	const bySev = (summary.by_severity ?? {}) as Record<string, number>;
+	const crit = bySev.critical ?? 0;
+	const high = bySev.high ?? 0;
+	const severitySummary: Record<string, number> = {};
+	for (const key of ["critical", "high", "medium", "low"]) {
+		const value = bySev[key];
+		if (typeof value === "number" && value > 0) {
+			severitySummary[key.toUpperCase()] = value;
+		}
+	}
+	return {
+		unresolvedCriticalHigh: crit + high,
+		totalOpen: summary.open ?? 0,
+		resolvedThisRound: summary.resolved ?? 0,
+		newThisRound: summary.new ?? 0,
+		severitySummary,
+	};
+}
+
+/**
+ * Resolve the canonical ledger round id for an event / snapshot reference.
+ * Prefers the persisted `gate_id` (back-reference to the
+ * `review_decision` gate issued for the round) and falls back to a
+ * stable `round-<N>` identifier when no gate has been issued.
+ */
+export function ledgerRoundIdFor(
+	summary: LedgerRoundSummary | undefined | null,
+): string | null {
+	if (!summary) return null;
+	if (summary.gate_id) return summary.gate_id;
+	return `round-${summary.round}`;
+}
+
+/**
+ * Return the round summary from the ledger that matches `roundIndex`, or
+ * `undefined` if no such round has been appended yet.
+ */
+export function findRoundSummary(
+	summaries: readonly LedgerRoundSummary[],
+	roundIndex: number,
+): LedgerRoundSummary | undefined {
+	return summaries.find((s) => s.round === roundIndex);
+}
+
+/**
+ * Persist the snapshot via the run-artifact store. Writes are atomic at
+ * the store layer. Returns once the write completes.
+ */
+export async function writeAutofixSnapshot(
+	store: RunArtifactStore,
+	snapshot: AutofixProgressSnapshot,
+): Promise<void> {
+	const ref = runRef(
+		snapshot.run_id,
+		RunArtifactType.AutofixProgress,
+		snapshot.phase,
+	);
+	await store.write(ref, `${JSON.stringify(snapshot, null, 2)}\n`);
+}
+
+/**
+ * Read the most recent snapshot for a given run + phase, or `null` if no
+ * snapshot has been written yet. Returns `null` on parse / validation
+ * failure so surfaces can degrade to polling the event stream rather than
+ * crashing on a torn write.
+ */
+export async function readAutofixSnapshot(
+	store: RunArtifactStore,
+	runId: string,
+	phase: AutofixProgressPhase,
+): Promise<AutofixProgressSnapshot | null> {
+	const ref = runRef(runId, RunArtifactType.AutofixProgress, phase);
+	if (!(await store.exists(ref))) return null;
+	let text: string;
+	try {
+		text = await store.read(ref);
+	} catch {
+		return null;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return null;
+	}
+	const errs = validateAutofixSnapshot(parsed);
+	if (errs.length > 0) return null;
+	return parsed as AutofixProgressSnapshot;
+}
+
+/**
+ * Start a heartbeat interval that refreshes the snapshot's
+ * `heartbeat_at` on the configured cadence. Returns a cancel function
+ * that stops the interval.
+ *
+ * Implementations SHOULD call `unref()` on the underlying timer so the
+ * process can exit naturally on loop completion even if cancellation is
+ * forgotten. Heartbeat writes are fire-and-forget; transient write
+ * failures (read-only filesystem, etc.) SHALL NOT crash the loop — the
+ * event stream remains the authoritative progress signal per the
+ * `ledger > events > snapshot` precedence rule.
+ */
+export function startAutofixHeartbeat(opts: {
+	readonly getCurrent: () => AutofixProgressSnapshot;
+	readonly write: (next: AutofixProgressSnapshot) => Promise<void>;
+	readonly intervalMs: number;
+	readonly now?: () => string;
+}): () => void {
+	const now = opts.now ?? (() => new Date().toISOString());
+	let stopped = false;
+	const tick = () => {
+		if (stopped) return;
+		const current = opts.getCurrent();
+		const refreshed: AutofixProgressSnapshot = {
+			...current,
+			heartbeat_at: now(),
+		};
+		// Fire-and-forget; writes are atomic at the store layer.
+		void opts.write(refreshed).catch(() => {
+			// Swallow — see docblock rationale.
+		});
+	};
+	const timer = setInterval(tick, opts.intervalMs);
+	// unref() is a Node-specific no-op elsewhere; guard for safety.
+	(timer as NodeJS.Timeout).unref?.();
+	return () => {
+		stopped = true;
+		clearInterval(timer);
+	};
+}
+
+/** Re-export for callers that need the zero-initialized counter shape. */
+export { ZERO_AUTOFIX_COUNTERS };

--- a/src/lib/autofix-progress-snapshot.ts
+++ b/src/lib/autofix-progress-snapshot.ts
@@ -7,13 +7,13 @@
 //
 // Spec: openspec/specs/review-autofix-progress-observability/spec.md
 
-import type { LedgerRoundSummary } from "../types/contracts.js";
-import type { AutofixRoundCounters } from "../types/observation-events.js";
 import {
 	type AutofixProgressSnapshot,
 	validateAutofixSnapshot,
 	ZERO_AUTOFIX_COUNTERS,
 } from "../types/autofix-progress.js";
+import type { LedgerRoundSummary } from "../types/contracts.js";
+import type { AutofixRoundCounters } from "../types/observation-events.js";
 import type { RunArtifactStore } from "./artifact-store.js";
 import {
 	type AutofixProgressPhase,

--- a/src/lib/local-fs-run-artifact-store.ts
+++ b/src/lib/local-fs-run-artifact-store.ts
@@ -9,12 +9,27 @@ import {
 	isRunArtifactType,
 	type RunArtifactQuery,
 	type RunArtifactRef,
+	RunArtifactType,
 	runRef,
 	UnknownArtifactTypeError,
 } from "./artifact-types.js";
 import { atomicWriteText, readText } from "./fs.js";
 
+/**
+ * Resolve the on-disk path for a run-domain artifact ref. `run-state` lives
+ * at `<runsDir>/<runId>/run.json` (historical shape). `autofix-progress`
+ * snapshots live at `<runsDir>/<runId>/autofix-progress-<phase>.json`,
+ * keyed by `run_id + phase` per the
+ * review-autofix-progress-observability contract.
+ */
 function resolvePath(runsDir: string, ref: RunArtifactRef): string {
+	if (ref.type === RunArtifactType.AutofixProgress) {
+		return resolve(
+			runsDir,
+			ref.runId,
+			`autofix-progress-${ref.qualifier}.json`,
+		);
+	}
 	return resolve(runsDir, ref.runId, "run.json");
 }
 

--- a/src/lib/review-runtime.ts
+++ b/src/lib/review-runtime.ts
@@ -23,6 +23,17 @@ import {
 export interface ReviewConfig {
 	readonly diffWarnThreshold: number;
 	readonly maxAutofixRounds: number;
+	/**
+	 * Upper bound on how long a running auto-fix loop may go without
+	 * refreshing the progress snapshot heartbeat. Default 30s. See
+	 * openspec/specs/review-autofix-progress-observability/spec.md.
+	 */
+	readonly autofixHeartbeatSeconds: number;
+	/**
+	 * Wall-clock age beyond which a non-terminal snapshot MAY be classified
+	 * as `abandoned` by a surface. Default 120s.
+	 */
+	readonly autofixStaleThresholdSeconds: number;
 }
 
 export type ReviewAgentName = "codex" | "claude";
@@ -90,9 +101,26 @@ export function readReviewConfig(projectRoot: string): ReviewConfig {
 		return {
 			diffWarnThreshold: 1000,
 			maxAutofixRounds: 4,
+			autofixHeartbeatSeconds: 30,
+			autofixStaleThresholdSeconds: 120,
 		};
 	}
 	const content = readFileSync(configPath, "utf8");
+	const autofixHeartbeatSeconds = readIntegerConfig(
+		content,
+		"autofix_heartbeat_seconds",
+		30,
+		{ min: 1 },
+	);
+	// Stale threshold SHALL be >= heartbeat, otherwise fall back to default.
+	const rawStale = readIntegerConfig(
+		content,
+		"autofix_stale_threshold_seconds",
+		120,
+		{ min: 1 },
+	);
+	const autofixStaleThresholdSeconds =
+		rawStale >= autofixHeartbeatSeconds ? rawStale : 120;
 	return {
 		diffWarnThreshold: readIntegerConfig(content, "diff_warn_threshold", 1000, {
 			min: 0,
@@ -101,6 +129,8 @@ export function readReviewConfig(projectRoot: string): ReviewConfig {
 			min: 1,
 			max: 10,
 		}),
+		autofixHeartbeatSeconds,
+		autofixStaleThresholdSeconds,
 	};
 }
 

--- a/src/tests/__snapshots__/specflow.review_apply.md.snap
+++ b/src/tests/__snapshots__/specflow.review_apply.md.snap
@@ -269,15 +269,63 @@ AskUserQuestion:
 ## Step 6: Auto-fix Loop
 
 
-ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator で auto-fix loop を実行する。
+ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator を **バックグラウンドで** 起動し、run_id をキーに進捗スナップショット / `review_completed` observation events をポーリングしながら進捗をユーザーに逐次レンダリングする。同期で Bash を待ってはいけない（チャットが「凍って見える」失敗モードを避けるため）。
 
-### Run Orchestrator
+### Resolve run_id first
+
+`run_id` を事前に取得する。`specflow.review_apply` の前段で解決済みの `RUN_ID`（`<CHANGE_ID>-<N>` 形式）をそのまま再利用する。未確定であれば次を実行:
 
 ```bash
-specflow-review-apply autofix-loop <CHANGE_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
+specflow-run get-field "<RUN_ID>" run_id
 ```
 
-Capture stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
+`RUN_ID` を確定できない場合は、その根本原因を調査して解決したうえで再実行する（autofix-loop は `RUN_ID` なしでも動作するが、進捗スナップショット / `review_completed` observation events の emission は発生しないため observability が失われる）。
+
+### Launch in background
+
+バックグラウンドで起動する（Claude chat の場合は `run_in_background: true`）。
+
+```bash
+specflow-review-apply autofix-loop <CHANGE_ID> --run-id <RUN_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
+```
+
+CLI の `LOOP_JSON` は終了時にのみ stdout に返る。CLI `stderr` の `Auto-fix Round N/M: ...` 行は人間向けの補助情報であり、**契約上の進捗ソースではない**。
+
+### Poll progress via snapshot + events
+
+`run_id` をキーにして以下のいずれか（両方可）をポーリングする:
+
+- **進捗スナップショット**（推奨・Fast path）: `.specflow/runs/<RUN_ID>/autofix-progress-apply_review.json` を Read で取得。スキーマは `review-autofix-progress-observability` 契約に従う: `round_index`, `max_rounds`, `loop_state`, `terminal_outcome`, `counters` (`unresolvedCriticalHigh`, `totalOpen`, `resolvedThisRound`, `newThisRound`, `severitySummary`), `heartbeat_at`, `ledger_round_id`。
+- **Observation events**: `.specflow/runs/<RUN_ID>/events.jsonl` を tail し、`event_kind == "review_completed"` かつ `payload.autofix != null` の行を抜き出す。`payload.autofix.loop_state` が状態遷移、`payload.autofix.counters` が severity カウンタを示す。
+
+**1 round あたりのイベント数**: CLI は 1 round につき `review_completed` を 2 件（start: `loop_state = in_progress`、end: `loop_state = awaiting_review` または terminal）と、ループ終了時に 1 件の終局イベント（`loop_state ∈ {terminal_success, terminal_failure}`）を emit する（合計 `2N+1` events）。
+
+### Render per-round progress
+
+`loop_state` が変わるたびにユーザーにレンダリングする:
+
+```
+Auto-fix Round {round_index}/{max_rounds}: {loop_state}
+  - Unresolved HIGH+: {counters.unresolvedCriticalHigh}
+  - Total open: {counters.totalOpen}
+  - Resolved this round: {counters.resolvedThisRound}
+  - Severity summary: {counters.severitySummary}
+```
+
+状態が変わらないままハートビートが更新された場合、1 分に 1 回まで `heartbeat_at` の経過時間を表示してもよい（オプション）。
+
+### Finalize only on terminal `loop_state` or `abandoned`
+
+ループの終了判定は次のいずれかでのみ行う:
+
+- `loop_state == "terminal_success"` または `loop_state == "terminal_failure"` を観測 → `LOOP_JSON` を Read で取得（バックグラウンドタスクの出力ファイルから）し、通常の Handoff に進む。
+- `heartbeat_at` が `autofix_stale_threshold_seconds`（デフォルト `120`）を超えて更新されない → run を `abandoned` と分類する。ユーザーにそのことを通知し、必要に応じて再実行を案内する。
+
+### Retry after `abandoned`
+
+`abandoned` と分類された run で `/specflow.review_apply` を再実行する場合、新しい invocation は新しい `RUN_ID` を生成する。surface は古い `RUN_ID` のスナップショット / event stream のポーリングを停止し、新しい `RUN_ID` の `.specflow/runs/<NEW_RUN_ID>/autofix-progress-apply_review.json` をポーリングする。古いスナップショットはその `RUN_ID`-scoped パスにより到達不能になるため、明示的なクリーンアップは不要。
+
+Capture final stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
 
 Parse `LOOP_JSON` as JSON. If parse fails, display raw output and **STOP**.
 

--- a/src/tests/__snapshots__/specflow.review_design.md.snap
+++ b/src/tests/__snapshots__/specflow.review_design.md.snap
@@ -248,15 +248,63 @@ AskUserQuestion:
 ## Step 6: Auto-fix Loop
 
 
-ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator で auto-fix loop を実行する。
+ユーザーが「Auto-fix 実行」を選択した場合、Bash orchestrator を **バックグラウンドで** 起動し、run_id をキーに進捗スナップショット / `review_completed` observation events をポーリングしながら進捗をユーザーに逐次レンダリングする。同期で Bash を待ってはいけない（チャットが「凍って見える」失敗モードを避けるため）。
 
-### Run Orchestrator
+### Resolve run_id first
+
+`run_id` を事前に取得する。`specflow.review_design` の前段で解決済みの `RUN_ID`（`<CHANGE_ID>-<N>` 形式）をそのまま再利用する。未確定であれば次を実行:
 
 ```bash
-specflow-review-design autofix-loop <CHANGE_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
+specflow-run get-field "<RUN_ID>" run_id
 ```
 
-Capture stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
+`RUN_ID` を確定できない場合は、その根本原因を調査して解決したうえで再実行する（autofix-loop は `RUN_ID` なしでも動作するが、進捗スナップショット / `review_completed` observation events の emission は発生しないため observability が失われる）。
+
+### Launch in background
+
+バックグラウンドで起動する（Claude chat の場合は `run_in_background: true`）。
+
+```bash
+specflow-review-design autofix-loop <CHANGE_ID> --run-id <RUN_ID> --max-rounds <MAX_AUTOFIX_ROUNDS>
+```
+
+CLI の `LOOP_JSON` は終了時にのみ stdout に返る。CLI `stderr` の `Auto-fix Round N/M: ...` 行は人間向けの補助情報であり、**契約上の進捗ソースではない**。
+
+### Poll progress via snapshot + events
+
+`run_id` をキーにして以下のいずれか（両方可）をポーリングする:
+
+- **進捗スナップショット**（推奨・Fast path）: `.specflow/runs/<RUN_ID>/autofix-progress-design_review.json` を Read で取得。スキーマは `review-autofix-progress-observability` 契約に従う: `round_index`, `max_rounds`, `loop_state`, `terminal_outcome`, `counters` (`unresolvedCriticalHigh`, `totalOpen`, `resolvedThisRound`, `newThisRound`, `severitySummary`), `heartbeat_at`, `ledger_round_id`。
+- **Observation events**: `.specflow/runs/<RUN_ID>/events.jsonl` を tail し、`event_kind == "review_completed"` かつ `payload.autofix != null` の行を抜き出す。`payload.autofix.loop_state` が状態遷移、`payload.autofix.counters` が severity カウンタを示す。
+
+**1 round あたりのイベント数**: CLI は 1 round につき `review_completed` を 2 件（start: `loop_state = in_progress`、end: `loop_state = awaiting_review` または terminal）と、ループ終了時に 1 件の終局イベント（`loop_state ∈ {terminal_success, terminal_failure}`）を emit する（合計 `2N+1` events）。
+
+### Render per-round progress
+
+`loop_state` が変わるたびにユーザーにレンダリングする:
+
+```
+Auto-fix Round {round_index}/{max_rounds}: {loop_state}
+  - Unresolved HIGH+: {counters.unresolvedCriticalHigh}
+  - Total open: {counters.totalOpen}
+  - Resolved this round: {counters.resolvedThisRound}
+  - Severity summary: {counters.severitySummary}
+```
+
+状態が変わらないままハートビートが更新された場合、1 分に 1 回まで `heartbeat_at` の経過時間を表示してもよい（オプション）。
+
+### Finalize only on terminal `loop_state` or `abandoned`
+
+ループの終了判定は次のいずれかでのみ行う:
+
+- `loop_state == "terminal_success"` または `loop_state == "terminal_failure"` を観測 → `LOOP_JSON` を Read で取得（バックグラウンドタスクの出力ファイルから）し、通常の Handoff に進む。
+- `heartbeat_at` が `autofix_stale_threshold_seconds`（デフォルト `120`）を超えて更新されない → run を `abandoned` と分類する。ユーザーにそのことを通知し、必要に応じて再実行を案内する。
+
+### Retry after `abandoned`
+
+`abandoned` と分類された run で `/specflow.review_design` を再実行する場合、新しい invocation は新しい `RUN_ID` を生成する。surface は古い `RUN_ID` のスナップショット / event stream のポーリングを停止し、新しい `RUN_ID` の `.specflow/runs/<NEW_RUN_ID>/autofix-progress-design_review.json` をポーリングする。古いスナップショットはその `RUN_ID`-scoped パスにより到達不能になるため、明示的なクリーンアップは不要。
+
+Capture final stdout as `LOOP_JSON`. If the command fails (non-zero exit), display the error and **STOP**.
 
 Parse `LOOP_JSON` as JSON. If parse fails, display raw output and **STOP**.
 

--- a/src/tests/artifact-types.test.ts
+++ b/src/tests/artifact-types.test.ts
@@ -30,9 +30,10 @@ test("changeArtifactTypes enumerates all 8 types", () => {
 	assert.ok(changeArtifactTypes.includes("approval-summary"));
 });
 
-test("runArtifactTypes enumerates exactly run-state", () => {
-	assert.equal(runArtifactTypes.length, 1);
+test("runArtifactTypes enumerates run-state and autofix-progress", () => {
+	assert.equal(runArtifactTypes.length, 2);
 	assert.ok(runArtifactTypes.includes("run-state"));
+	assert.ok(runArtifactTypes.includes("autofix-progress"));
 });
 
 test("reviewLedgerKinds enumerates proposal, design, apply", () => {

--- a/src/types/autofix-progress.ts
+++ b/src/types/autofix-progress.ts
@@ -1,0 +1,139 @@
+// Auto-fix progress snapshot contract — shared type definitions.
+//
+// See openspec/specs/review-autofix-progress-observability/spec.md for the
+// authoritative contract. The snapshot is persisted per-run per-phase under
+// the run-artifact store and refreshed on a bounded heartbeat.
+
+import type {
+	AutofixLoopState,
+	AutofixRoundCounters,
+	AutofixTerminalOutcome,
+} from "./observation-events.js";
+
+/** Review phase a snapshot belongs to. */
+export type AutofixPhase = "design_review" | "apply_review";
+
+export const AUTOFIX_PHASES: readonly AutofixPhase[] = [
+	"design_review",
+	"apply_review",
+] as const;
+
+/** Current snapshot schema version — bump when fields change shape. */
+export const AUTOFIX_SNAPSHOT_SCHEMA_VERSION = 1;
+
+/**
+ * Self-contained progress snapshot. Writers SHALL rewrite this atomically;
+ * readers MAY rely on `heartbeat_at` to classify stalled loops as
+ * `abandoned`.
+ */
+export interface AutofixProgressSnapshot {
+	readonly schema_version: number;
+	readonly run_id: string;
+	readonly change_id: string;
+	readonly phase: AutofixPhase;
+	readonly round_index: number;
+	readonly max_rounds: number;
+	readonly loop_state: AutofixLoopState;
+	readonly terminal_outcome: AutofixTerminalOutcome | null;
+	readonly counters: AutofixRoundCounters;
+	readonly heartbeat_at: string;
+	readonly ledger_round_id: string | null;
+}
+
+/** Narrowing guard for `AutofixPhase`. */
+export function isAutofixPhase(value: unknown): value is AutofixPhase {
+	return (
+		typeof value === "string" &&
+		(AUTOFIX_PHASES as readonly string[]).includes(value)
+	);
+}
+
+/** Validation error returned by `validateAutofixSnapshot`. */
+export interface AutofixSnapshotValidationError {
+	readonly field: string;
+	readonly message: string;
+}
+
+/**
+ * Shape-check a snapshot. Returns an empty array when `value` conforms.
+ * Unknown extra fields are tolerated per the spec's forward-compatibility
+ * rule; only missing / type-mismatched required fields are reported.
+ */
+export function validateAutofixSnapshot(
+	value: unknown,
+): readonly AutofixSnapshotValidationError[] {
+	const errs: AutofixSnapshotValidationError[] = [];
+	if (!value || typeof value !== "object") {
+		errs.push({ field: "$root", message: "expected object" });
+		return errs;
+	}
+	const v = value as Record<string, unknown>;
+	if (typeof v.schema_version !== "number")
+		errs.push({ field: "schema_version", message: "expected number" });
+	if (typeof v.run_id !== "string" || !v.run_id)
+		errs.push({ field: "run_id", message: "expected non-empty string" });
+	if (typeof v.change_id !== "string" || !v.change_id)
+		errs.push({ field: "change_id", message: "expected non-empty string" });
+	if (!isAutofixPhase(v.phase))
+		errs.push({
+			field: "phase",
+			message: `expected one of ${AUTOFIX_PHASES.join("|")}`,
+		});
+	if (typeof v.round_index !== "number" || v.round_index < 0)
+		errs.push({ field: "round_index", message: "expected non-negative number" });
+	if (typeof v.max_rounds !== "number" || v.max_rounds < 1)
+		errs.push({ field: "max_rounds", message: "expected positive number" });
+	if (typeof v.loop_state !== "string")
+		errs.push({ field: "loop_state", message: "expected string" });
+	if (v.terminal_outcome !== null && typeof v.terminal_outcome !== "string")
+		errs.push({
+			field: "terminal_outcome",
+			message: "expected string or null",
+		});
+	if (!v.counters || typeof v.counters !== "object")
+		errs.push({ field: "counters", message: "expected object" });
+	if (typeof v.heartbeat_at !== "string")
+		errs.push({ field: "heartbeat_at", message: "expected ISO 8601 string" });
+	if (v.ledger_round_id !== null && typeof v.ledger_round_id !== "string")
+		errs.push({
+			field: "ledger_round_id",
+			message: "expected string or null",
+		});
+	return errs;
+}
+
+/** Zero-initialized counters used before any round has completed. */
+export const ZERO_AUTOFIX_COUNTERS: AutofixRoundCounters = {
+	unresolvedCriticalHigh: 0,
+	totalOpen: 0,
+	resolvedThisRound: 0,
+	newThisRound: 0,
+	severitySummary: {},
+};
+
+/**
+ * Build a baseline `starting` snapshot for a loop that has been invoked but
+ * not yet entered round 1. Callers pass the wall-clock `now` so tests can
+ * inject deterministic timestamps.
+ */
+export function buildStartingSnapshot(args: {
+	readonly runId: string;
+	readonly changeId: string;
+	readonly phase: AutofixPhase;
+	readonly maxRounds: number;
+	readonly now: string;
+}): AutofixProgressSnapshot {
+	return {
+		schema_version: AUTOFIX_SNAPSHOT_SCHEMA_VERSION,
+		run_id: args.runId,
+		change_id: args.changeId,
+		phase: args.phase,
+		round_index: 0,
+		max_rounds: args.maxRounds,
+		loop_state: "starting",
+		terminal_outcome: null,
+		counters: ZERO_AUTOFIX_COUNTERS,
+		heartbeat_at: args.now,
+		ledger_round_id: null,
+	};
+}

--- a/src/types/autofix-progress.ts
+++ b/src/types/autofix-progress.ts
@@ -80,7 +80,10 @@ export function validateAutofixSnapshot(
 			message: `expected one of ${AUTOFIX_PHASES.join("|")}`,
 		});
 	if (typeof v.round_index !== "number" || v.round_index < 0)
-		errs.push({ field: "round_index", message: "expected non-negative number" });
+		errs.push({
+			field: "round_index",
+			message: "expected non-negative number",
+		});
 	if (typeof v.max_rounds !== "number" || v.max_rounds < 1)
 		errs.push({ field: "max_rounds", message: "expected positive number" });
 	if (typeof v.loop_state !== "string")

--- a/src/types/observation-events.ts
+++ b/src/types/observation-events.ts
@@ -119,10 +119,85 @@ export interface ArtifactWrittenPayload {
 	readonly content_hash: string | null;
 }
 
+/**
+ * Closed five-value loop-state enum carried by an auto-fix round event /
+ * progress snapshot. See
+ * openspec/specs/review-autofix-progress-observability/spec.md.
+ */
+export type AutofixLoopState =
+	| "starting"
+	| "in_progress"
+	| "awaiting_review"
+	| "terminal_success"
+	| "terminal_failure";
+
+export const AUTOFIX_LOOP_STATES: readonly AutofixLoopState[] = [
+	"starting",
+	"in_progress",
+	"awaiting_review",
+	"terminal_success",
+	"terminal_failure",
+] as const;
+
+/** Terminal outcomes set when `loop_state` is a terminal value. */
+export type AutofixTerminalOutcome =
+	| "loop_no_findings"
+	| "loop_with_findings"
+	| "max_rounds_reached"
+	| "no_progress"
+	| "consecutive_failures";
+
+export const AUTOFIX_TERMINAL_OUTCOMES: readonly AutofixTerminalOutcome[] = [
+	"loop_no_findings",
+	"loop_with_findings",
+	"max_rounds_reached",
+	"no_progress",
+	"consecutive_failures",
+] as const;
+
+/**
+ * Severity counters attached to an auto-fix round payload / snapshot.
+ * Derived from the review ledger via `unresolvedCriticalHighCount` and
+ * siblings; see `review-ledger` helpers.
+ */
+export interface AutofixRoundCounters {
+	readonly unresolvedCriticalHigh: number;
+	readonly totalOpen: number;
+	readonly resolvedThisRound: number;
+	readonly newThisRound: number;
+	/** Free-form severity tally (e.g. {"HIGH":1,"MEDIUM":0,"LOW":2}). */
+	readonly severitySummary: Record<string, number>;
+}
+
+/**
+ * Auto-fix round metadata carried inside `ReviewCompletedPayload.autofix`.
+ * Present (non-null) only on emissions from the auto-fix loop
+ * (`specflow-review-design autofix-loop` / `specflow-review-apply autofix-loop`).
+ */
+export interface AutofixRoundPayload {
+	readonly round_index: number;
+	readonly max_rounds: number;
+	readonly loop_state: AutofixLoopState;
+	readonly terminal_outcome: AutofixTerminalOutcome | null;
+	readonly counters: AutofixRoundCounters;
+	readonly ledger_round_id: string | null;
+}
+
+/**
+ * The `autofix_in_progress` outcome value is reserved for non-terminal
+ * autofix emissions. See workflow-observation-events spec D9.
+ */
+export type ReviewCompletedOutcome =
+	| "approved"
+	| "changes_requested"
+	| "rejected"
+	| "autofix_in_progress";
+
 export interface ReviewCompletedPayload {
-	readonly outcome: "approved" | "changes_requested" | "rejected";
+	readonly outcome: ReviewCompletedOutcome;
 	readonly reviewer: string;
 	readonly score: number | null;
+	readonly autofix: AutofixRoundPayload | null;
 }
 
 export interface BundleStartedPayload {


### PR DESCRIPTION
## Summary

- Fixes #172: the auto-fix loop (`specflow-review-{design,apply} autofix-loop`) now emits per-round `review_completed` observation events and a per-run progress snapshot keyed by `run_id` + phase under the run-artifact store, so Claude chat (and any surface) can poll progress between rounds instead of waiting on a single blocking `LOOP_JSON` return.
- New capability `review-autofix-progress-observability`: closed 5-value `loop_state` enum (`starting`/`in_progress`/`awaiting_review`/`terminal_success`/`terminal_failure`), snapshot schema with bounded 30s heartbeat + 120s stale threshold (both configurable via `openspec/config.yaml`), `abandoned` classification rule, and `ledger > events > snapshot` authority precedence.
- Extends `workflow-observation-events` `review_completed` payload with optional `autofix: AutofixRoundPayload | null` and reserves `autofix_in_progress` outcome for non-terminal progress — the 15-kind event catalog remains closed.
- Updates `review_design` / `review_apply` slash-command guides to mandate background invocation + snapshot/event polling for chat surfaces.

## Accepted Risks

The implementation was approved as accepted-risk with 5 impl findings (F1–F5) and 1 design finding (R4-F06) that should be addressed in follow-up issues — see the archived approval summary at `openspec/changes/archive/2026-04-19-auto-fixloopbackground/approval-summary.md` for details. Summary: `RunArtifactStore.list()` doesn't yet enumerate autofix-progress refs (F1); terminal rounds emit 2N instead of 2N+1 because `break` precedes round-end emission (F2); apply `no_changes` reason is coerced to `loop_with_findings` (F3); slash-command guides hardcode the default stale threshold (F4); no integration tests for `autofix-loop --run-id` yet (F5).

## Issue

Closes https://github.com/skr19930617/specflow/issues/172

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test` (642 tests, all passing)
- [x] `openspec validate auto-fixloopbackground --type change` and `specflow-spec-verify auto-fixloopbackground` pass on the change deltas
- [ ] End-to-end: run `/specflow.review_design` or `/specflow.review_apply` against a seeded change in Claude chat, trigger the auto-fix loop, and observe per-round updates rendered from `autofix-progress-<phase>.json` and `events.jsonl`
- [ ] End-to-end: kill the loop process mid-round and confirm the next `/specflow.review_*` invocation classifies the prior run as `abandoned` (snapshot stale > 120s) and starts a fresh loop under a new `run_id`